### PR TITLE
feat: pending tips for unconnected recipients

### DIFF
--- a/db/migrations/0008_pending_tips.sql
+++ b/db/migrations/0008_pending_tips.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "pending_tip" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "workspace_id" TEXT NOT NULL REFERENCES "workspace" ("id") ON DELETE CASCADE,
+  "idempotency_key" TEXT NOT NULL UNIQUE,
+  "sender_member_id" TEXT NOT NULL REFERENCES "member" ("id"),
+  "recipient_provider_user_id" TEXT NOT NULL,
+  "recipient_provider_label" TEXT,
+  "amount" INTEGER NOT NULL CHECK ("amount" > 0),
+  "token_address" TEXT NOT NULL,
+  "memo" TEXT,
+  "provider" TEXT NOT NULL DEFAULT 'slack' CHECK ("provider" IN ('slack')),
+  "provider_id" TEXT NOT NULL,
+  "provider_channel_id" TEXT NOT NULL,
+  "provider_thread_id" TEXT,
+  "claimed_at" TEXT,
+  "expired_at" TEXT,
+  "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK ("claimed_at" IS NULL OR "expired_at" IS NULL)
+);
+
+CREATE INDEX "pending_tip_recipient_idx" ON "pending_tip" ("workspace_id", "recipient_provider_user_id");
+CREATE INDEX "pending_tip_sender_idx" ON "pending_tip" ("sender_member_id");

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -51,6 +51,26 @@ export const member = z.object({
   workspace_id: z.string(),
 })
 
