### PR TITLE
feat: money_mouth_face emoji tips $1

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -113,8 +113,11 @@ export function getChat() {
         .where('provider_id', '=', reaction.team_id)
         .executeTakeFirst()
       if (!workspace) return
-      if (reaction.reaction !== workspace.reaction_tip_emoji) return
+      const isDefaultEmoji = reaction.reaction === workspace.reaction_tip_emoji
+      const isMoneyMouth = reaction.reaction === 'money_mouth_face'
+      if (!isDefaultEmoji && !isMoneyMouth) return
       return {
+        amount: isMoneyMouth ? 1_000_000 : undefined, // $1 for money_mouth_face
         db,
         provider: { id: reaction.team_id, type: 'slack' },
         workspace,
@@ -810,6 +813,7 @@ type TipEvent = {
 }
 
 type ReactionHandlerContext = {
+  amount?: number
   db: DB.Type
   provider: ProviderContext
   workspace: DB_gen.Selectable.workspace
@@ -1278,6 +1282,7 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
   if (!inserted) return
 
   const result = await Tip.handleTipRequest(env, {
+    ...(context.amount !== undefined ? { amount: context.amount } : {}),
     idempotencyKey,
     memo: null,
     provider: provider.type,


### PR DESCRIPTION
React with `:money_mouth_face:` on any message to tip the author $1 (1,000,000 micro-units), independent of the workspace default amount.

The existing configurable `reaction_tip_emoji` continues to use the workspace `default_amount` as before.

**Changes:**
- `onReaction` handler now matches both `workspace.reaction_tip_emoji` and `money_mouth_face`
- When `money_mouth_face` is the reaction, passes `amount: 1_000_000` ($1) override to `handleTipRequest`
- Added optional `amount` field to `ReactionHandlerContext`

All checks pass (`pnpm check` + `pnpm check:types`).