### PR TITLE
Add basic Tipbot bounty commands

### DIFF
--- a/db/migrations/0011_bounties.sql
+++ b/db/migrations/0011_bounties.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "bounty" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "workspace_id" TEXT NOT NULL REFERENCES "workspace" ("id") ON DELETE CASCADE,
+  "provider_channel_id" TEXT NOT NULL,
+  "provider_thread_id" TEXT,
+  "creator_member_id" TEXT NOT NULL REFERENCES "member" ("id"),
+  "oracle_member_id" TEXT NOT NULL REFERENCES "member" ("id"),
+  "amount" INTEGER NOT NULL CHECK ("amount" > 0),
+  "token_address" TEXT NOT NULL,
+  "memo" TEXT,
+  "deadline_at" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'open' CHECK ("status" IN ('open', 'resolved', 'refunded', 'canceled')),
+  "resolution_batch_id" TEXT REFERENCES "tip_batch" ("id") ON DELETE SET NULL,
+  "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "resolved_at" TEXT,
+  "refunded_at" TEXT,
+  CHECK ("resolved_at" IS NULL OR "refunded_at" IS NULL)
+);
+
+CREATE INDEX "bounty_workspace_status_deadline_idx" ON "bounty" ("workspace_id", "status", "deadline_at");
+CREATE INDEX "bounty_creator_idx" ON "bounty" ("creator_member_id", "created_at");
+CREATE INDEX "bounty_oracle_idx" ON "bounty" ("oracle_member_id", "created_at");

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -40,6 +40,25 @@ export const account_link_token = z.object({
   used_at: z.string().nullable(),
 })
 
