### PR TITLE
feat: improve Connected message with wallet address and usage hints

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { Address, Base64, Hex } from 'ox'
+import * as chat from 'chat'
 import { z } from 'zod'
 import * as Chat from '#/chat.ts'
 import * as AccountLink from '#/lib/accountLink.ts'
@@ -240,16 +241,34 @@ export const api = new Hono<{
               const installation = await Chat.getSlack().getInstallation(link.provider_id)
               if (!installation) return
 
+              const channelRef = Chat.getChat().channel(
+                link.provider_channel_id!.startsWith('slack:')
+                  ? link.provider_channel_id!
+                  : `slack:${link.provider_channel_id!}`,
+              )
+              const truncatedAddress = `${account.address.slice(0, 6)}…${account.address.slice(-4)}`
+              const explorerUrl = Tempo.formatTokenLink(link.chain_id, account.address)
+
               await Chat.getSlack().withBotToken(installation.botToken, () =>
-                Chat.getChat()
-                  .channel(
-                    link.provider_channel_id!.startsWith('slack:')
-                      ? link.provider_channel_id!
-                      : `slack:${link.provider_channel_id!}`,
-                  )
-                  .postEphemeral(link.member_provider_user_id, 'Connected', {
-                    fallbackToDM: false,
-                  }),
+                channelRef.postEphemeral(
+                  link.member_provider_user_id,
+                  {
+                    card: chat.Card({
+                      children: [
+                        chat.CardText(
+                          `Wallet connected: \`${truncatedAddress}\` <${explorerUrl}|View>`,
+                        ),
+                        chat.CardText(
+                          'Mention `@Tipbot @user` or use `/tip @user` to send a payment. React with 💸 to tip a message.',
+                          { style: 'muted' },
+                        ),
+                      ],
+                      title: 'Connected',
+                    }),
+                    fallbackText: `Connected\nWallet: ${account.address}\nUse /tip @user to send your first tip.`,
+                  },
+                  { fallbackToDM: false },
+                ),
               )
             })().catch((error) => {
               console.error('Failed to notify Slack member after wallet connection:', error)

--- a/src/api.ts
+++ b/src/api.ts
@@ -100,6 +100,7 @@ export const api = new Hono<{
           'workspace.default_token_address',
           'workspace.id as workspace_id',
           'workspace.provider_id',
+          'workspace.reaction_tip_emoji',
         ])
         .where(
           'account_link_token.token_hash',
@@ -259,7 +260,7 @@ export const api = new Hono<{
                           `Wallet connected: \`${truncatedAddress}\` <${explorerUrl}|View>`,
                         ),
                         chat.CardText(
-                          'Mention `@Tipbot @user` or use `/tip @user` to send a payment. React with 💸 to tip a message.',
+                          `Mention \`@Tipbot @user\` or use \`/tip @user\` to send a payment. React with :${link.reaction_tip_emoji}: to tip a message.`,
                           { style: 'muted' },
                         ),
                       ],

--- a/src/api.ts
+++ b/src/api.ts
@@ -248,7 +248,7 @@ export const api = new Hono<{
                   : `slack:${link.provider_channel_id!}`,
               )
               const truncatedAddress = `${account.address.slice(0, 6)}…${account.address.slice(-4)}`
-              const explorerUrl = Tempo.formatTokenLink(link.chain_id, account.address)
+              const explorerUrl = Tempo.explorerLink(link.chain_id, account.address)
 
               await Chat.getSlack().withBotToken(installation.botToken, () =>
                 channelRef.postEphemeral(

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1733,7 +1733,7 @@ function configCard(
         ...(options?.updated ? [chat.CardText('Workspace settings updated')] : []),
       ],
     }),
-    fallbackText: `Network ${networkLabel}\nDefault token ${token.symbol} ${Tempo.formatTokenLink(workspace.chain_id, tokenAddress)}\nDefault amount ${formatAmount(workspace.default_amount)}\nReaction 💸 \`:${workspace.reaction_tip_emoji}:\`${options?.updated ? '\nWorkspace settings updated' : ''}`,
+    fallbackText: `Network ${networkLabel}\nDefault token ${token.symbol} ${Tempo.explorerLink(workspace.chain_id, tokenAddress)}\nDefault amount ${formatAmount(workspace.default_amount)}\nReaction 💸 \`:${workspace.reaction_tip_emoji}:\`${options?.updated ? '\nWorkspace settings updated' : ''}`,
   }
 }
 
@@ -1804,7 +1804,7 @@ function configFallbackText(
   options?: { updated?: boolean },
 ) {
   const tokenAddress = workspace.default_token_address ?? Tempo.addressLookup.pathUsd
-  return `Setting Value\nNetwork ${configNetworkLabel(workspace)}\nDefault token ${configToken(workspace).symbol} ${Tempo.formatTokenLink(workspace.chain_id, tokenAddress)}\nDefault amount ${formatAmount(workspace.default_amount)}\nReaction 💸 \`:${workspace.reaction_tip_emoji}:\`${options?.updated ? '\nWorkspace settings updated' : ''}`
+  return `Setting Value\nNetwork ${configNetworkLabel(workspace)}\nDefault token ${configToken(workspace).symbol} ${Tempo.explorerLink(workspace.chain_id, tokenAddress)}\nDefault amount ${formatAmount(workspace.default_amount)}\nReaction 💸 \`:${workspace.reaction_tip_emoji}:\`${options?.updated ? '\nWorkspace settings updated' : ''}`
 }
 
 function configNetworkLabel(workspace: DB_gen.Selectable.workspace) {

--- a/src/lib/tempo.test.ts
+++ b/src/lib/tempo.test.ts
@@ -72,5 +72,8 @@ test('formats Tempo token symbols and transaction links', () => {
     currency: 'USD',
     symbol: '0x0000…0002',
   })
+  expect(Tempo.explorerLink(Tempo.chainLookup.testnet, Tempo.addressLookup.pathUsd)).toContain(
+    `/address/${Tempo.addressLookup.pathUsd}`,
+  )
   expect(Tempo.formatTxLink(Tempo.chainLookup.testnet, '0xabc')).toContain('/tx/0xabc')
 })

--- a/src/lib/tempo.ts
+++ b/src/lib/tempo.ts
@@ -51,9 +51,9 @@ export function formatTxLink(chainId: number, transactionHash: string) {
   return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/tx/${transactionHash}`
 }
 
-export function formatTokenLink(chainId: number, tokenAddress: string) {
+export function explorerLink(chainId: number, address: string) {
   const chain = getChain(chainId)
-  return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/address/${tokenAddress}`
+  return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/address/${address}`
 }
 
 export function isAllowedToken(chainId: number, tokenAddress: string) {


### PR DESCRIPTION
Updates the ephemeral "Connected" message shown after wallet linking to include:

- **Wallet address** — truncated with an explorer link to the full address
- **How it works** — brief copy on `@Tipbot @user`, `/tip @user`, and 💸 reaction tipping
- **CTA** — guides users to send their first tip

Existing test assertion unchanged since the fallbackText still starts with `Connected`.