### PR TITLE
Show tipbot leaderboard amounts

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -635,17 +635,27 @@ const handlers = {
       [
         'Tips received',
         [
-          'Rank Account Tips',
+          'Rank Account Amount Tips',
           ...received.map((row, index) =>
-            [String(index + 1), `<@${row.providerUserId}>`, String(row.tipCount)].join(' '),
+            [
+              String(index + 1),
+              `<@${row.providerUserId}>`,
+              formatCurrencyAmount(formatAmount(row.amount), 'USD'),
+              String(row.tipCount),
+            ].join(' '),
           ),
         ].join('\n'),
         '',
         'Tips sent',
         [
-          'Rank Account Tips',
+          'Rank Account Amount Tips',
           ...sent.map((row, index) =>
-            [String(index + 1), `<@${row.providerUserId}>`, String(row.tipCount)].join(' '),
+            [
+              String(index + 1),
+              `<@${row.providerUserId}>`,
+              formatCurrencyAmount(formatAmount(row.amount), 'USD'),
+              String(row.tipCount),
+            ].join(' '),
           ),
         ].join('\n'),
       ].join('\n'),
@@ -659,10 +669,16 @@ const handlers = {
         },
         {
           rows: [
-            [slackTableCell('Rank'), slackTableCell('Account'), slackTableCell('Tips')],
+            [
+              slackTableCell('Rank'),
+              slackTableCell('Account'),
+              slackTableCell('Amount'),
+              slackTableCell('Tips'),
+            ],
             ...received.map((row, index) => [
               slackTableCell(String(index + 1)),
               slackTableUserCell(row.providerUserId),
+              slackTableCell(formatCurrencyAmount(formatAmount(row.amount), 'USD')),
               slackTableCell(String(row.tipCount)),
             ]),
           ],
@@ -674,10 +690,16 @@ const handlers = {
         },
         {
           rows: [
-            [slackTableCell('Rank'), slackTableCell('Account'), slackTableCell('Tips')],
+            [
+              slackTableCell('Rank'),
+              slackTableCell('Account'),
+              slackTableCell('Amount'),
+              slackTableCell('Tips'),
+            ],
             ...sent.map((row, index) => [
               slackTableCell(String(index + 1)),
               slackTableUserCell(row.providerUserId),
+              slackTableCell(formatCurrencyAmount(formatAmount(row.amount), 'USD')),
               slackTableCell(String(row.tipCount)),
             ]),
           ],
@@ -901,6 +923,7 @@ type ReactionHandlerContext = {
 }
 
 type LeaderboardRow = {
+  amount: number
   providerUserId: string
   tipCount: number
 }
@@ -1982,10 +2005,15 @@ async function getLeaderboardRows(
   const rows = await ctx.db
     .selectFrom('tip')
     .innerJoin('member', 'member.id', options.memberIdColumn)
-    .select(['member.provider_user_id', sql<number>`count("tip"."id")`.as('tip_count')])
+    .select([
+      'member.provider_user_id',
+      sql<number>`coalesce(sum("tip"."amount"), 0)`.as('amount'),
+      sql<number>`count("tip"."id")`.as('tip_count'),
+    ])
     .where('tip.workspace_id', '=', options.workspaceId)
     .where('tip.confirmed_at', 'is not', null)
     .groupBy(['member.id', 'member.provider_user_id'])
+    .orderBy('amount', 'desc')
     .orderBy('tip_count', 'desc')
     .orderBy('member.provider_user_id', 'asc')
     .limit(10)
@@ -1994,6 +2022,7 @@ async function getLeaderboardRows(
   return rows.map(
     (row) =>
       ({
+        amount: Number(row.amount),
         providerUserId: row.provider_user_id,
         tipCount: Number(row.tip_count),
       }) satisfies LeaderboardRow,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2450,6 +2450,7 @@ describe('/tip leaderboard', () => {
     const now = new Date().toISOString()
     const tips = [
       {
+        amount: 1000,
         confirmed_at: now,
         recipient_id: memberAccount.id,
         recipient_member_id: memberMember.id,
@@ -2458,6 +2459,7 @@ describe('/tip leaderboard', () => {
         workspace_id: workspace.id,
       },
       {
+        amount: 1000,
         confirmed_at: now,
         recipient_id: memberAccount.id,
         recipient_member_id: memberMember.id,
@@ -2466,6 +2468,7 @@ describe('/tip leaderboard', () => {
         workspace_id: workspace.id,
       },
       {
+        amount: 1000,
         confirmed_at: now,
         recipient_id: memberAccount.id,
         recipient_member_id: memberMember.id,
@@ -2474,6 +2477,7 @@ describe('/tip leaderboard', () => {
         workspace_id: workspace.id,
       },
       {
+        amount: 5000,
         confirmed_at: now,
         recipient_id: adminAccount.id,
         recipient_member_id: adminMember.id,
@@ -2482,6 +2486,7 @@ describe('/tip leaderboard', () => {
         workspace_id: workspace.id,
       },
       {
+        amount: 9000,
         confirmed_at: null,
         recipient_id: thirdAccount.id,
         recipient_member_id: thirdMember.id,
@@ -2490,6 +2495,7 @@ describe('/tip leaderboard', () => {
         workspace_id: workspace.id,
       },
       {
+        amount: 1000000,
         confirmed_at: now,
         recipient_id: thirdAccount.id,
         recipient_member_id: otherMember.id,
@@ -2505,12 +2511,12 @@ describe('/tip leaderboard', () => {
     expect(response.status).toBe(200)
     await expectSlackPublicMessage('Tips received')
     await expectSlackMessage('Tips received')
-    await expectSlackMessage(`1 <@${Constants.slack.memberUserId}> 3`)
-    await expectSlackMessage(`2 <@${Constants.slack.adminUserId}> 1`)
+    await expectSlackMessage(`1 <@${Constants.slack.adminUserId}> $0.005 1`)
+    await expectSlackMessage(`2 <@${Constants.slack.memberUserId}> $0.003 3`)
     await expectSlackMessage('Tips sent')
-    await expectSlackMessage(`1 <@${Constants.slack.adminUserId}> 2`)
-    await expectSlackMessage(`2 <@${Constants.slack.memberUserId}> 1`)
-    await expectSlackMessage('3 <@U000000003> 1')
+    await expectSlackMessage(`1 <@${Constants.slack.memberUserId}> $0.005 1`)
+    await expectSlackMessage(`2 <@${Constants.slack.adminUserId}> $0.002 2`)
+    await expectSlackMessage('3 <@U000000003> $0.001 1')
     await expectSlackMessageNotContaining('U000000004')
   })
 


### PR DESCRIPTION
## Summary
- rank /tip leaderboard received and sent tables by total amount
- add Amount columns while preserving tip counts
- update worker coverage for amount-based ordering

## Verification
- pnpm check:types
- pnpm test src/chat.workers.test.ts -t leaderboard (blocked in global setup: local Tempo RPC returned HTTP 400 during fee payer mint before leaderboard assertions)