+export const bounty = z.object({
+  amount: z.number(),
+  created_at: z.string(),
+  creator_member_id: z.string(),
+  deadline_at: z.string(),
+  id: z.string(),
+  memo: z.string().nullable(),
+  oracle_member_id: z.string(),
+  provider_channel_id: z.string(),
+  provider_thread_id: z.string().nullable(),
+  refunded_at: z.string().nullable(),
+  resolution_batch_id: z.string().nullable(),
+  resolved_at: z.string().nullable(),
+  status: z.enum(['open', 'resolved', 'refunded', 'canceled']),
+  token_address: z.string(),
+  updated_at: z.string(),
+  workspace_id: z.string(),
+})
+
 export const member = z.object({
   created_at: z.string(),
   id: z.string(),
@@ -160,6 +179,7 @@ export const db = {
   access_key: access_key,
   account: account,
   account_link_token: account_link_token,
+  bounty: bounty,
   member: member,
   provider_identity: provider_identity,
   reaction_tip: reaction_tip,

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -6,6 +6,7 @@ export interface DB {
   access_key: access_key
   account: account
   account_link_token: account_link_token
+  bounty: bounty
   member: member
   provider_identity: provider_identity
   reaction_tip: reaction_tip
@@ -51,6 +52,25 @@ type account_link_token = {
   provider_channel_id: string | null
   token_hash: string
   used_at: string | null
+}
+
+type bounty = {
+  amount: number
+  created_at: k.Generated<string>
+  creator_member_id: string
+  deadline_at: string
+  id: string
+  memo: string | null
+  oracle_member_id: string
+  provider_channel_id: string
+  provider_thread_id: string | null
+  refunded_at: string | null
+  resolution_batch_id: string | null
+  resolved_at: string | null
+  status: k.Generated<'open' | 'resolved' | 'refunded' | 'canceled'>
+  token_address: string
+  updated_at: k.Generated<string>
+  workspace_id: string
 }
 
 type member = {
@@ -166,6 +186,7 @@ export declare namespace DB {
   type access_key = k.Selectable<DB['access_key']>
   type account = k.Selectable<DB['account']>
   type account_link_token = k.Selectable<DB['account_link_token']>
+  type bounty = k.Selectable<DB['bounty']>
   type member = k.Selectable<DB['member']>
   type provider_identity = k.Selectable<DB['provider_identity']>
   type reaction_tip = k.Selectable<DB['reaction_tip']>
@@ -178,6 +199,7 @@ export declare namespace DB {
     type access_key = k.Insertable<DB['access_key']>
     type account = k.Insertable<DB['account']>
     type account_link_token = k.Insertable<DB['account_link_token']>
+    type bounty = k.Insertable<DB['bounty']>
     type member = k.Insertable<DB['member']>
     type provider_identity = k.Insertable<DB['provider_identity']>
     type reaction_tip = k.Insertable<DB['reaction_tip']>
@@ -191,6 +213,7 @@ export declare namespace DB {
     type access_key = k.Selectable<DB['access_key']>
     type account = k.Selectable<DB['account']>
     type account_link_token = k.Selectable<DB['account_link_token']>
+    type bounty = k.Selectable<DB['bounty']>
     type member = k.Selectable<DB['member']>
     type provider_identity = k.Selectable<DB['provider_identity']>
     type reaction_tip = k.Selectable<DB['reaction_tip']>
@@ -204,6 +227,7 @@ export declare namespace DB {
     type access_key = k.Updateable<DB['access_key']>
     type account = k.Updateable<DB['account']>
     type account_link_token = k.Updateable<DB['account_link_token']>
+    type bounty = k.Updateable<DB['bounty']>
     type member = k.Updateable<DB['member']>
     type provider_identity = k.Updateable<DB['provider_identity']>
     type reaction_tip = k.Updateable<DB['reaction_tip']>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -453,6 +453,9 @@ const handlers = {
       canEdit: await canManageSlackWorkspaceSettings(ctx.provider.id, event.user.userId),
     })
   },
+  async bounty(event, ctx) {
+    await handleBountyCommand(event, ctx)
+  },
   async connect(event, ctx) {
     await postConnectLink(event, ctx)
   },
@@ -507,6 +510,12 @@ const handlers = {
     const commandRows = [
       [`${getSlackCommand(env.HOST)} @account [amount] [token] [for memo]`, 'Send payment'],
       [`${getSlackCommand(env.HOST)} balance`, 'Show wallet balance'],
+      [
+        `${getSlackCommand(env.HOST)} bounty create [amount] by YYYY-MM-DD oracle @account [for memo]`,
+        'Create bounty',
+      ],
+      [`${getSlackCommand(env.HOST)} bounty resolve [id] @account...`, 'Resolve bounty'],
+      [`${getSlackCommand(env.HOST)} bounty refund [id]`, 'Refund expired bounty'],
       [`${getSlackCommand(env.HOST)} config`, 'Manage workspace configuration'],
       [`${getSlackCommand(env.HOST)} connect`, 'Connect to Tipbot'],
       [`${getSlackCommand(env.HOST)} disconnect`, 'Disconnect from Tipbot'],
@@ -857,6 +866,7 @@ const handlers = {
 
 const commandNames = [
   'balance',
+  'bounty',
   'config',
   'connect',
   'disconnect',
@@ -927,6 +937,190 @@ const slackReactionEventSchema = z.object({
 })
 
 type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>
+
+async function handleBountyCommand(event: chat.SlashCommandEvent, ctx: HandlerContext) {
+  const workspace = await ctx.db
+    .selectFrom('workspace')
+    .selectAll()
+    .where('provider', '=', ctx.provider.type)
+    .where('provider_id', '=', ctx.provider.id)
+    .executeTakeFirst()
+  if (!workspace) {
+    await postPrivateReply(
+      event,
+      event.user,
+      'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
+    )
+    return
+  }
+
+  const [subcommand = '', ...rest] = ctx.text.split(/\s+/)
+  const text = rest.join(' ').trim()
+  if (subcommand === 'create') {
+    const parsed = parseBountyCreateText(text, workspace.chain_id)
+    if (!parsed) {
+      await postPrivateReply(
+        event,
+        event.user,
+        `Invalid bounty usage. Try \`${getSlackCommand(env.HOST)} bounty create $10 by 2026-06-01 oracle @account for launch demo\`.`,
+      )
+      return
+    }
+    const tokenAddress = parsed.token
+      ? Tempo.getTokenAddress(workspace.chain_id, parsed.token)
+      : (workspace.default_token_address ?? Tempo.addressLookup.pathUsd)
+    if (!tokenAddress || !Tempo.isAllowedToken(workspace.chain_id, tokenAddress)) {
+      await postPrivateReply(event, event.user, 'Bounty not created. Token is not supported.')
+      return
+    }
+    const creator = await getOrCreateSlackMember(ctx, workspace, event.user.userId)
+    const oracle = await getOrCreateSlackMember(ctx, workspace, parsed.oracleProviderUserId)
+    const id = Nanoid.generate().slice(0, 10)
+    const now = new Date().toISOString()
+    await ctx.db
+      .insertInto('bounty')
+      .values({
+        amount: parsed.amount,
+        created_at: now,
+        creator_member_id: creator.id,
+        deadline_at: parsed.deadlineAt,
+        id,
+        memo: parsed.memo,
+        oracle_member_id: oracle.id,
+        provider_channel_id: event.channel.id,
+        provider_thread_id: ctx.threadTs ?? null,
+        token_address: Address.checksum(tokenAddress),
+        updated_at: now,
+        workspace_id: workspace.id,
+      })
+      .execute()
+    await event.channel.post(
+      `Bounty ${id} created: ${formatBountyAmount(parsed.amount, workspace.chain_id, tokenAddress)} by ${formatBountyDate(parsed.deadlineAt)}. Oracle: <@${parsed.oracleProviderUserId}>.${parsed.memo ? ` ${parsed.memo}` : ''}\nResolve with \`${getSlackCommand(env.HOST)} bounty resolve ${id} @winner\`.`,
+    )
+    return
+  }
+
+  if (subcommand === 'resolve') {
+    const parsed = parseBountyResolveText(text)
+    if (!parsed) {
+      await postPrivateReply(
+        event,
+        event.user,
+        `Invalid bounty usage. Try \`${getSlackCommand(env.HOST)} bounty resolve bounty_id @winner [@winner2]\`.`,
+      )
+      return
+    }
+    const bounty = await getBounty(ctx, workspace.id, parsed.id)
+    if (!bounty) {
+      await postPrivateReply(event, event.user, 'Bounty not found.')
+      return
+    }
+    if (bounty.status !== 'open') {
+      await postPrivateReply(event, event.user, `Bounty is already ${bounty.status}.`)
+      return
+    }
+    const oracle = await ctx.db
+      .selectFrom('member')
+      .select('provider_user_id')
+      .where('id', '=', bounty.oracle_member_id)
+      .executeTakeFirstOrThrow()
+    if (oracle.provider_user_id !== event.user.userId) {
+      await postPrivateReply(event, event.user, 'Only the bounty oracle can resolve this bounty.')
+      return
+    }
+    const creator = await ctx.db
+      .selectFrom('member')
+      .select('provider_user_id')
+      .where('id', '=', bounty.creator_member_id)
+      .executeTakeFirstOrThrow()
+    const share = Math.floor(bounty.amount / parsed.winnerProviderUserIds.length)
+    if (share <= 0) {
+      await postPrivateReply(event, event.user, 'Bounty amount is too small to split.')
+      return
+    }
+    const result = await Tip.handleTipBatchRequest(env, {
+      amount: share,
+      idempotencyKey: `bounty:${bounty.id}:resolve`,
+      memo: `bounty ${bounty.id}`,
+      provider: ctx.provider.type,
+      providerChannelId: event.channel.id,
+      providerId: ctx.provider.id,
+      providerThreadId: ctx.threadTs,
+      recipients: parsed.winnerProviderUserIds.map((recipientProviderUserId) => ({
+        recipientProviderUserId,
+      })),
+      senderProviderUserId: creator.provider_user_id,
+      source: 'command',
+      tokenAddress: bounty.token_address,
+    })
+    if (!result.ok) {
+      await postPrivateReply(event, event.user, bountyResultError(result))
+      return
+    }
+    const batch = await ctx.db
+      .selectFrom('tip_batch')
+      .select('id')
+      .where('idempotency_key', '=', `bounty:${bounty.id}:resolve`)
+      .executeTakeFirst()
+    await ctx.db
+      .updateTable('bounty')
+      .set({
+        resolution_batch_id: batch?.id ?? null,
+        resolved_at: new Date().toISOString(),
+        status: 'resolved',
+        updated_at: new Date().toISOString(),
+      })
+      .where('id', '=', bounty.id)
+      .execute()
+    await event.channel.post(
+      `Bounty ${bounty.id} resolved: ${parsed.winnerProviderUserIds.map((id) => `<@${id}>`).join(', ')} split ${formatBountyAmount(bounty.amount, workspace.chain_id, bounty.token_address)}.`,
+    )
+    return
+  }
+
+  if (subcommand === 'refund') {
+    const id = text.trim()
+    const bounty = id ? await getBounty(ctx, workspace.id, id) : null
+    if (!bounty) {
+      await postPrivateReply(event, event.user, 'Bounty not found.')
+      return
+    }
+    const creator = await ctx.db
+      .selectFrom('member')
+      .select('provider_user_id')
+      .where('id', '=', bounty.creator_member_id)
+      .executeTakeFirstOrThrow()
+    if (creator.provider_user_id !== event.user.userId) {
+      await postPrivateReply(event, event.user, 'Only the bounty creator can refund this bounty.')
+      return
+    }
+    if (bounty.status !== 'open') {
+      await postPrivateReply(event, event.user, `Bounty is already ${bounty.status}.`)
+      return
+    }
+    if (Date.now() < new Date(bounty.deadline_at).getTime()) {
+      await postPrivateReply(event, event.user, 'Bounty deadline has not passed yet.')
+      return
+    }
+    await ctx.db
+      .updateTable('bounty')
+      .set({
+        refunded_at: new Date().toISOString(),
+        status: 'refunded',
+        updated_at: new Date().toISOString(),
+      })
+      .where('id', '=', bounty.id)
+      .execute()
+    await event.channel.post(`Bounty ${bounty.id} refunded to creator.`)
+    return
+  }
+
+  await postPrivateReply(
+    event,
+    event.user,
+    `Invalid bounty usage. Try \`${getSlackCommand(env.HOST)} bounty create $10 by 2026-06-01 oracle @account\`.`,
+  )
+}
 
 async function handleTipText(
   event: TipEvent,
@@ -1307,6 +1501,128 @@ async function handleTipText(
         // Best effort only. Payment/error flow must not depend on Slack assistant UI cleanup.
       })
   }
+}
+
+function parseBountyCreateText(value: string, chainId: number) {
+  const match = value.match(
+    /^(\$?\d+(?:\.\d+)?)(?:\s+([A-Za-z0-9._-]+))?\s+by\s+(\d{4}-\d{2}-\d{2})\s+oracle\s+<@([A-Z0-9_]+)(?:\|[^>]+)?>(?:\s+for\s+([\s\S]+))?$/i,
+  )
+  if (!match) return null
+  const amount = Tip.parseAmount(match[1]!)
+  if (amount === null) return null
+  const maybeToken = match[2] ?? null
+  const token = maybeToken && Tempo.getTokenAddress(chainId, maybeToken) ? maybeToken : null
+  if (maybeToken && !token) return null
+  const deadline = new Date(`${match[3]}T23:59:59.999Z`)
+  if (Number.isNaN(deadline.getTime())) return null
+  return {
+    amount,
+    deadlineAt: deadline.toISOString(),
+    memo: match[5]?.trim() || null,
+    oracleProviderUserId: match[4]!,
+    token,
+  }
+}
+
+function parseBountyResolveText(value: string) {
+  const [id = '', ...winnerParts] = value.trim().split(/\s+/)
+  const winnerProviderUserIds = winnerParts
+    .map((part) => part.match(/^<@([A-Z0-9_]+)(?:\|[^>]+)?>$/)?.[1])
+    .filter((winner): winner is string => Boolean(winner))
+  if (
+    !id ||
+    winnerProviderUserIds.length !== winnerParts.length ||
+    winnerProviderUserIds.length === 0
+  )
+    return null
+  return { id, winnerProviderUserIds: [...new Set(winnerProviderUserIds)] }
+}
+
+async function getBounty(ctx: HandlerContext, workspaceId: string, id: string) {
+  return await ctx.db
+    .selectFrom('bounty')
+    .selectAll()
+    .where('workspace_id', '=', workspaceId)
+    .where('id', '=', id)
+    .executeTakeFirst()
+}
+
+async function getOrCreateSlackMember(
+  ctx: HandlerContext,
+  workspace: DB_gen.Selectable.workspace,
+  providerUserId: string,
+) {
+  const existing = await ctx.db
+    .selectFrom('member')
+    .selectAll()
+    .where('workspace_id', '=', workspace.id)
+    .where('provider_user_id', '=', providerUserId)
+    .executeTakeFirst()
+  if (existing) return existing
+
+  const now = new Date().toISOString()
+  const providerIdentityId = Nanoid.generate()
+  const memberId = Nanoid.generate()
+  await ctx.db
+    .insertInto('provider_identity')
+    .values({
+      account_id: null,
+      created_at: now,
+      display_name: null,
+      id: providerIdentityId,
+      metadata: null,
+      provider: workspace.provider,
+      provider_global_user_id: null,
+      provider_user_id: providerUserId,
+      provider_workspace_id: workspace.provider_id,
+      real_name: null,
+      updated_at: now,
+    })
+    .execute()
+  await ctx.db
+    .insertInto('member')
+    .values({
+      created_at: now,
+      id: memberId,
+      login: null,
+      name: null,
+      provider_identity_id: providerIdentityId,
+      provider_user_id: providerUserId,
+      updated_at: now,
+      workspace_id: workspace.id,
+    })
+    .execute()
+  return await ctx.db
+    .selectFrom('member')
+    .selectAll()
+    .where('id', '=', memberId)
+    .executeTakeFirstOrThrow()
+}
+
+function formatBountyAmount(amount: number, chainId: number, tokenAddress: string) {
+  const token = workspaceTokenOptions(chainId).find((option) =>
+    Address.isEqual(Address.checksum(tokenAddress), option.address),
+  )
+  const formatted = formatAmount(amount)
+  return token
+    ? formatTipAmount(formatted, 'USD', token.label)
+    : formatCurrencyAmount(formatted, 'USD')
+}
+
+function formatBountyDate(value: string) {
+  return value.slice(0, 10)
+}
+
+function bountyResultError(result: Extract<Tip.TipBatchResult, { ok: false }>) {
+  if (result.code === 'sender_unconnected' || result.code === 'missing_sender_access_key')
+    return 'Bounty not resolved. The oracle needs to connect Tipbot first.'
+  if (result.code === 'recipient_unconnected')
+    return `Bounty not resolved. <@${result.recipientProviderUserId}> needs to connect Tipbot first.`
+  if (result.code === 'insufficient_funds')
+    return 'Bounty not resolved. The oracle wallet has insufficient funds.'
+  if (result.code === 'confirmation_required')
+    return 'Bounty not resolved. The oracle needs to confirm this payment first.'
+  return result.message ?? 'Bounty not resolved. Payment failed.'
 }
 
 async function setSlackAssistantThreadStatus(

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2108,6 +2108,40 @@ describe('/tip config', () => {
   })
 })
 
+describe('/tip bounty', () => {
+  test('creates a bounty with amount, deadline, oracle, and memo', async () => {
+    const response = await postSlashCommand(
+      `bounty create $10 by 2099-06-01 oracle <@${Constants.slack.memberUserId}> for launch demo`,
+    )
+    const bounty = await db
+      .selectFrom('bounty')
+      .innerJoin('member as creator', 'creator.id', 'bounty.creator_member_id')
+      .innerJoin('member as oracle', 'oracle.id', 'bounty.oracle_member_id')
+      .select([
+        'bounty.amount',
+        'bounty.deadline_at',
+        'bounty.memo',
+        'bounty.status',
+        'creator.provider_user_id as creator_provider_user_id',
+        'oracle.provider_user_id as oracle_provider_user_id',
+      ])
+      .executeTakeFirstOrThrow()
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('Bounty ')
+    await expectSlackMessage('created: $10.00 PathUSD by 2099-06-01')
+    await expectSlackMessage(`Oracle: <@${Constants.slack.memberUserId}>`)
+    expect(bounty).toMatchObject({
+      amount: 10_000_000,
+      creator_provider_user_id: Constants.slack.adminUserId,
+      deadline_at: '2099-06-01T23:59:59.999Z',
+      memo: 'launch demo',
+      oracle_provider_user_id: Constants.slack.memberUserId,
+      status: 'open',
+    })
+  })
+})
+
 describe('/tip connect', () => {
   test('creates one-time account link', async () => {
     const response = await postSlashCommand('connect')


### PR DESCRIPTION
## Summary
- add a bounty table for creator/oracle/deadline/status tracking
- add `/tip bounty create`, `/tip bounty resolve`, and `/tip bounty refund`
- wire help text and add a worker test covering bounty creation

## Notes
This is intentionally a basic draft: it records bounty intent and uses the existing atomic multi-tip path at resolution time. It does not yet implement true immediate on-chain escrow; that needs a follow-up escrow account/contract flow before this should be treated as production-complete.

## Verification
- `PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0rYIybh:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm check`
- `PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0rYIybh:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm check:types`
- `PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0rYIybh:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm test src/lib/tip.test.ts`

Worker integration note: `PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0rYIybh:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm test src/chat.workers.test.ts -- --runInBand` did not reach tests because global setup failed minting against the local Tempo node: `eth_getTransactionCount` returned HTTP 400.