### PR TITLE
fix: parse amounts with >6 decimal places, reject sub-minimum $-prefixed amounts

### DIFF
--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -11,12 +11,18 @@ test('parses positive decimal amounts', () => {
   expect(Tip.parseAmount('123.456789')).toBe(123_456_789)
 })
 
+test('truncates extra decimals beyond 6 places', () => {
+  expect(Tip.parseAmount('1.1234567')).toBe(1_123_456)
+  expect(Tip.parseAmount('$1.12345678')).toBe(1_123_456)
+  expect(Tip.parseAmount('0.0000001')).toBe(null)
+  expect(Tip.parseAmount('$0.00000001')).toBe(null)
+})
+
 test('rejects invalid decimal amounts', () => {
   expect(Tip.parseAmount('0')).toBe(null)
   expect(Tip.parseAmount('0.000000')).toBe(null)
   expect(Tip.parseAmount('-1')).toBe(null)
   expect(Tip.parseAmount('01')).toBe(null)
-  expect(Tip.parseAmount('1.0000001')).toBe(null)
   expect(Tip.parseAmount('1.')).toBe(null)
   expect(Tip.parseAmount('abc')).toBe(null)
   expect(Tip.parseAmount('9007199255')).toBe(null)
@@ -130,6 +136,7 @@ test('parses tip mentions and memos', () => {
     recipientProviderUserId: 'UMEMBER',
     token: null,
   })
+  expect(Tip.parseTipText("<@UMEMBER> $0.00000001 let's see")).toBe(null)
 })
 
 test('rejects text without tip mentions', () => {

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -176,10 +176,11 @@ export async function handleTipRequest(
 }
 
 export function parseAmount(value: string) {
-  const match = value.match(/^\$?(0|[1-9]\d*)(?:\.(\d{1,6}))?$/)
+  const match = value.match(/^\$?(0|[1-9]\d*)(?:\.(\d+))?$/)
   if (!match) return null
 
-  const amount = Number(match[1]) * 1_000_000 + Number((match[2] ?? '').padEnd(6, '0'))
+  const decimals = (match[2] ?? '').slice(0, 6).padEnd(6, '0')
+  const amount = Number(match[1]) * 1_000_000 + Number(decimals)
   if (!Number.isSafeInteger(amount) || amount <= 0) return null
   return amount
 }
@@ -196,6 +197,7 @@ export function parseTipText(value: string, options: { chainId?: number } = {}) 
   const afterMention = text.slice((mention.index ?? 0) + mention[0].length).trim()
   const [first = '', ...rest] = afterMention.split(/\s+/)
   const amount = parseAmount(first)
+  if (amount === null && /^\$\d/.test(first)) return null
   if (amount !== null) {
     const remaining = rest.join(' ').trim()
     const memoOnly = remaining.match(/^for\s+([\s\S]+)$/i)


### PR DESCRIPTION
## Problem

When a user sends `@tipbot @user $0.00000001 let's see`, the bot treats `$0.00000001` as part of the memo and sends the default amount ($0.001) instead.

**Root cause:** `parseAmount` regex only accepts 1–6 decimal places (`\d{1,6}`). `$0.00000001` (8 decimals) fails the regex → returns `null` → `parseTipText` falls through to the default-amount path, treating the entire string as a memo.

[Example from Slack](https://tempoxyz.slack.com/archives/C0B2C23F05U/p1778864411028449?thread_ts=1778842235.816989&cid=C0B2C23F05U)

## Fix

1. **`parseAmount`**: Accept any number of decimal places, truncate to 6. Amounts that truncate to 0 are still rejected.
2. **`parseTipText`**: When the first word starts with `$` but `parseAmount` returns null (e.g. `$0.00000001` truncates to 0), return `null` (invalid tip) instead of silently swallowing the dollar value into the memo.

## Tests

All existing tests pass + new tests for truncation and the `$0.00000001` edge case.