### PR TITLE
fix: use /receipt/ instead of /tx/ for explorer transaction links

### DIFF
--- a/src/lib/tempo.test.ts
+++ b/src/lib/tempo.test.ts
@@ -75,5 +75,5 @@ test('formats Tempo token symbols and transaction links', () => {
   expect(Tempo.explorerLink(Tempo.chainLookup.testnet, Tempo.addressLookup.pathUsd)).toContain(
     `/address/${Tempo.addressLookup.pathUsd}`,
   )
-  expect(Tempo.formatTxLink(Tempo.chainLookup.testnet, '0xabc')).toContain('/tx/0xabc')
+  expect(Tempo.formatTxLink(Tempo.chainLookup.testnet, '0xabc')).toContain('/receipt/0xabc')
 })

--- a/src/lib/tempo.ts
+++ b/src/lib/tempo.ts
@@ -48,7 +48,7 @@ export function getChainName(chainId: number) {
 
 export function formatTxLink(chainId: number, transactionHash: string) {
   const chain = getChain(chainId)
-  return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/tx/${transactionHash}`
+  return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/receipt/${transactionHash}`
 }
 
 export function explorerLink(chainId: number, address: string) {


### PR DESCRIPTION
Switches `formatTxLink` from `/tx/{hash}` to `/receipt/{hash}` so tipbot explorer links use the receipt view.

Example: `https://explore.tempo.xyz/receipt/0xc37c1...` instead of `https://explore.tempo.xyz/tx/0xc37c1...`