### PR TITLE
feat: add /tip balance command

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -13,6 +13,8 @@ import * as chat from 'chat'
 import { env } from 'cloudflare:workers'
 import { sql } from 'kysely'
 import { Address } from 'ox'
+import { createClient, http } from 'viem'
+import { Actions } from 'viem/tempo'
 import { z } from 'zod'
 
 const creaturePattern =
@@ -334,6 +336,77 @@ const modalSubmits = {
 >
 
 const handlers = {
+  async balance(event, ctx) {
+    if (ctx.text) {
+      await postInvalidUsage(event, ctx)
+      return
+    }
+    const workspace = await ctx.db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider', '=', ctx.provider.type)
+      .where('provider_id', '=', ctx.provider.id)
+      .executeTakeFirst()
+    if (!workspace) {
+      await postPrivateReply(
+        event,
+        event.user,
+        'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
+      )
+      return
+    }
+
+    const member = await ctx.db
+      .selectFrom('member')
+      .innerJoin('account', 'account.id', 'member.account_id')
+      .select('account.address as account_address')
+      .where('member.workspace_id', '=', workspace.id)
+      .where('member.provider_user_id', '=', event.user.userId)
+      .executeTakeFirst()
+    if (!member) {
+      await postPrivateReply(event, event.user, 'No account connected. Run `/tip connect` first.')
+      return
+    }
+
+    const client = createClient({
+      chain: Tempo.getChain(workspace.chain_id),
+      transport: http(Tempo.getRpcUrl(env, workspace.chain_id)),
+    })
+    const tokens = workspaceTokenOptions(workspace.chain_id)
+    const balances = await Promise.all(
+      tokens.map(async (token) => {
+        try {
+          const balance = await Actions.token.getBalance(client, {
+            account: member.account_address as Address.Address,
+            token: token.address as Address.Address,
+          })
+          return { balance, label: token.label }
+        } catch {
+          return { balance: 0n, label: token.label }
+        }
+      }),
+    )
+
+    const lines = balances
+      .filter((b) => b.balance > 0n)
+      .map((b) => `${b.label} ${formatCurrencyAmount(formatAmount(Number(b.balance)), 'USD')}`)
+    const truncatedAddress = `${member.account_address.slice(0, 6)}…${member.account_address.slice(-4)}`
+    const explorerUrl = Tempo.explorerLink(workspace.chain_id, member.account_address)
+    if (lines.length === 0) {
+      await postPrivateReply(
+        event,
+        event.user,
+        `Wallet ${truncatedAddress} has no balances.\nView on explorer: ${explorerUrl}`,
+      )
+      return
+    }
+
+    await postPrivateReply(
+      event,
+      event.user,
+      [`Wallet ${truncatedAddress}`, ...lines, `View on explorer: ${explorerUrl}`].join('\n'),
+    )
+  },
   async config(event, ctx) {
     const workspace = await ctx.db
       .selectFrom('workspace')
@@ -402,6 +475,7 @@ const handlers = {
 
     const commandRows = [
       ['/tip @account [amount] [token] [for memo]', 'Send payment'],
+      ['/tip balance', 'Show wallet balance'],
       ['/tip config', 'Manage workspace configuration'],
       ['/tip connect', 'Connect to Tipbot'],
       ['/tip disconnect', 'Disconnect from Tipbot'],
@@ -748,6 +822,7 @@ const handlers = {
 >
 
 const commandNames = [
+  'balance',
   'config',
   'connect',
   'disconnect',

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2339,6 +2339,86 @@ describe('/tip stats', () => {
   })
 })
 
+describe('/tip balance', () => {
+  test('shows token balances for connected account', async () => {
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('balance')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('Wallet 0x')
+    await expectSlackMessage('View on explorer:')
+  }, 20_000) // 20 seconds
+
+  test('handles no connected account', async () => {
+    const response = await postSlashCommand('balance')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('No account connected. Run `/tip connect` first.')
+  })
+
+  test('handles missing workspace', async () => {
+    await db.deleteFrom('workspace').where('provider_id', '=', providerId).execute()
+
+    const response = await postSlashCommand('balance')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
+    )
+  })
+
+  test('shows no balances message when all balances are zero', async () => {
+    const account = await factory.account.insert({})
+    const workspace = await db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider_id', '=', providerId)
+      .executeTakeFirstOrThrow()
+    await factory.member.insert({
+      account_id: account.id,
+      provider_user_id: Constants.slack.adminUserId,
+      workspace_id: workspace.id,
+    })
+
+    const response = await postSlashCommand('balance')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('has no balances')
+    await expectSlackMessage('View on explorer:')
+  }, 20_000) // 20 seconds
+
+  test('rejects extra text', async () => {
+    const response = await postSlashCommand('balance extra')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Invalid `/tip` usage. Try `/tip @account` or `/tip help` for more info.',
+    )
+  })
+
+  test('shows balance from direct message', async () => {
+    const dm = setupSlackDMPostMessageFetchSpy()
+    const account = await factory.account.insert({})
+    const workspace = await db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider_id', '=', providerId)
+      .executeTakeFirstOrThrow()
+    await factory.member.insert({
+      account_id: account.id,
+      provider_user_id: Constants.slack.adminUserId,
+      workspace_id: workspace.id,
+    })
+
+    const response = await postSlashCommand('balance', { channelId: dm.channelId })
+
+    expect(response.status).toBe(200)
+    await expectSlackPostMessageCall(dm.fetchSpy, dm.channelId, 'Wallet')
+    dm.fetchSpy.mockRestore()
+  }, 20_000) // 20 seconds
+})
+
 describe('/tip status', () => {
   test('shows current connected account', async () => {
     const account = await factory.account.insert({})


### PR DESCRIPTION
Adds a new `/tip balance` slash command that returns the token balances for the connected wallet of the user who sent the message.

## What it does

- Looks up the sender's connected wallet via workspace + member tables
- Creates a viem client for the workspace's configured chain
- Fetches balances for all allowed tokens on that network in parallel via `Actions.token.getBalance`
- Replies with non-zero balances formatted as currency, plus an explorer link
- Shows a helpful message if no account is connected or if balances are zero

## Changes

- `src/chat.ts`: Added `balance` handler, added to `commandNames`, added to help table, imported `createClient`/`http` from viem and `Actions` from viem/tempo

## Verification

- `pnpm check` — passes (lint + format)
- `pnpm check:types` — passes
- Tests require a local Tempo node (pre-existing CI requirement)