### PR TITLE
Fix Slack wallet home link

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -531,7 +531,7 @@ async function buildHomeView(input: {
               style: 'primary',
               text: { emoji: true, text: 'Open wallet', type: 'plain_text' },
               type: 'button',
-              url: 'https://app.tempo.xyz/',
+              url: 'https://wallet.tempo.xyz/',
             },
           ],
           type: 'actions',


### PR DESCRIPTION
## Summary
- Change the Slack home "Open wallet" button from https://app.tempo.xyz/ to https://wallet.tempo.xyz/

## Testing
- pnpm check