### PR TITLE
feat: support multiple reaction emoji with per-emoji tip amounts

### DIFF
--- a/db/migrations/0008_workspace_reaction_emoji.sql
+++ b/db/migrations/0008_workspace_reaction_emoji.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "workspace_reaction_emoji" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "workspace_id" TEXT NOT NULL REFERENCES "workspace" ("id") ON DELETE CASCADE,
+  "emoji" TEXT NOT NULL CHECK ("emoji" <> ''),
+  "amount" INTEGER NOT NULL CHECK ("amount" > 0),
+  "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "workspace_reaction_emoji_workspace_emoji_idx" ON "workspace_reaction_emoji" (
+  "workspace_id",
+  "emoji"
+);
+CREATE INDEX "workspace_reaction_emoji_workspace_idx" ON "workspace_reaction_emoji" ("workspace_id");

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -112,6 +112,15 @@ export const workspace = z.object({
   updated_at: z.string(),
 })
 
+export const workspace_reaction_emoji = z.object({
+  amount: z.number(),
+  created_at: z.string(),
+  emoji: z.string(),
+  id: z.string(),
+  updated_at: z.string(),
+  workspace_id: z.string(),
+})
+
 export const db = {
   access_key: access_key,
   account: account,
@@ -121,4 +130,5 @@ export const db = {
   reaction_tip_thread: reaction_tip_thread,
   tip: tip,
   workspace: workspace,
+  workspace_reaction_emoji: workspace_reaction_emoji,
 }

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -11,6 +11,7 @@ export interface DB {
   reaction_tip_thread: reaction_tip_thread
   tip: tip
   workspace: workspace
+  workspace_reaction_emoji: workspace_reaction_emoji
 }
 
 type access_key = {
@@ -123,6 +124,15 @@ type workspace = {
   updated_at: k.Generated<string>
 }
 
+type workspace_reaction_emoji = {
+  amount: number
+  created_at: k.Generated<string>
+  emoji: string
+  id: string
+  updated_at: k.Generated<string>
+  workspace_id: string
+}
+
 export declare namespace DB {
   type access_key = k.Selectable<DB['access_key']>
   type account = k.Selectable<DB['account']>
@@ -132,6 +142,7 @@ export declare namespace DB {
   type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
   type tip = k.Selectable<DB['tip']>
   type workspace = k.Selectable<DB['workspace']>
+  type workspace_reaction_emoji = k.Selectable<DB['workspace_reaction_emoji']>
 
   export namespace Insertable {
     type access_key = k.Insertable<DB['access_key']>
@@ -142,6 +153,7 @@ export declare namespace DB {
     type reaction_tip_thread = k.Insertable<DB['reaction_tip_thread']>
     type tip = k.Insertable<DB['tip']>
     type workspace = k.Insertable<DB['workspace']>
+    type workspace_reaction_emoji = k.Insertable<DB['workspace_reaction_emoji']>
   }
 
   export namespace Selectable {
@@ -153,6 +165,7 @@ export declare namespace DB {
     type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
     type tip = k.Selectable<DB['tip']>
     type workspace = k.Selectable<DB['workspace']>
+    type workspace_reaction_emoji = k.Selectable<DB['workspace_reaction_emoji']>
   }
 
   export namespace Updateable {
@@ -164,5 +177,6 @@ export declare namespace DB {
     type reaction_tip_thread = k.Updateable<DB['reaction_tip_thread']>
     type tip = k.Updateable<DB['tip']>
     type workspace = k.Updateable<DB['workspace']>
+    type workspace_reaction_emoji = k.Updateable<DB['workspace_reaction_emoji']>
   }
 }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -110,8 +110,20 @@ export function getChat() {
         .where('provider_id', '=', reaction.team_id)
         .executeTakeFirst()
       if (!workspace) return
-      if (reaction.reaction !== workspace.reaction_tip_emoji) return
+
+      // Check workspace_reaction_emoji table for per-emoji amount overrides
+      const emojiRow = await db
+        .selectFrom('workspace_reaction_emoji')
+        .selectAll()
+        .where('workspace_id', '=', workspace.id)
+        .where('emoji', '=', reaction.reaction)
+        .executeTakeFirst()
+
+      // Fall back to legacy single-emoji column
+      if (!emojiRow && reaction.reaction !== workspace.reaction_tip_emoji) return
+
       return {
+        amountOverride: emojiRow?.amount,
         db,
         provider: { id: reaction.team_id, type: 'slack' },
         workspace,
@@ -411,6 +423,7 @@ const handlers = {
       ['/tip disconnect', 'Disconnect from Tipbot'],
       ['/tip help', 'Show help message'],
       ['/tip leaderboard', 'Show top tippers and recipients'],
+      ['/tip reactions', 'Manage reaction emoji tips'],
       ['/tip status', 'Check connection status'],
     ]
     const paymentExampleRows = [
@@ -606,6 +619,115 @@ const handlers = {
     )
     if (!json.ok) throw Slack.slackApiError('chat.postMessage', json.error)
   },
+  async reactions(event, ctx) {
+    const workspace = await ctx.db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider', '=', ctx.provider.type)
+      .where('provider_id', '=', ctx.provider.id)
+      .executeTakeFirst()
+    if (!workspace) {
+      await event.channel.postEphemeral(
+        event.user,
+        'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
+        { fallbackToDM: false },
+      )
+      return
+    }
+
+    const isAdmin = await canManageSlackWorkspaceSettings(ctx.provider.id, event.user.userId)
+
+    // Parse subcommands: "add :emoji: $amount", "remove :emoji:", or no args to list
+    const addMatch = ctx.text.match(/^add\s+:?([a-z0-9_+-]+):?\s+(.+)$/i)
+    const removeMatch = ctx.text.match(/^remove\s+:?([a-z0-9_+-]+):?$/i)
+
+    if (addMatch) {
+      if (!isAdmin) {
+        await event.channel.postEphemeral(
+          event.user,
+          'Only Slack admins can manage reaction emojis.',
+          { fallbackToDM: false },
+        )
+        return
+      }
+      const emoji = addMatch[1]!.toLowerCase()
+      const amount = Tip.parseAmount(addMatch[2]!.trim())
+      if (amount === null) {
+        await event.channel.postEphemeral(
+          event.user,
+          'Invalid amount. Example: `/tip reactions add :money_mouth_face: $1`',
+          { fallbackToDM: false },
+        )
+        return
+      }
+      const now = new Date().toISOString()
+      await ctx.db
+        .insertInto('workspace_reaction_emoji')
+        .values({
+          amount,
+          created_at: now,
+          emoji,
+          id: Nanoid.generate(),
+          updated_at: now,
+          workspace_id: workspace.id,
+        })
+        .onConflict((oc) =>
+          oc.columns(['workspace_id', 'emoji']).doUpdateSet({ amount, updated_at: now }),
+        )
+        .execute()
+      await event.channel.postEphemeral(
+        event.user,
+        `Reaction tip added: :${emoji}: sends ${formatAmount(amount)}`,
+        { fallbackToDM: false },
+      )
+      return
+    }
+
+    if (removeMatch) {
+      if (!isAdmin) {
+        await event.channel.postEphemeral(
+          event.user,
+          'Only Slack admins can manage reaction emojis.',
+          { fallbackToDM: false },
+        )
+        return
+      }
+      const emoji = removeMatch[1]!.toLowerCase()
+      const deleted = await ctx.db
+        .deleteFrom('workspace_reaction_emoji')
+        .where('workspace_id', '=', workspace.id)
+        .where('emoji', '=', emoji)
+        .execute()
+      if (deleted[0] && Number(deleted[0].numDeletedRows) > 0)
+        await event.channel.postEphemeral(event.user, `Reaction tip removed: :${emoji}:`, {
+          fallbackToDM: false,
+        })
+      else
+        await event.channel.postEphemeral(event.user, `No reaction tip found for :${emoji}:`, {
+          fallbackToDM: false,
+        })
+      return
+    }
+
+    // List all reaction emojis
+    const emojis = await ctx.db
+      .selectFrom('workspace_reaction_emoji')
+      .selectAll()
+      .where('workspace_id', '=', workspace.id)
+      .orderBy('created_at', 'asc')
+      .execute()
+
+    const lines = [
+      `Default: :${workspace.reaction_tip_emoji}: sends ${formatAmount(workspace.default_amount)}`,
+      ...emojis.map((row) => `:${row.emoji}: sends ${formatAmount(row.amount)}`),
+    ]
+    if (isAdmin)
+      lines.push(
+        '',
+        'Manage: `/tip reactions add :emoji: $amount` or `/tip reactions remove :emoji:`',
+      )
+    await event.channel.postEphemeral(event.user, lines.join('\n'), { fallbackToDM: false })
+  },
   async status(event, ctx) {
     const workspace = await ctx.db
       .selectFrom('workspace')
@@ -658,7 +780,15 @@ const handlers = {
   (event: chat.SlashCommandEvent, ctx: HandlerContext) => Promise<void>
 >
 
-const commandNames = ['config', 'connect', 'disconnect', 'help', 'leaderboard', 'status'] as const
+const commandNames = [
+  'config',
+  'connect',
+  'disconnect',
+  'help',
+  'leaderboard',
+  'reactions',
+  'status',
+] as const
 const commandPattern = new RegExp(`^(${commandNames.join('|')})(?:\\s+([\\s\\S]*))?$`)
 const actionNames = ['config_edit', 'connect_cancel', 'confirm_cancel'] as const
 const modalSubmitNames = ['config_edit'] as const
@@ -689,6 +819,7 @@ type TipEvent = {
 }
 
 type ReactionHandlerContext = {
+  amountOverride?: number
   db: DB.Type
   provider: ProviderContext
   workspace: DB_gen.Selectable.workspace
@@ -1152,6 +1283,7 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
   if (!inserted) return
 
   const result = await Tip.handleTipRequest(env, {
+    ...(context.amountOverride ? { amount: context.amountOverride } : {}),
     idempotencyKey,
     memo: null,
     provider: provider.type,


### PR DESCRIPTION
## Summary

Adds support for multiple reaction emojis, each with its own tip amount. Currently tipbot only supports one reaction emoji per workspace. This change lets admins configure additional emojis — e.g. `:money_mouth_face:` → $1.

## Changes

**New migration** (`0008_workspace_reaction_emoji.sql`): creates a `workspace_reaction_emoji` table with per-workspace emoji→amount mappings.

**Reaction handler**: now checks the `workspace_reaction_emoji` table first for per-emoji amount overrides, falling back to the legacy `workspace.reaction_tip_emoji` column for backward compatibility. No migration of existing data needed.

**New `/tip reactions` command**:
- `/tip reactions` — list all configured reaction emojis and their amounts
- `/tip reactions add :emoji: $amount` — add or update a reaction emoji (admin only)
- `/tip reactions remove :emoji:` — remove a reaction emoji (admin only)

## Usage

```
/tip reactions add :money_mouth_face: $1
```

Then react to any message with 🤑 to send $1.