### PR TITLE
fix: treat non-token words after amount as memo in mention tips

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -426,10 +426,9 @@ const handlers = {
       ['/tip @account 0.005 USDC for coffee', 'Send custom token with memo'],
     ]
     const mentionExampleRows = [
-      [
-        '@Tipbot [tip|send|pay] @account [amount] [token] [for memo]',
-        'Send payment by mentioning Tipbot',
-      ],
+      ['@Tipbot @account', 'Send default amount'],
+      ['@Tipbot @account for coffee', 'Send default amount with memo'],
+      ['@Tipbot @account 0.005 for coffee', 'Send custom amount with memo'],
       [
         `[emoji] :${workspace?.reaction_tip_emoji ?? 'money_with_wings'}:`,
         'Send default amount by reacting to a message',
@@ -1676,7 +1675,7 @@ async function postInvalidUsage(
   body.set(
     'text',
     options.mention
-      ? 'Invalid `@Tipbot` usage. Try `@Tipbot @account [amount] [token] [for memo]` or `@Tipbot tip @account`.'
+      ? 'Invalid `@Tipbot` usage. Try `@Tipbot @account for coffee` or `@Tipbot @account 0.005 for coffee`.'
       : 'Invalid `/tip` usage. Try `/tip @account` or `/tip help` for more info.',
   )
   if (options.threadTs) body.set('thread_ts', options.threadTs)
@@ -1740,11 +1739,11 @@ async function generateInvalidMentionReply(mentionText: string) {
   const isThanksText = /^(thank you|thanks|ty|thx|thank u)\b/i.test(text)
   const fallback = (() => {
     if (creatureMatch && isTipText)
-      return `${creatureMatch[0].toUpperCase()}? Excellent. For tips: \`@Tipbot tip @account [amount] [token] [for memo]\`.`
+      return `${creatureMatch[0].toUpperCase()}? Excellent. For tips: \`@Tipbot @account for coffee\`.`
     if (creatureMatch) return `${creatureMatch[0].toUpperCase()}? Now we are talking.`
     if (isThanksText) return 'Anytime.'
     if (isSetupText) return 'Run `/tip connect`, then try `@Tipbot tip @account`.'
-    if (isTipText) return 'Almost. Try `@Tipbot tip @account [amount] [token] [for memo]`.'
+    if (isTipText) return 'Almost. Try `@Tipbot @account for coffee`.'
     return 'Anytime.'
   })()
   try {
@@ -1756,7 +1755,7 @@ async function generateInvalidMentionReply(mentionText: string) {
           messages: [
             {
               content:
-                'You are Tipbot in Slack. Reply to an invalid @Tipbot mention. Keep it under 140 chars. Be short and pithy. Do not mention users. If the user mentions goblins or other creatures, get REALLY EXCITED. If the user seems to be trying to send a tip/payment, include this exact syntax: `@Tipbot tip @account [amount] [token] [for memo]`. Otherwise just acknowledge or deflect lightly.',
+                'You are Tipbot in Slack. Reply to an invalid @Tipbot mention. Keep it under 140 chars. Be short and pithy. Do not mention users. If the user mentions goblins or other creatures, get REALLY EXCITED. If the user seems to be trying to send a tip/payment, include this exact syntax: `@Tipbot @account for coffee`. Otherwise just acknowledge or deflect lightly.',
               role: 'system',
             },
             { content: text || '(empty mention)', role: 'user' },
@@ -1786,7 +1785,7 @@ async function postSlackIntroduction(event: TipEvent, ctx: HandlerContext, threa
 
   const text =
     'I’m Tipbot: sometime tipper, sometime messenger, always bot.\n' +
-    'Connect with `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `/tip @account for coffee`, or a 💸 reaction.'
+    'Connect with `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `@Tipbot @account 0.005 for coffee`, `/tip @account for coffee`, or a 💸 reaction.'
   const body = new URLSearchParams()
   body.set('channel', event.channel.id.replace(/^slack:/, ''))
   body.set('text', text)

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -852,7 +852,15 @@ async function handleTipText(
     threadTs?: string
   },
 ) {
-  const parsed = Tip.parseTipText(ctx.text)
+  const workspace = await ctx.db
+    .selectFrom('workspace')
+    .selectAll()
+    .where('provider', '=', ctx.provider.type)
+    .where('provider_id', '=', ctx.provider.id)
+    .executeTakeFirst()
+  const parsed = Tip.parseTipText(ctx.text, {
+    chainId: workspace?.chain_id ?? Tempo.chainLookup.mainnet,
+  })
   if (!parsed) {
     if (options.mention && options.threadTs) {
       await postInvalidMentionReply(event, ctx, ctx.text, options.threadTs)
@@ -862,12 +870,6 @@ async function handleTipText(
     return
   }
 
-  const workspace = await ctx.db
-    .selectFrom('workspace')
-    .selectAll()
-    .where('provider', '=', ctx.provider.type)
-    .where('provider_id', '=', ctx.provider.id)
-    .executeTakeFirst()
   const tokenAddress = parsed.token
     ? Tempo.getTokenAddress(workspace?.chain_id ?? Tempo.chainLookup.mainnet, parsed.token)
     : null

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -498,6 +498,13 @@ test.each([
   },
   {
     amount: 2000,
+    memo: 'v2 launch',
+    name: 'token-like memo after amount',
+    text: '0.002 v2 launch',
+    tokenAddress: undefined,
+  },
+  {
+    amount: 2000,
     memo: 'lunch',
     name: 'custom token with memo',
     text: '0.002 BetaUSD for lunch',

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -481,6 +481,54 @@ test('@Tipbot mention sends tip in thread', async () => {
   fetchSpy.mockRestore()
 }, 20_000) // 20 seconds
 
+test.each([
+  {
+    amount: 2000,
+    memo: null,
+    name: 'custom token',
+    text: '0.002 BetaUSD',
+    tokenAddress: Tempo.addressLookup.betaUsd,
+  },
+  {
+    amount: 2000,
+    memo: 'thanks for the help',
+    name: 'memo after amount',
+    text: '0.002 thanks for the help',
+    tokenAddress: undefined,
+  },
+  {
+    amount: 2000,
+    memo: 'lunch',
+    name: 'custom token with memo',
+    text: '0.002 BetaUSD for lunch',
+    tokenAddress: Tempo.addressLookup.betaUsd,
+  },
+])('@Tipbot mention parses $name', async (input) => {
+  const handleTipRequest = vi.spyOn(Tip, 'handleTipRequest').mockResolvedValue({
+    code: 'pending',
+    ok: false,
+  })
+  const messageTs = `1700000017.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}> ${input.text}`,
+  })
+
+  expect(response.status).toBe(200)
+  expect(handleTipRequest).toHaveBeenCalledWith(
+    env,
+    expect.objectContaining({
+      amount: input.amount,
+      memo: input.memo,
+      providerThreadId: messageTs,
+      recipientProviderUserId: Constants.slack.memberUserId,
+      tokenAddress: input.tokenAddress,
+    }),
+  )
+  expect(aiRunMock).not.toHaveBeenCalled()
+})
+
 test.each(['pay', 'send', 'tip'])(
   '@Tipbot mention accepts %s before recipient',
   async (verb) => {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -528,7 +528,7 @@ test('@Tipbot mention introduces itself', async () => {
   )
   await expectSlackThreadMessage(
     messageTs,
-    'Connect with `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `/tip @account for coffee`, or a 💸 reaction.',
+    'Connect with `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `@Tipbot @account 0.005 for coffee`, `/tip @account for coffee`, or a 💸 reaction.',
   )
   expect(tips).toHaveLength(0)
 })
@@ -728,7 +728,7 @@ test('@Tipbot mention accepts repeated bot mentions', async () => {
 
 test('@Tipbot mention rejects ambiguous mentions', async () => {
   aiRunMock.mockResolvedValueOnce({
-    response: 'Almost. Try `@Tipbot tip @account [amount] [token] [for memo]`.',
+    response: 'Almost. Try `@Tipbot @account for coffee`.',
   } as never)
   const messageTs = `1700000003.${Nanoid.generate().slice(0, 6)}`
 
@@ -745,10 +745,7 @@ test('@Tipbot mention rejects ambiguous mentions', async () => {
 
   expect(response.status).toBe(200)
   expect(tips).toHaveLength(0)
-  await expectSlackThreadMessage(
-    messageTs,
-    'Almost. Try `@Tipbot tip @account [amount] [token] [for memo]`.',
-  )
+  await expectSlackThreadMessage(messageTs, 'Almost. Try `@Tipbot @account for coffee`.')
   await expectSlackThreadMessageNotContaining(messageTs, 'tipped')
 })
 
@@ -1859,7 +1856,9 @@ describe('/tip help', () => {
     await expectSlackMessage('/tip @account 0.005 for coffee')
     await expectSlackMessage('/tip @account 0.005 USDC')
     await expectSlackMessage('/tip @account 0.005 USDC for coffee')
-    await expectSlackMessage('@Tipbot [tip|send|pay] @account [amount] [token] [for memo]')
+    await expectSlackMessage('@Tipbot @account')
+    await expectSlackMessage('@Tipbot @account for coffee')
+    await expectSlackMessage('@Tipbot @account 0.005 for coffee')
     await expectSlackMessage('[emoji] :money_with_wings:')
     await expectSlackMessage('Send default amount by reacting to a message')
     await expectSlackMessageNotContaining('Payment examples')

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -118,6 +118,18 @@ test('parses tip mentions and memos', () => {
     recipientProviderUserId: 'UMEMBER',
     token: null,
   })
+  expect(Tip.parseTipText('<@UMEMBER> $0.001 v2 launch')).toEqual({
+    amount: 1_000,
+    memo: 'v2 launch',
+    recipientProviderUserId: 'UMEMBER',
+    token: null,
+  })
+  expect(Tip.parseTipText('<@UMEMBER> $0.001 ship-it')).toEqual({
+    amount: 1_000,
+    memo: 'ship-it',
+    recipientProviderUserId: 'UMEMBER',
+    token: null,
+  })
 })
 
 test('rejects text without tip mentions', () => {

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from 'vitest'
+import * as Tempo from '#/lib/tempo.ts'
 import * as Tip from '#/lib/tip.ts'
+import { expect, test } from 'vitest'
 
 test('parses positive decimal amounts', () => {
   expect(Tip.parseAmount('1')).toBe(1_000_000)
@@ -64,6 +65,34 @@ test('parses tip mentions and memos', () => {
     memo: 'lunch',
     recipientProviderUserId: 'UMEMBER',
     token: 'USDC.e',
+  })
+  expect(Tip.parseTipText('<@UMEMBER> 5 usdc for lunch')).toEqual({
+    amount: 5_000_000,
+    memo: 'lunch',
+    recipientProviderUserId: 'UMEMBER',
+    token: 'usdc',
+  })
+  expect(Tip.parseTipText('<@UMEMBER> 5 BetaUSD', { chainId: Tempo.chainLookup.localnet })).toEqual(
+    {
+      amount: 5_000_000,
+      memo: null,
+      recipientProviderUserId: 'UMEMBER',
+      token: 'BetaUSD',
+    },
+  )
+  expect(
+    Tip.parseTipText('<@UMEMBER> 5 beta for lunch', { chainId: Tempo.chainLookup.localnet }),
+  ).toEqual({
+    amount: 5_000_000,
+    memo: 'lunch',
+    recipientProviderUserId: 'UMEMBER',
+    token: 'beta',
+  })
+  expect(Tip.parseTipText('<@UMEMBER> 5 pathUSD')).toEqual({
+    amount: 5_000_000,
+    memo: null,
+    recipientProviderUserId: 'UMEMBER',
+    token: 'pathUSD',
   })
   expect(Tip.parseTipText('<@UMEMBER> $0.001 thanks for the help')).toEqual({
     amount: 1_000,

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -94,6 +94,18 @@ test('parses tip mentions and memos', () => {
     recipientProviderUserId: 'UMEMBER',
     token: 'pathUSD',
   })
+  expect(Tip.parseTipText('<@UMEMBER> 5 BetaUSD')).toEqual({
+    amount: 5_000_000,
+    memo: null,
+    recipientProviderUserId: 'UMEMBER',
+    token: 'BetaUSD',
+  })
+  expect(Tip.parseTipText('<@UMEMBER> 5 FAKE')).toEqual({
+    amount: 5_000_000,
+    memo: null,
+    recipientProviderUserId: 'UMEMBER',
+    token: 'FAKE',
+  })
   expect(Tip.parseTipText('<@UMEMBER> $0.001 thanks for the help')).toEqual({
     amount: 1_000,
     memo: 'thanks for the help',

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -65,6 +65,18 @@ test('parses tip mentions and memos', () => {
     recipientProviderUserId: 'UMEMBER',
     token: 'USDC.e',
   })
+  expect(Tip.parseTipText('<@UMEMBER> $0.001 thanks for the help')).toEqual({
+    amount: 1_000,
+    memo: 'thanks for the help',
+    recipientProviderUserId: 'UMEMBER',
+    token: null,
+  })
+  expect(Tip.parseTipText('<@UMEMBER> $0.001 great work')).toEqual({
+    amount: 1_000,
+    memo: 'great work',
+    recipientProviderUserId: 'UMEMBER',
+    token: null,
+  })
 })
 
 test('rejects text without tip mentions', () => {

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -189,7 +189,7 @@ function isTokenLike(value: string) {
   return /^[A-Z]{2,10}$/.test(value) // e.g. USDC, USDT, PATH
 }
 
-export function parseTipText(value: string) {
+export function parseTipText(value: string, options: { chainId?: number } = {}) {
   const text = value.trim()
   const mention = text.match(/<@([A-Z0-9_]+)(?:\|([^>]+))?>/)
   if (!mention) return null
@@ -209,8 +209,8 @@ export function parseTipText(value: string) {
       }
 
     const [token = '', ...tokenRest] = remaining.split(/\s+/)
-    // token symbols contain dots, digits, or are all-uppercase short strings (e.g. USDC.e, USDT)
-    if (isTokenLike(token)) {
+    const chainId = options.chainId ?? Tempo.chainLookup.mainnet
+    if (Tempo.getTokenAddress(chainId, token) || isTokenLike(token)) {
       const afterToken = tokenRest.join(' ').trim()
       const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
       if (afterToken && !memo) return null
@@ -223,7 +223,6 @@ export function parseTipText(value: string) {
       }
     }
 
-    // remaining text is not a token — treat it as memo
     return {
       amount,
       memo: remaining.replace(/^for\s+/i, '').trim() || null,

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -185,7 +185,7 @@ export function parseAmount(value: string) {
 }
 
 function isTokenLike(value: string) {
-  if (/[.\-_\d]/.test(value)) return true // e.g. USDC.e, usdt0
+  if (/[._\d]/.test(value)) return true // e.g. USDC.e, usdt0
   return /^[A-Z]{2,10}$/.test(value) // e.g. USDC, USDT, PATH
 }
 
@@ -210,13 +210,22 @@ export function parseTipText(value: string, options: { chainId?: number } = {}) 
 
     const [token = '', ...tokenRest] = remaining.split(/\s+/)
     const chainId = options.chainId ?? Tempo.chainLookup.mainnet
-    const isKnownToken = Object.values(Tempo.chainLookup).some((chainId) =>
-      Tempo.getTokenAddress(chainId, token),
+    const isKnownToken = Object.values(Tempo.chainLookup).some((knownChainId) =>
+      Tempo.getTokenAddress(knownChainId, token),
     )
-    if (Tempo.getTokenAddress(chainId, token) || isKnownToken || isTokenLike(token)) {
-      const afterToken = tokenRest.join(' ').trim()
-      const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
+    const afterToken = tokenRest.join(' ').trim()
+    const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
+    if (Tempo.getTokenAddress(chainId, token) || isKnownToken) {
       if (afterToken && !memo) return null
+      return {
+        amount,
+        memo: memo?.[1]?.trim() || null,
+        ...(mention[2]?.trim() ? { recipientProviderLabel: mention[2].trim() } : {}),
+        recipientProviderUserId: mention[1]!,
+        token,
+      }
+    }
+    if (isTokenLike(token) && (!afterToken || memo)) {
       return {
         amount,
         memo: memo?.[1]?.trim() || null,

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -184,6 +184,11 @@ export function parseAmount(value: string) {
   return amount
 }
 
+function isTokenLike(value: string) {
+  if (/[.\-_\d]/.test(value)) return true // e.g. USDC.e, usdt0
+  return /^[A-Z]{2,10}$/.test(value) // e.g. USDC, USDT, PATH
+}
+
 export function parseTipText(value: string) {
   const text = value.trim()
   const mention = text.match(/<@([A-Z0-9_]+)(?:\|([^>]+))?>/)
@@ -204,15 +209,27 @@ export function parseTipText(value: string) {
       }
 
     const [token = '', ...tokenRest] = remaining.split(/\s+/)
-    const afterToken = tokenRest.join(' ').trim()
-    const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
-    if (afterToken && !memo) return null
+    // token symbols contain dots, digits, or are all-uppercase short strings (e.g. USDC.e, USDT)
+    if (isTokenLike(token)) {
+      const afterToken = tokenRest.join(' ').trim()
+      const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
+      if (afterToken && !memo) return null
+      return {
+        amount,
+        memo: memo?.[1]?.trim() || null,
+        ...(mention[2]?.trim() ? { recipientProviderLabel: mention[2].trim() } : {}),
+        recipientProviderUserId: mention[1]!,
+        token,
+      }
+    }
+
+    // remaining text is not a token — treat it as memo
     return {
       amount,
-      memo: memo?.[1]?.trim() || null,
+      memo: remaining.replace(/^for\s+/i, '').trim() || null,
       ...(mention[2]?.trim() ? { recipientProviderLabel: mention[2].trim() } : {}),
       recipientProviderUserId: mention[1]!,
-      token,
+      token: null,
     }
   }
   return {

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -225,6 +225,9 @@ export function parseTipText(value: string, options: { chainId?: number } = {}) 
         token,
       }
     }
+    // TODO: Replace this unsupported-token heuristic if token symbols become dynamic or user-defined.
+    // It intentionally keeps single token-like words like FAKE on the unsupported-token path,
+    // while allowing phrases like "v2 launch" to fall through as memos.
     if (isTokenLike(token) && (!afterToken || memo)) {
       return {
         amount,

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -210,7 +210,10 @@ export function parseTipText(value: string, options: { chainId?: number } = {}) 
 
     const [token = '', ...tokenRest] = remaining.split(/\s+/)
     const chainId = options.chainId ?? Tempo.chainLookup.mainnet
-    if (Tempo.getTokenAddress(chainId, token) || isTokenLike(token)) {
+    const isKnownToken = Object.values(Tempo.chainLookup).some((chainId) =>
+      Tempo.getTokenAddress(chainId, token),
+    )
+    if (Tempo.getTokenAddress(chainId, token) || isKnownToken || isTokenLike(token)) {
       const afterToken = tokenRest.join(' ').trim()
       const memo = afterToken.match(/^for\s+([\s\S]+)$/i)
       if (afterToken && !memo) return null


### PR DESCRIPTION
## Problem

`@Tipbot @user $0.001 thanks for the help` would try to parse `thanks` as a token symbol, fail with "This token is not supported on this network" (shown as an ephemeral message only visible to the sender).

This made it seem like the mention syntax doesn't support memos at all.

## Fix

Added `isTokenLike()` check before treating the first word after the amount as a token name. Token symbols must contain dots/digits/underscores or be short all-uppercase strings (e.g. `USDC.e`, `USDT`, `PATH`). If the word doesn't look like a token, the entire remaining text is treated as memo instead.

### Now works:
- `@Tipbot @user $0.001 thanks for the help` → memo: "thanks for the help"
- `@Tipbot @user $0.001 great work` → memo: "great work"
- `@Tipbot @user $0.001 for great work` → memo: "great work" (already worked)
- `@Tipbot @user $0.001 USDC.e for lunch` → token: USDC.e, memo: "lunch" (still works)

## Tests

All existing tests pass + 2 new test cases added.