+export const pending_tip = z.object({
+  amount: z.number(),
+  claimed_at: z.string().nullable(),
+  created_at: z.string(),
+  expired_at: z.string().nullable(),
+  id: z.string(),
+  idempotency_key: z.string(),
+  memo: z.string().nullable(),
+  provider: z.literal('slack'),
+  provider_channel_id: z.string(),
+  provider_id: z.string(),
+  provider_thread_id: z.string().nullable(),
+  recipient_provider_label: z.string().nullable(),
+  recipient_provider_user_id: z.string(),
+  sender_member_id: z.string(),
+  token_address: z.string(),
+  updated_at: z.string(),
+  workspace_id: z.string(),
+})
+
 export const reaction_tip = z.object({
   channel_id: z.string(),
   created_at: z.string(),
@@ -117,6 +137,7 @@ export const db = {
   account: account,
   account_link_token: account_link_token,
   member: member,
+  pending_tip: pending_tip,
   reaction_tip: reaction_tip,
   reaction_tip_thread: reaction_tip_thread,
   tip: tip,

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -7,6 +7,7 @@ export interface DB {
   account: account
   account_link_token: account_link_token
   member: member
+  pending_tip: pending_tip
   reaction_tip: reaction_tip
   reaction_tip_thread: reaction_tip_thread
   tip: tip
@@ -58,6 +59,26 @@ type member = {
   login: string | null
   name: string | null
   provider_user_id: string
+  updated_at: k.Generated<string>
+  workspace_id: string
+}
+
+type pending_tip = {
+  amount: number
+  claimed_at: string | null
+  created_at: k.Generated<string>
+  expired_at: string | null
+  id: string
+  idempotency_key: string
+  memo: string | null
+  provider: k.Generated<'slack'>
+  provider_channel_id: string
+  provider_id: string
+  provider_thread_id: string | null
+  recipient_provider_label: string | null
+  recipient_provider_user_id: string
+  sender_member_id: string
+  token_address: string
   updated_at: k.Generated<string>
   workspace_id: string
 }
@@ -128,6 +149,7 @@ export declare namespace DB {
   type account = k.Selectable<DB['account']>
   type account_link_token = k.Selectable<DB['account_link_token']>
   type member = k.Selectable<DB['member']>
+  type pending_tip = k.Selectable<DB['pending_tip']>
   type reaction_tip = k.Selectable<DB['reaction_tip']>
   type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
   type tip = k.Selectable<DB['tip']>
@@ -138,6 +160,7 @@ export declare namespace DB {
     type account = k.Insertable<DB['account']>
     type account_link_token = k.Insertable<DB['account_link_token']>
     type member = k.Insertable<DB['member']>
+    type pending_tip = k.Insertable<DB['pending_tip']>
     type reaction_tip = k.Insertable<DB['reaction_tip']>
     type reaction_tip_thread = k.Insertable<DB['reaction_tip_thread']>
     type tip = k.Insertable<DB['tip']>
@@ -149,6 +172,7 @@ export declare namespace DB {
     type account = k.Selectable<DB['account']>
     type account_link_token = k.Selectable<DB['account_link_token']>
     type member = k.Selectable<DB['member']>
+    type pending_tip = k.Selectable<DB['pending_tip']>
     type reaction_tip = k.Selectable<DB['reaction_tip']>
     type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
     type tip = k.Selectable<DB['tip']>
@@ -160,6 +184,7 @@ export declare namespace DB {
     type account = k.Updateable<DB['account']>
     type account_link_token = k.Updateable<DB['account_link_token']>
     type member = k.Updateable<DB['member']>
+    type pending_tip = k.Updateable<DB['pending_tip']>
     type reaction_tip = k.Updateable<DB['reaction_tip']>
     type reaction_tip_thread = k.Updateable<DB['reaction_tip_thread']>
     type tip = k.Updateable<DB['tip']>

--- a/src/api.ts
+++ b/src/api.ts
@@ -251,13 +251,18 @@ export const api = new Hono<{
                   .where('id', '=', entry.senderMemberId)
                   .executeTakeFirst()
                 if (!sender) continue
-                const channelId = link.provider_channel_id?.replace(/^slack:/, '')
+                const channelId = entry.providerChannelId.replace(/^slack:/, '')
                 if (!channelId) continue
                 const tipAmount = entry.result.isDefaultToken
                   ? formatCurrencyAmount(entry.result.amount, entry.result.tokenCurrency)
-                  : formatTipAmount(entry.result.amount, entry.result.tokenCurrency, entry.result.tokenSymbol)
+                  : formatTipAmount(
+                      entry.result.amount,
+                      entry.result.tokenCurrency,
+                      entry.result.tokenSymbol,
+                    )
                 const body = new URLSearchParams()
                 body.set('channel', channelId)
+                if (entry.providerThreadId) body.set('thread_ts', entry.providerThreadId)
                 body.set(
                   'text',
                   `<@${sender.provider_user_id}> ${entry.result.memo ? 'sent' : 'tipped'} <@${link.member_provider_user_id}> ${tipAmount}${entry.result.memo ? ` for ${entry.result.memo}` : ''}. · <${Tempo.formatTxLink(entry.result.chainId, entry.result.transactionHash)}|Receipt>`,

--- a/src/api.ts
+++ b/src/api.ts
@@ -235,6 +235,49 @@ export const api = new Hono<{
           .where('id', '=', link.id)
           .execute()
 
+        c.executionCtx.waitUntil(
+          Tip.claimPendingTips(c.env, link.workspace_id, link.member_provider_user_id)
+            .then(async (claimed) => {
+              if (claimed.length === 0) return
+              await Chat.getChat().initialize()
+              const installation = await Chat.getSlack().getInstallation(link.provider_id)
+              if (!installation) return
+
+              for (const entry of claimed) {
+                if (!entry.result.ok) continue
+                const sender = await c.var.db
+                  .selectFrom('member')
+                  .select('provider_user_id')
+                  .where('id', '=', entry.senderMemberId)
+                  .executeTakeFirst()
+                if (!sender) continue
+                const channelId = link.provider_channel_id?.replace(/^slack:/, '')
+                if (!channelId) continue
+                const tipAmount = entry.result.isDefaultToken
+                  ? formatCurrencyAmount(entry.result.amount, entry.result.tokenCurrency)
+                  : formatTipAmount(entry.result.amount, entry.result.tokenCurrency, entry.result.tokenSymbol)
+                const body = new URLSearchParams()
+                body.set('channel', channelId)
+                body.set(
+                  'text',
+                  `<@${sender.provider_user_id}> ${entry.result.memo ? 'sent' : 'tipped'} <@${link.member_provider_user_id}> ${tipAmount}${entry.result.memo ? ` for ${entry.result.memo}` : ''}. · <${Tempo.formatTxLink(entry.result.chainId, entry.result.transactionHash)}|Receipt>`,
+                )
+                body.set('unfurl_links', 'false')
+                body.set('unfurl_media', 'false')
+                await Chat.getSlack().withBotToken(installation.botToken, () =>
+                  fetch(`${c.env.SLACK_API_URL}/chat.postMessage`, {
+                    body,
+                    headers: { authorization: `Bearer ${installation.botToken}` },
+                    method: 'POST',
+                  }),
+                )
+              }
+            })
+            .catch((error) => {
+              console.error('Failed to claim pending tips:', error)
+            }),
+        )
+
         if (link.provider_channel_id)
           c.executionCtx.waitUntil(
             (async () => {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -853,6 +853,8 @@ async function handleTipText(
           return 'Payment not sent. Cannot send a payment to yourself.'
         if (result.code === 'recipient_unconnected')
           return `Payment not sent. ${event.channel.mentionUser(result.recipientProviderUserId ?? parsed.recipientProviderUserId)} needs to connect Tipbot before receiving payments.`
+        if (result.code === 'recipient_pending')
+          return `Payment pending. ${event.channel.mentionUser(result.recipientProviderUserId ?? parsed.recipientProviderUserId)} needs to connect Tipbot with \`/tip connect\`. The payment will be sent automatically once they connect.`
         if (result.code === 'pending') return 'Payment still sending.'
         if (result.code === 'insufficient_funds')
           return 'Payment not sent. Your wallet has insufficient funds.'
@@ -1032,25 +1034,18 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
     return
   }
   const recipient = await getConnectedSlackMember(db, workspace.id, recipientProviderUserId)
-  if (!recipient) {
-    await postSlackEphemeral(
-      provider.id,
-      event.item.channel,
-      event.user,
-      `Payment not sent. <@${recipientProviderUserId}> needs to connect Tipbot before receiving payments.`,
-    )
-    return
-  }
 
-  const existing = await db
-    .selectFrom('reaction_tip')
-    .select('id')
-    .where('workspace_id', '=', workspace.id)
-    .where('channel_id', '=', event.item.channel)
-    .where('message_ts', '=', event.item.ts)
-    .where('reaction', '=', event.reaction)
-    .where('sender_member_id', '=', sender.memberId)
-    .executeTakeFirst()
+  const existing = recipient
+    ? await db
+        .selectFrom('reaction_tip')
+        .select('id')
+        .where('workspace_id', '=', workspace.id)
+        .where('channel_id', '=', event.item.channel)
+        .where('message_ts', '=', event.item.ts)
+        .where('reaction', '=', event.reaction)
+        .where('sender_member_id', '=', sender.memberId)
+        .executeTakeFirst()
+    : null
   if (existing) return
 
   const idempotencyKey = [
@@ -1062,33 +1057,35 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
     sender.memberId,
     event.event_ts,
   ].join(':')
-  const inserted = await (async () => {
-    const now = new Date().toISOString()
-    try {
-      await db
-        .insertInto('reaction_tip')
-        .values({
-          channel_id: event.item.channel,
-          created_at: now,
-          id: Nanoid.generate(),
-          idempotency_key: idempotencyKey,
-          message_ts: event.item.ts,
-          reaction: event.reaction,
-          recipient_member_id: recipient.memberId,
-          sender_member_id: sender.memberId,
-          thread_ts: message.thread_ts ?? event.item.ts,
-          tip_id: null,
-          updated_at: now,
-          workspace_id: workspace.id,
-        })
-        .execute()
-      return true
-    } catch (error) {
-      if (isUniqueConstraintError(error)) return false
-      throw error
-    }
-  })()
-  if (!inserted) return
+  if (recipient) {
+    const inserted = await (async () => {
+      const now = new Date().toISOString()
+      try {
+        await db
+          .insertInto('reaction_tip')
+          .values({
+            channel_id: event.item.channel,
+            created_at: now,
+            id: Nanoid.generate(),
+            idempotency_key: idempotencyKey,
+            message_ts: event.item.ts,
+            reaction: event.reaction,
+            recipient_member_id: recipient.memberId,
+            sender_member_id: sender.memberId,
+            thread_ts: message.thread_ts ?? event.item.ts,
+            tip_id: null,
+            updated_at: now,
+            workspace_id: workspace.id,
+          })
+          .execute()
+        return true
+      } catch (error) {
+        if (isUniqueConstraintError(error)) return false
+        throw error
+      }
+    })()
+    if (!inserted) return
+  }
 
   const result = await Tip.handleTipRequest(env, {
     idempotencyKey,
@@ -1096,7 +1093,7 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
     provider: provider.type,
     providerChannelId: event.item.channel,
     providerId: provider.id,
-    recipientProviderUserId: recipient.providerUserId,
+    recipientProviderUserId: recipientProviderUserId,
     senderProviderUserId: sender.providerUserId,
   }).catch(
     (error) =>
@@ -1162,6 +1159,16 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
           },
         ],
       },
+    )
+    return
+  }
+
+  if (result.code === 'recipient_pending') {
+    await postSlackEphemeral(
+      provider.id,
+      event.item.channel,
+      event.user,
+      `Payment pending. <@${recipientProviderUserId}> needs to connect Tipbot with \`/tip connect\`. The payment will be sent automatically once they connect.`,
     )
     return
   }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1069,7 +1069,10 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
     )
     return
   }
-  if (message.bot_id || message.subtype) {
+  if (
+    message.bot_id ||
+    (message.subtype && !['reply_broadcast', 'thread_broadcast'].includes(message.subtype))
+  ) {
     await postSlackEphemeral(
       provider.id,
       event.item.channel,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -263,11 +263,23 @@ describe('/tip @account', () => {
     await connectTipAccounts({ recipient: false })
 
     const response = await postSlashCommand(`<@${Constants.slack.memberUserId}>`)
+    const pendingTips = await db
+      .selectFrom('pending_tip')
+      .innerJoin('workspace', 'workspace.id', 'pending_tip.workspace_id')
+      .selectAll('pending_tip')
+      .where('workspace.provider_id', '=', providerId)
+      .execute()
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      `Payment not sent. <@${Constants.slack.memberUserId}> needs to connect Tipbot before receiving payments.`,
+      `Payment pending. <@${Constants.slack.memberUserId}> needs to connect Tipbot with \`/tip connect\`. The payment will be sent automatically once they connect.`,
     )
+    expect(pendingTips).toHaveLength(1)
+    expect(pendingTips[0]).toMatchObject({
+      amount: 1000,
+      provider_channel_id: `slack:${Constants.slack.channelId}`,
+      recipient_provider_user_id: Constants.slack.memberUserId,
+    })
     await expectSlackMessageNotContaining('tried to tip you')
   })
 
@@ -975,6 +987,78 @@ test('reaction tipping sends default tip and updates aggregate thread reply', as
   )
 })
 
+for (const subtype of ['thread_broadcast', 'reply_broadcast']) {
+  test(`reaction tipping supports ${subtype} messages`, async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    await connectTipAccounts()
+    const channelId = await createSlackTestChannel('rt')
+    const parent = await memberSlack.chat.postMessage({
+      channel: channelId,
+      text: 'broadcast parent',
+    })
+    if (!parent.ts) throw new Error('Expected Slack parent message timestamp.')
+    const reply = await memberSlack.chat.postMessage({
+      channel: channelId,
+      text: `${subtype} reply`,
+      thread_ts: parent.ts,
+    })
+    if (!reply.ts) throw new Error('Expected Slack reply message timestamp.')
+    fetchSpy.mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const params = slackFetchBodyParams(init?.body)
+      if (url.endsWith('/conversations.replies') && params.get('ts') === reply.ts)
+        return Promise.resolve(
+          Response.json({
+            messages: [
+              {
+                subtype,
+                thread_ts: parent.ts,
+                ts: reply.ts,
+                user: Constants.slack.memberUserId,
+              },
+            ],
+            ok: true,
+          }),
+        )
+      return originalFetch(input, init)
+    })
+
+    const response = await postSlackReaction({
+      channelId,
+      messageTs: reply.ts,
+      reaction: 'money_with_wings',
+      userId: Constants.slack.adminUserId,
+    })
+    let reactionTip = await db
+      .selectFrom('reaction_tip')
+      .innerJoin('workspace', 'workspace.id', 'reaction_tip.workspace_id')
+      .selectAll('reaction_tip')
+      .where('workspace.provider_id', '=', providerId)
+      .executeTakeFirst()
+    for (let index = 0; index < 20 && !reactionTip; index++) {
+      await new Promise((resolve) => setTimeout(resolve, 10)) // 10 milliseconds
+      reactionTip = await db
+        .selectFrom('reaction_tip')
+        .innerJoin('workspace', 'workspace.id', 'reaction_tip.workspace_id')
+        .selectAll('reaction_tip')
+        .where('workspace.provider_id', '=', providerId)
+        .executeTakeFirst()
+    }
+
+    expect(response.status).toBe(200)
+    expect(reactionTip).toMatchObject({ message_ts: reply.ts, thread_ts: parent.ts })
+    expect(
+      fetchSpy.mock.calls.some((call) =>
+        slackFetchBodyParams(call[1]?.body)
+          .get('text')
+          ?.includes('Reaction tips only work on regular account messages'),
+      ),
+    ).toBe(false)
+    fetchSpy.mockRestore()
+  }, 20_000) // 20 seconds
+}
+
 test('reaction tipping updates one aggregate reply for multiple tipped messages in a thread', async () => {
   const connected = await connectTipAccounts()
   if (!connected.recipientMember) throw new Error('Expected connected recipient.')
@@ -1207,7 +1291,7 @@ test('reaction tipping reports unconnected recipient', async () => {
   expect(reactionTips).toHaveLength(0)
   await expectSlackPostEphemeralCall(
     fetchSpy,
-    `Payment not sent. <@${Constants.slack.memberUserId}> needs to connect Tipbot before receiving payments.`,
+    `Payment pending. <@${Constants.slack.memberUserId}> needs to connect Tipbot with \`/tip connect\`. The payment will be sent automatically once they connect.`,
   )
   await expectSlackThreadMessageNotContaining(message.ts, 'tipped', { channelId })
   fetchSpy.mockRestore()

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -36,6 +36,7 @@ export type TipResult =
         | 'insufficient_funds'
         | 'missing_sender_access_key'
         | 'pending'
+        | 'recipient_pending'
         | 'recipient_unconnected'
         | 'self_tip'
         | 'sender_unconnected'
@@ -114,12 +115,21 @@ export async function handleTipRequest(
   if (!sender) return { code: 'sender_unconnected', ok: false }
   const recipient = await getConnectedMember(db, workspace.id, input.recipientProviderUserId)
   if (!recipient)
-    return {
-      code: 'recipient_unconnected',
-      ok: false,
+    return await createPendingTip(db, {
+      amount,
+      idempotencyKey: input.idempotencyKey,
+      memo: input.memo,
+      provider: input.provider,
+      providerChannelId: input.providerChannelId,
+      providerId: input.providerId,
+      providerThreadId: input.providerThreadId,
+      recipientProviderLabel: input.recipientProviderLabel,
       recipientProviderUserId: input.recipientProviderUserId,
+      senderMemberId: sender.member.id,
       senderProviderUserId: input.senderProviderUserId,
-    }
+      tokenAddress,
+      workspace,
+    })
 
   const accessKeys = await db
     .selectFrom('access_key')
@@ -1037,4 +1047,132 @@ async function createSponsorshipMemo(
     ),
   )
   return `0x74697001${Hex.fromBytes(new Uint8Array(digest)).slice(10, 66)}`
+}
+
+async function createPendingTip(
+  db: DB.Type,
+  input: {
+    amount: number
+    idempotencyKey: string
+    memo: string | null
+    provider: Database.Selectable.workspace['provider']
+    providerChannelId: string
+    providerId: string
+    providerThreadId?: string
+    recipientProviderLabel?: string
+    recipientProviderUserId: string
+    senderMemberId: string
+    senderProviderUserId: string
+    tokenAddress: string
+    workspace: Database.Selectable.workspace
+  },
+): Promise<TipResult> {
+  const existing = await db
+    .selectFrom('pending_tip')
+    .select('id')
+    .where('idempotency_key', '=', input.idempotencyKey)
+    .executeTakeFirst()
+  if (existing)
+    return {
+      code: 'recipient_pending',
+      ok: false,
+      recipientProviderUserId: input.recipientProviderUserId,
+      senderProviderUserId: input.senderProviderUserId,
+    }
+
+  const now = new Date().toISOString()
+  await db
+    .insertInto('pending_tip')
+    .values({
+      amount: input.amount,
+      created_at: now,
+      id: Nanoid.generate(),
+      idempotency_key: input.idempotencyKey,
+      memo: input.memo,
+      provider: input.provider,
+      provider_channel_id: input.providerChannelId,
+      provider_id: input.providerId,
+      provider_thread_id: input.providerThreadId ?? null,
+      recipient_provider_label: input.recipientProviderLabel ?? null,
+      recipient_provider_user_id: input.recipientProviderUserId,
+      sender_member_id: input.senderMemberId,
+      token_address: Address.checksum(input.tokenAddress),
+      updated_at: now,
+      workspace_id: input.workspace.id,
+    })
+    .execute()
+
+  return {
+    code: 'recipient_pending',
+    ok: false,
+    recipientProviderUserId: input.recipientProviderUserId,
+    senderProviderUserId: input.senderProviderUserId,
+  }
+}
+
+export async function claimPendingTips(
+  env: Env,
+  workspaceId: string,
+  recipientProviderUserId: string,
+) {
+  const db = DB.create(env.DB)
+  const pendingTips = await db
+    .selectFrom('pending_tip')
+    .selectAll()
+    .where('workspace_id', '=', workspaceId)
+    .where('recipient_provider_user_id', '=', recipientProviderUserId)
+    .where('claimed_at', 'is', null)
+    .where('expired_at', 'is', null)
+    .orderBy('created_at', 'asc')
+    .execute()
+  if (pendingTips.length === 0) return []
+
+  const results: Array<{
+    pendingTipId: string
+    result: TipResult
+    senderMemberId: string
+  }> = []
+  for (const pending of pendingTips) {
+    const sender = await db
+      .selectFrom('member')
+      .select('provider_user_id')
+      .where('id', '=', pending.sender_member_id)
+      .executeTakeFirst()
+    if (!sender) continue
+
+    const result = await handleTipRequest(env, {
+      amount: pending.amount,
+      idempotencyKey: pending.idempotency_key,
+      memo: pending.memo,
+      provider: pending.provider,
+      providerChannelId: pending.provider_channel_id,
+      providerId: pending.provider_id,
+      providerThreadId: pending.provider_thread_id ?? undefined,
+      recipientProviderLabel: pending.recipient_provider_label ?? undefined,
+      recipientProviderUserId: pending.recipient_provider_user_id,
+      senderProviderUserId: sender.provider_user_id,
+      tokenAddress: pending.token_address,
+    })
+
+    const now = new Date().toISOString()
+    if (result.ok)
+      await db
+        .updateTable('pending_tip')
+        .set({ claimed_at: now, updated_at: now })
+        .where('id', '=', pending.id)
+        .execute()
+    else if (result.code !== 'recipient_unconnected' && result.code !== 'recipient_pending')
+      await db
+        .updateTable('pending_tip')
+        .set({ expired_at: now, updated_at: now })
+        .where('id', '=', pending.id)
+        .execute()
+
+    results.push({
+      pendingTipId: pending.id,
+      result,
+      senderMemberId: pending.sender_member_id,
+    })
+  }
+  return results
 }

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -1082,26 +1082,30 @@ async function createPendingTip(
     }
 
   const now = new Date().toISOString()
-  await db
-    .insertInto('pending_tip')
-    .values({
-      amount: input.amount,
-      created_at: now,
-      id: Nanoid.generate(),
-      idempotency_key: input.idempotencyKey,
-      memo: input.memo,
-      provider: input.provider,
-      provider_channel_id: input.providerChannelId,
-      provider_id: input.providerId,
-      provider_thread_id: input.providerThreadId ?? null,
-      recipient_provider_label: input.recipientProviderLabel ?? null,
-      recipient_provider_user_id: input.recipientProviderUserId,
-      sender_member_id: input.senderMemberId,
-      token_address: Address.checksum(input.tokenAddress),
-      updated_at: now,
-      workspace_id: input.workspace.id,
-    })
-    .execute()
+  try {
+    await db
+      .insertInto('pending_tip')
+      .values({
+        amount: input.amount,
+        created_at: now,
+        id: Nanoid.generate(),
+        idempotency_key: input.idempotencyKey,
+        memo: input.memo,
+        provider: input.provider,
+        provider_channel_id: input.providerChannelId,
+        provider_id: input.providerId,
+        provider_thread_id: input.providerThreadId ?? null,
+        recipient_provider_label: input.recipientProviderLabel ?? null,
+        recipient_provider_user_id: input.recipientProviderUserId,
+        sender_member_id: input.senderMemberId,
+        token_address: Address.checksum(input.tokenAddress),
+        updated_at: now,
+        workspace_id: input.workspace.id,
+      })
+      .execute()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+  }
 
   return {
     code: 'recipient_pending',
@@ -1130,6 +1134,8 @@ export async function claimPendingTips(
 
   const results: Array<{
     pendingTipId: string
+    providerChannelId: string
+    providerThreadId: string | null
     result: TipResult
     senderMemberId: string
   }> = []
@@ -1171,9 +1177,15 @@ export async function claimPendingTips(
 
     results.push({
       pendingTipId: pending.id,
+      providerChannelId: pending.provider_channel_id,
+      providerThreadId: pending.provider_thread_id,
       result,
       senderMemberId: pending.sender_member_id,
     })
   }
   return results
+}
+
+function isUniqueConstraintError(error: unknown) {
+  return error instanceof Error && /unique constraint|constraint failed/i.test(error.message)
 }


### PR DESCRIPTION
When a tip is sent to someone who hasn't connected Tipbot:

- Creates a `pending_tip` record instead of failing with "Payment not sent"
- Sender sees "Payment pending. @user needs to connect Tipbot with `/tip connect`. The payment will be sent automatically once they connect."
- When recipient connects via `/tip connect`, all pending tips are automatically claimed and executed
- Receipt messages posted to the original channel on successful claim

### Changes
- **Migration 0008**: new `pending_tip` table
- **tip.ts**: new `recipient_pending` result code + `createPendingTip` / `claimPendingTips` functions
- **chat.ts**: pending-aware messages for both slash command and reaction tip flows
- **api.ts**: sweep pending tips in `waitUntil` after successful account link