### PR TITLE
Clarify thread tipping syntax

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -547,6 +547,8 @@ const handlers = {
         '',
         paymentExampleRows.map((row) => `${row[0]} ${row[1]}`).join('\n'),
         '',
+        `Thread tip: Slack does not support app slash commands in threads. Use @${getSlackBotDisplayName(env.HOST)} instead.`,
+        '',
         mentionExampleRows.map((row) => `${row[0]} ${row[1]}`).join('\n'),
       ].join('\n'),
     )
@@ -572,6 +574,13 @@ const handlers = {
             ]),
           ],
           type: 'table',
+        },
+        {
+          text: {
+            text: `Slack does not support app slash commands in threads. Use \`@${getSlackBotDisplayName(env.HOST)} @account for coffee\` instead.`,
+            type: 'mrkdwn',
+          },
+          type: 'section',
         },
         {
           rows: [

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2386,6 +2386,9 @@ describe('/tip help', () => {
     await expectSlackMessage('/tip @account 0.005 for coffee')
     await expectSlackMessage('/tip @account 0.005 USDC')
     await expectSlackMessage('/tip @account 0.005 USDC for coffee')
+    await expectSlackMessage(
+      'Slack does not support app slash commands in threads. Use `@Tipbot @account for coffee` instead.',
+    )
     await expectSlackMessage('@Tipbot @account')
     await expectSlackMessage('@Tipbot @account for coffee')
     await expectSlackMessage('@Tipbot @account 0.005 for coffee')


### PR DESCRIPTION
## Summary
- Add a /tip help note explaining Slack blocks app slash commands in threads
- Point users to the @Tipbot thread syntax instead
- Add a worker-test assertion for the new help copy

## Verification
- PATH=/tmp/codex-bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0GDp4Ia:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm check
- PATH=/tmp/codex-bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0GDp4Ia:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm check:types
- PATH=/tmp/codex-bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0GDp4Ia:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm test src/chat.workers.test.ts -- --runInBand *(fails before tests: worker global setup local Tempo RPC returned 400 for eth_getTransactionCount while minting fee payer)*