### PR TITLE
feat: support single channel guests

### DIFF
--- a/config/patches/emulate@0.5.0.patch
+++ b/config/patches/emulate@0.5.0.patch
@@ -57,7 +57,16 @@ index 6876d0e..57d3549 100644
      topic: ch.topic,
      purpose: ch.purpose,
      creator: ch.creator,
-@@ -1322,16 +1363,44 @@ function seedFromConfig(store, _baseUrl, config) {
+@@ -415,6 +456,8 @@ function formatUser(u) {
+     name: u.name,
+     real_name: u.real_name,
+     is_admin: u.is_admin,
++    is_restricted: u.is_restricted,
++    is_ultra_restricted: u.is_ultra_restricted,
+     is_bot: u.is_bot,
+     deleted: u.deleted,
+     profile: u.profile
+@@ -1322,16 +1365,48 @@ function seedFromConfig(store, _baseUrl, config) {
    const teamId = team?.team_id ?? "T000000001";
    if (config.users) {
      for (const u of config.users) {
@@ -76,6 +85,8 @@ index 6876d0e..57d3549 100644
 +          enterprise_team_id: u.enterprise_team_id ?? existing.enterprise_team_id,
 +          enterprise_user_id: u.enterprise_user_id ?? existing.enterprise_user_id,
 +          is_admin: u.is_admin ?? existing.is_admin,
++          is_restricted: u.is_restricted ?? existing.is_restricted,
++          is_ultra_restricted: u.is_ultra_restricted ?? existing.is_ultra_restricted,
 +          name: u.name ?? existing.name,
 +          profile: {
 +            ...existing.profile,
@@ -104,9 +115,11 @@ index 6876d0e..57d3549 100644
 +        enterprise_team_id: u.enterprise_team_id,
 +        enterprise_user_id: u.enterprise_user_id,
          is_admin: u.is_admin ?? false,
++        is_restricted: u.is_restricted ?? false,
++        is_ultra_restricted: u.is_ultra_restricted ?? false,
          is_bot: false,
          deleted: false,
-@@ -1347,18 +1416,42 @@ function seedFromConfig(store, _baseUrl, config) {
+@@ -1347,18 +1420,42 @@ function seedFromConfig(store, _baseUrl, config) {
    }
    if (config.channels) {
      for (const ch of config.channels) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ patchedDependencies:
   '@chat-adapter/slack@4.27.0': f129c43965d79b15a626b2f5e493aee5ae9b5638ff12257bd4cf6cecb048d1dd
   '@slack/web-api@7.15.2': 97b9149f438abff67b083a9f281917a3b7e1d3133ca6b8be85c6e6ba78b591ae
   '@tanstack/react-start@1.167.65': c2ace716aae8d228b9e34c7f0029a2c2471417d45b6c7823b22943889cfba6a2
-  emulate@0.5.0: 67fe2db5f9c966e113c6d1948ef757e1091bbb5f9169d766f13ee5d421d1c1c5
+  emulate@0.5.0: 81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691
   prool@0.2.4: 242ad315de9eb06e5a654896de221f947e3f0f5f318b55d898191bfad0a9530f
 
 importers:
@@ -138,7 +138,7 @@ importers:
         version: 12.9.0
       emulate:
         specifier: 0.5.0
-        version: 0.5.0(patch_hash=67fe2db5f9c966e113c6d1948ef757e1091bbb5f9169d766f13ee5d421d1c1c5)(hono@4.12.18)
+        version: 0.5.0(patch_hash=81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691)(hono@4.12.18)
       msw:
         specifier: 2.13.6
         version: 2.13.6(@types/node@22.19.17)(typescript@6.0.3)
@@ -6018,7 +6018,7 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  emulate@0.5.0(patch_hash=67fe2db5f9c966e113c6d1948ef757e1091bbb5f9169d766f13ee5d421d1c1c5)(hono@4.12.18):
+  emulate@0.5.0(patch_hash=81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691)(hono@4.12.18):
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       commander: 14.0.3

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -73,8 +73,17 @@ export function getChat() {
     const installation = await getSlack().getInstallation(providerId)
     if (!installation?.botUserId) throw new Error('Slack app installation missing bot user id.')
 
-    const threadTs = raw.thread_ts ?? raw.ts
     const event = { channel: thread.channel, user: message.author } satisfies TipEvent
+    if (await isExternalSlackConnectActor(providerId, raw.channel, raw.user)) {
+      await postPrivateReply(
+        event,
+        event.user,
+        `Tipbot isn't installed in your Slack workspace yet. Ask an admin to install Tipbot there, then try again.`,
+      )
+      return
+    }
+
+    const threadTs = raw.thread_ts ?? raw.ts
     const mentionText = normalizeSlackMentionText(raw.text, installation.botUserId)
     const context = {
       db: DB.create(env.DB),
@@ -82,21 +91,68 @@ export function getChat() {
       text: parseSlackMentionTipText(mentionText) ?? '',
     } satisfies HandlerContext
 
-    if (isSlackIntroduceYourselfText(mentionText)) {
-      await postSlackIntroduction(event, context, threadTs)
+    if (mentionText.toLowerCase() === 'introduce yourself') {
+      // Keep the one-off introduction response local to mention handling.
+      const installation = await getSlack().getInstallation(context.provider.id)
+      if (!installation) throw new Error('Tibot app not installed for this workspace.')
+
+      const text =
+        `I’m ${getSlackBotDisplayName(env.HOST)}: sometime tipper, sometime messenger, always bot.\n` +
+        `Connect with \`@${getSlackBotDisplayName(env.HOST)} connect\` or \`${getSlackCommand(env.HOST)} connect\`, then send stablecoins with \`@${getSlackBotDisplayName(env.HOST)} @account for coffee\`, \`@${getSlackBotDisplayName(env.HOST)} @account 0.005 for coffee\`, \`${getSlackCommand(env.HOST)} @account for coffee\`, or a 💸 reaction.`
+      const body = new URLSearchParams()
+      body.set('channel', event.channel.id.replace(/^slack:/, ''))
+      body.set('text', text)
+      body.set('thread_ts', threadTs)
+      body.set('unfurl_links', 'false')
+      body.set('unfurl_media', 'false')
+      const response = await getSlack().withBotToken(installation.botToken, () =>
+        fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
+          body,
+          headers: { authorization: `Bearer ${installation.botToken}` },
+          method: 'POST',
+        }),
+      )
+      const json = z.parse(
+        z.object({
+          error: z.string().optional(),
+          ok: z.boolean().optional(),
+        }),
+        await response.json(),
+      )
+      if (!json.ok) throw Slack.slackApiError('chat.postMessage', json.error)
+      return
+    }
+
+    const match = mentionText.match(commandPattern)
+    if (match) {
+      const name = z.parse(z.enum(commandNames), match[1])
+      await handlers[name](event, { ...context, text: match[2]?.trim() ?? '', threadTs })
       return
     }
 
     if (!context.text) {
-      if (isSlackSelfMentionChatter(raw.text, installation.botUserId, mentionText)) return
+      // Ignore messages that only repeat Tipbot mentions without a command or tip intent.
+      const isSelfMentionChatter = (() => {
+        const mentions = [...raw.text.matchAll(/<@([A-Z0-9_]+)(?:\|[^>]+)?>/g)].map(
+          (match) => match[1],
+        )
+        if (mentions.filter((mention) => mention === installation.botUserId).length < 2)
+          return false
+        if (mentions.some((mention) => mention !== installation.botUserId)) return false
+        return !hasInvalidMentionIntent(mentionText)
+      })()
+      if (isSelfMentionChatter) return
       await postInvalidMentionReply(event, context, mentionText, threadTs)
       return
     }
 
-    await handleTipText(event, context, {
-      idempotencyKey: `mention:${providerId}:${raw.channel}:${raw.ts}`,
-      insufficientFundsThreadTs: raw.thread_ts,
-      mention: true,
+    await handlers.default(event, {
+      ...context,
+      defaultTip: {
+        idempotencyKey: `mention:${providerId}:${raw.channel}:${raw.ts}`,
+        insufficientFundsThreadTs: raw.thread_ts,
+        mention: true,
+      },
       threadTs,
     })
   })
@@ -390,7 +446,11 @@ const handlers = {
       .where('member.provider_user_id', '=', event.user.userId)
       .executeTakeFirst()
     if (!member) {
-      await postPrivateReply(event, event.user, 'No account connected. Run `/tip connect` first.')
+      await postPrivateReply(
+        event,
+        event.user,
+        `No account connected. Run \`@${getSlackBotDisplayName(env.HOST)} connect\` or \`${getSlackCommand(env.HOST)} connect\` first.`,
+      )
       return
     }
 
@@ -527,6 +587,8 @@ const handlers = {
       ],
     ]
     const mentionExampleRows = [
+      [`@${getSlackBotDisplayName(env.HOST)} connect`, 'Connect to Tipbot'],
+      [`@${getSlackBotDisplayName(env.HOST)} help`, 'Show help message'],
       [`@${getSlackBotDisplayName(env.HOST)} @account`, 'Send default amount'],
       [`@${getSlackBotDisplayName(env.HOST)} @account for coffee`, 'Send default amount with memo'],
       [
@@ -840,19 +902,403 @@ const handlers = {
     )
   },
   async default(event, ctx) {
-    if (!event.triggerId) {
+    const defaultTip = (() => {
+      if (ctx.defaultTip) return ctx.defaultTip
+      if (!('triggerId' in event) || !event.triggerId) return null
+      return {
+        idempotencyKey: `command:${ctx.provider.id}:${event.triggerId}`,
+        insufficientFundsThreadTs: ctx.threadTs,
+      }
+    })()
+    if (!defaultTip) {
       await postPrivateReply(event, event.user, 'Payment not sent. Try again.')
       return
     }
-    await handleTipText(event, ctx, {
-      idempotencyKey: `command:${ctx.provider.id}:${event.triggerId}`,
-      insufficientFundsThreadTs: ctx.threadTs,
-      threadTs: ctx.threadTs,
+
+    const options = { ...defaultTip, threadTs: ctx.threadTs }
+    const workspace = await ctx.db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider', '=', ctx.provider.type)
+      .where('provider_id', '=', ctx.provider.id)
+      .executeTakeFirst()
+    const parsed = Tip.parseTipBatchText(ctx.text, {
+      chainId: workspace?.chain_id ?? Tempo.chainLookup.mainnet,
     })
+    if (!parsed) {
+      if (options.mention && options.threadTs) {
+        await postInvalidMentionReply(event, ctx, ctx.text, options.threadTs)
+        return
+      }
+      await postInvalidUsage(event, ctx, { mention: options.mention, threadTs: options.threadTs })
+      return
+    }
+
+    const tokenAddress = parsed.token
+      ? Tempo.getTokenAddress(workspace?.chain_id ?? Tempo.chainLookup.mainnet, parsed.token)
+      : null
+    if (parsed.token && !tokenAddress) {
+      await postPrivateReply(
+        event,
+        event.user,
+        'Payment not sent. This token is not supported on this network.',
+      )
+      return
+    }
+    if (Tip.isTransferMemoTooLong(parsed.memo)) {
+      const suggestion = await (async () => {
+        // Best-effort UX sugar: the hard requirement is returning the length error.
+        if (!parsed.memo) return null
+        try {
+          const value = z
+            .parse(
+              z.object({ response: z.string().default('') }),
+              await env.AI.run('@cf/meta/llama-3.2-1b-instruct', {
+                max_tokens: 24,
+                messages: [
+                  {
+                    content:
+                      'Shorten this payment memo to at most 32 UTF-8 bytes. Preserve the meaning. Return only the shortened memo text, no quotes, no explanation, no punctuation unless needed.',
+                    role: 'system',
+                  },
+                  { content: parsed.memo, role: 'user' },
+                ],
+              }),
+            )
+            .response.replace(/[\r\n]+/g, ' ')
+            .trim()
+            .replace(/^['"]|['"]$/g, '')
+          if (!value || Tip.isTransferMemoTooLong(value)) return null
+          if (/[`\r\n]|<@[A-Z0-9_]+/i.test(value)) return null
+          const memoWords = new Set(parsed.memo.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [])
+          const suggestionWords = value.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []
+          if (!suggestionWords.length) return null
+          if (suggestionWords.some((word) => !memoWords.has(word))) return null
+          return value
+        } catch (error) {
+          console.error('Failed to generate short memo suggestion:', error)
+        }
+        return null
+      })()
+      await postPrivateReply(
+        event,
+        event.user,
+        `Payment not sent. Memo must be at most 32 bytes; shorten the text after \`for\`.${suggestion ? ` Try: \`${suggestion}\`.` : ''}`,
+      )
+      if (options.threadTs)
+        await setSlackAssistantThreadStatus(event, ctx, options.threadTs, '').catch(() => {
+          // Best effort only. Payment/error flow must not depend on Slack assistant UI cleanup.
+        })
+      return
+    }
+    const recipients = await (async (): Promise<
+      { ok: true; value: Tip.TipRecipientInput[] } | { message: string; ok: false }
+    > => {
+      if (ctx.provider.type !== 'slack') return { ok: true, value: parsed.recipients }
+      const installation = await getSlack().getInstallation(ctx.provider.id)
+      if (!installation) return { ok: true, value: parsed.recipients }
+
+      const body = new URLSearchParams()
+      body.set('channel', event.channel.id.replace(/^slack:/, ''))
+      const response = await getSlack().withBotToken(installation.botToken, () =>
+        fetch(`${env.SLACK_API_URL}/conversations.info`, {
+          body,
+          headers: { authorization: `Bearer ${installation.botToken}` },
+          method: 'POST',
+        }),
+      )
+      const conversation = z.parse(
+        z.object({
+          channel: z
+            .object({
+              context_team_id: z.string().optional(),
+              is_ext_shared: z.boolean().optional(),
+              is_shared: z.boolean().optional(),
+              shared_team_ids: z.array(z.string()).optional(),
+            })
+            .optional(),
+          ok: z.boolean().optional(),
+        }),
+        await response.json(),
+      )
+      const isSharedChannel =
+        conversation.channel?.is_ext_shared ||
+        conversation.channel?.is_shared ||
+        conversation.channel?.shared_team_ids?.some(
+          (teamId) => teamId !== conversation.channel?.context_team_id,
+        )
+      if (!conversation.ok || !conversation.channel || !isSharedChannel)
+        return { ok: true, value: parsed.recipients }
+
+      const tokenTeamIds = new Set(
+        [
+          ctx.provider.id,
+          conversation.channel.context_team_id,
+          ...(conversation.channel.shared_team_ids ?? []),
+        ].filter((teamId) => teamId !== undefined),
+      )
+      const value = [] as Tip.TipRecipientInput[]
+      for (const recipient of parsed.recipients) {
+        const candidates = [...tokenTeamIds].map((tokenTeamId) => ({
+          providerUserId: recipient.recipientProviderUserId,
+          providerWorkspaceId: tokenTeamId,
+        }))
+        for (const tokenTeamId of tokenTeamIds) {
+          const tokenInstallation = await getSlack().getInstallation(tokenTeamId)
+          if (!tokenInstallation) continue
+          const userBody = new URLSearchParams()
+          userBody.set('user', recipient.recipientProviderUserId)
+          const userResponse = await getSlack().withBotToken(tokenInstallation.botToken, () =>
+            fetch(`${env.SLACK_API_URL}/users.info`, {
+              body: userBody,
+              headers: { authorization: `Bearer ${tokenInstallation.botToken}` },
+              method: 'POST',
+            }),
+          )
+          const info = z.parse(
+            z.object({
+              ok: z.boolean().optional(),
+              user: z
+                .object({
+                  id: z.string().optional(),
+                  team_id: z.string().optional(),
+                })
+                .optional(),
+            }),
+            await userResponse.json(),
+          )
+          if (!info.ok || !info.user?.id || !info.user.team_id) continue
+          candidates.push({
+            providerUserId: info.user.id,
+            providerWorkspaceId: info.user.team_id,
+          })
+        }
+
+        const seen = new Set<string>()
+        const matches = [] as Array<{ providerUserId: string; providerWorkspaceId: string }>
+        for (const candidate of candidates) {
+          const key = `${candidate.providerWorkspaceId}:${candidate.providerUserId}`
+          if (seen.has(key)) continue
+          seen.add(key)
+          const candidateWorkspace = await ctx.db
+            .selectFrom('workspace')
+            .select('id')
+            .where('provider', '=', 'slack')
+            .where('provider_id', '=', candidate.providerWorkspaceId)
+            .executeTakeFirst()
+          if (!candidateWorkspace) continue
+          const candidateMember = await ctx.db
+            .selectFrom('member')
+            .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+            .innerJoin('account', 'account.id', 'provider_identity.account_id')
+            .select('member.id')
+            .where('member.provider_user_id', '=', candidate.providerUserId)
+            .where('member.workspace_id', '=', candidateWorkspace.id)
+            .executeTakeFirst()
+          if (candidateMember) matches.push(candidate)
+        }
+        if (matches.length === 0) {
+          const connectedMembers = await ctx.db
+            .selectFrom('member')
+            .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+            .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+            .innerJoin('account', 'account.id', 'provider_identity.account_id')
+            .select([
+              'member.provider_user_id as providerUserId',
+              'workspace.provider_id as providerWorkspaceId',
+            ])
+            .where('member.provider_user_id', '=', recipient.recipientProviderUserId)
+            .where('workspace.provider', '=', 'slack')
+            .execute()
+          if (connectedMembers.length === 1) matches.push(connectedMembers[0]!)
+        }
+        if (matches.length !== 1)
+          return {
+            message:
+              matches.length === 0
+                ? `Payment not sent. <@${recipient.recipientProviderUserId}> needs to install or connect Tipbot in their Slack workspace before receiving Slack Connect payments.`
+                : `Payment not sent. <@${recipient.recipientProviderUserId}> could not be resolved safely across Slack workspaces.`,
+            ok: false,
+          }
+        value.push({ ...recipient, recipientProviderWorkspaceId: matches[0]!.providerWorkspaceId })
+      }
+      return { ok: true, value }
+    })()
+    if (!recipients.ok) {
+      await postPrivateReply(event, event.user, recipients.message)
+      return
+    }
+
+    if (options.threadTs)
+      void setSlackAssistantThreadStatus(event, ctx, options.threadTs, 'is sending a tip', {
+        loadingMessages: ['Sending tip'],
+      }).catch(() => {
+        // Best effort only. Payment flow must not depend on Slack assistant UI.
+      })
+    try {
+      const result = await (
+        parsed.recipients.length === 1
+          ? Tip.handleTipRequest(env, {
+              amount: parsed.amount,
+              idempotencyKey: options.idempotencyKey,
+              memo: parsed.memo,
+              provider: ctx.provider.type,
+              providerChannelId: event.channel.id,
+              providerId: ctx.provider.id,
+              providerThreadId: options.threadTs,
+              recipientProviderLabel: recipients.value[0]?.recipientProviderLabel,
+              recipientProviderUserId: recipients.value[0]!.recipientProviderUserId,
+              recipientProviderWorkspaceId: recipients.value[0]?.recipientProviderWorkspaceId,
+              senderProviderUserId: event.user.userId,
+              tokenAddress: tokenAddress ?? undefined,
+            })
+          : Tip.handleTipBatchRequest(env, {
+              amount: parsed.amount,
+              idempotencyKey: options.idempotencyKey,
+              memo: parsed.memo,
+              provider: ctx.provider.type,
+              providerChannelId: event.channel.id,
+              providerId: ctx.provider.id,
+              providerThreadId: options.threadTs,
+              recipients: recipients.value,
+              senderProviderUserId: event.user.userId,
+              source: options.mention ? 'mention' : 'command',
+              tokenAddress: tokenAddress ?? undefined,
+            })
+      ).catch(
+        (error) =>
+          ({
+            code: 'failed',
+            message: error instanceof Error ? error.message : 'Command failed.',
+            ok: false,
+          }) satisfies Tip.TipResult,
+      )
+
+      if (result.ok && result.status === 'sent' && 'recipients' in result) {
+        const amount = result.isDefaultToken
+          ? formatCurrencyAmount(result.amount, result.tokenCurrency)
+          : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
+        await postSlackReceiptMessage(
+          event,
+          ctx,
+          `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${result.recipients.map((recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`).join('\n')}`,
+          result.chainId,
+          result.transactionHash,
+          undefined,
+          result.feePayer === 'sender'
+            ? 'Fee sponsor unavailable; fee paid from your balance.'
+            : undefined,
+          options.threadTs,
+        )
+        if (result.memo && options.threadTs)
+          await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
+      } else if (result.ok && result.status === 'sent' && !('recipients' in result)) {
+        await postSlackReceiptMessage(
+          event,
+          ctx,
+          `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${event.channel.mentionUser(result.recipientProviderUserId)} ${result.isDefaultToken ? formatCurrencyAmount(result.amount, result.tokenCurrency) : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)}${result.memo ? ` for ${result.memo}` : ''}.`,
+          result.chainId,
+          result.transactionHash,
+          undefined,
+          result.feePayer === 'sender'
+            ? 'Fee sponsor unavailable; fee paid from your balance.'
+            : undefined,
+          options.threadTs,
+        )
+        if (result.memo && options.threadTs)
+          await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
+      } else if (result.ok)
+        await postSlackReceiptMessage(
+          event,
+          ctx,
+          'Payment sent.',
+          result.chainId,
+          result.transactionHash,
+          event.user,
+          result.feePayer === 'sender'
+            ? 'Fee sponsor unavailable; fee paid from your balance.'
+            : undefined,
+          options.threadTs,
+        )
+      else {
+        if (result.code === 'confirmation_required' && result.confirmUrl) {
+          const confirmUrlLabel = result.confirmUrl.replace(/(\/confirm\/.{8}).+$/, '$1...')
+          await postPrivateReply(event, event.user, {
+            card: chat.Card({
+              children: [
+                chat.CardText('Tipbot needs your approval to send this payment.'),
+                chat.Actions([
+                  chat.LinkButton({
+                    label: 'Confirm payment',
+                    style: 'primary',
+                    url: result.confirmUrl,
+                  }),
+                  chat.Button({ id: 'confirm_cancel', label: 'Cancel' }),
+                ]),
+                chat.CardText(
+                  `Link expires in 10 minutes. <${result.confirmUrl}|${confirmUrlLabel}>`,
+                  {
+                    style: 'muted',
+                  },
+                ),
+              ],
+            }),
+            fallbackText: `Tipbot needs your approval to send this payment.\nConfirm payment: ${result.confirmUrl}\nLink expires in 10 minutes.`,
+          })
+          return
+        }
+        if (result.code === 'sender_unconnected' || result.code === 'missing_sender_access_key') {
+          await postConnectLink(event, ctx)
+          return
+        }
+        const message = await (async () => {
+          if (result.code === 'self_tip')
+            return 'Payment not sent. Cannot send a payment to yourself.'
+          if (result.code === 'recipient_unconnected')
+            return `Payment not sent. ${event.channel.mentionUser(result.recipientProviderUserId ?? recipients.value[0]!.recipientProviderUserId)} needs to connect Tipbot before receiving payments.`
+          if (result.code === 'pending') return 'Payment still sending.'
+          if (result.code === 'insufficient_funds')
+            return 'Payment not sent. Your wallet has insufficient funds.'
+          return 'Payment failed.'
+        })()
+        if (result.code === 'insufficient_funds') {
+          await postSlackInsufficientFunds(
+            event,
+            ctx,
+            options.mention ? options.insufficientFundsThreadTs : options.threadTs,
+          )
+          return
+        }
+        if (
+          'chainId' in result &&
+          result.chainId &&
+          'transactionHash' in result &&
+          result.transactionHash
+        )
+          await postSlackReceiptMessage(
+            event,
+            ctx,
+            message,
+            result.chainId,
+            result.transactionHash,
+            event.user,
+            undefined,
+            options.threadTs,
+          )
+        else await postPrivateReply(event, event.user, message)
+      }
+    } finally {
+      // Clear Slack's assistant thread status after this request finishes or hands off to
+      // confirmation.
+      if (options.threadTs)
+        await setSlackAssistantThreadStatus(event, ctx, options.threadTs, '').catch(() => {
+          // Best effort only. Payment/error flow must not depend on Slack assistant UI cleanup.
+        })
+    }
   },
 } as const satisfies Record<
   (typeof commandNames)[number] | 'default',
-  (event: chat.SlashCommandEvent, ctx: HandlerContext) => Promise<void>
+  (event: chat.SlashCommandEvent | TipEvent, ctx: HandlerContext) => Promise<void>
 >
 
 const commandNames = [
@@ -881,6 +1327,11 @@ const workspaceSettingsAccountAddressAllowlist = [
 ] as const
 
 type HandlerContext = {
+  defaultTip?: {
+    idempotencyKey: string
+    insufficientFundsThreadTs?: string
+    mention?: boolean
+  }
   db: DB.Type
   provider: ProviderContext
   text: string
@@ -928,397 +1379,6 @@ const slackReactionEventSchema = z.object({
 
 type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>
 
-async function handleTipText(
-  event: TipEvent,
-  ctx: HandlerContext,
-  options: {
-    idempotencyKey: string
-    insufficientFundsThreadTs?: string
-    mention?: boolean
-    threadTs?: string
-  },
-) {
-  const workspace = await ctx.db
-    .selectFrom('workspace')
-    .selectAll()
-    .where('provider', '=', ctx.provider.type)
-    .where('provider_id', '=', ctx.provider.id)
-    .executeTakeFirst()
-  const parsed = Tip.parseTipBatchText(ctx.text, {
-    chainId: workspace?.chain_id ?? Tempo.chainLookup.mainnet,
-  })
-  if (!parsed) {
-    if (options.mention && options.threadTs) {
-      await postInvalidMentionReply(event, ctx, ctx.text, options.threadTs)
-      return
-    }
-    await postInvalidUsage(event, ctx, { mention: options.mention, threadTs: options.threadTs })
-    return
-  }
-
-  const tokenAddress = parsed.token
-    ? Tempo.getTokenAddress(workspace?.chain_id ?? Tempo.chainLookup.mainnet, parsed.token)
-    : null
-  if (parsed.token && !tokenAddress) {
-    await postPrivateReply(
-      event,
-      event.user,
-      'Payment not sent. This token is not supported on this network.',
-    )
-    return
-  }
-  if (Tip.isTransferMemoTooLong(parsed.memo)) {
-    const suggestion = await (async () => {
-      // Best-effort UX sugar: the hard requirement is returning the length error.
-      if (!parsed.memo) return null
-      try {
-        const value = z
-          .parse(
-            z.object({ response: z.string().default('') }),
-            await env.AI.run('@cf/meta/llama-3.2-1b-instruct', {
-              max_tokens: 24,
-              messages: [
-                {
-                  content:
-                    'Shorten this payment memo to at most 32 UTF-8 bytes. Preserve the meaning. Return only the shortened memo text, no quotes, no explanation, no punctuation unless needed.',
-                  role: 'system',
-                },
-                { content: parsed.memo, role: 'user' },
-              ],
-            }),
-          )
-          .response.replace(/[\r\n]+/g, ' ')
-          .trim()
-          .replace(/^['"]|['"]$/g, '')
-        if (!value || Tip.isTransferMemoTooLong(value)) return null
-        if (/[`\r\n]|<@[A-Z0-9_]+/i.test(value)) return null
-        const memoWords = new Set(parsed.memo.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [])
-        const suggestionWords = value.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []
-        if (!suggestionWords.length) return null
-        if (suggestionWords.some((word) => !memoWords.has(word))) return null
-        return value
-      } catch (error) {
-        console.error('Failed to generate short memo suggestion:', error)
-      }
-      return null
-    })()
-    await postPrivateReply(
-      event,
-      event.user,
-      `Payment not sent. Memo must be at most 32 bytes; shorten the text after \`for\`.${suggestion ? ` Try: \`${suggestion}\`.` : ''}`,
-    )
-    if (options.threadTs)
-      await setSlackAssistantThreadStatus(event, ctx, options.threadTs, '').catch(() => {
-        // Best effort only. Payment/error flow must not depend on Slack assistant UI cleanup.
-      })
-    return
-  }
-  const recipients = await (async (): Promise<
-    { ok: true; value: Tip.TipRecipientInput[] } | { message: string; ok: false }
-  > => {
-    if (ctx.provider.type !== 'slack') return { ok: true, value: parsed.recipients }
-    const installation = await getSlack().getInstallation(ctx.provider.id)
-    if (!installation) return { ok: true, value: parsed.recipients }
-
-    const body = new URLSearchParams()
-    body.set('channel', event.channel.id.replace(/^slack:/, ''))
-    const response = await getSlack().withBotToken(installation.botToken, () =>
-      fetch(`${env.SLACK_API_URL}/conversations.info`, {
-        body,
-        headers: { authorization: `Bearer ${installation.botToken}` },
-        method: 'POST',
-      }),
-    )
-    const conversation = z.parse(
-      z.object({
-        channel: z
-          .object({
-            context_team_id: z.string().optional(),
-            is_ext_shared: z.boolean().optional(),
-            is_shared: z.boolean().optional(),
-            shared_team_ids: z.array(z.string()).optional(),
-          })
-          .optional(),
-        ok: z.boolean().optional(),
-      }),
-      await response.json(),
-    )
-    const isSharedChannel =
-      conversation.channel?.is_ext_shared ||
-      conversation.channel?.is_shared ||
-      conversation.channel?.shared_team_ids?.some(
-        (teamId) => teamId !== conversation.channel?.context_team_id,
-      )
-    if (!conversation.ok || !conversation.channel || !isSharedChannel)
-      return { ok: true, value: parsed.recipients }
-
-    const tokenTeamIds = new Set(
-      [
-        ctx.provider.id,
-        conversation.channel.context_team_id,
-        ...(conversation.channel.shared_team_ids ?? []),
-      ].filter((teamId) => teamId !== undefined),
-    )
-    const value = [] as Tip.TipRecipientInput[]
-    for (const recipient of parsed.recipients) {
-      const candidates = [...tokenTeamIds].map((tokenTeamId) => ({
-        providerUserId: recipient.recipientProviderUserId,
-        providerWorkspaceId: tokenTeamId,
-      }))
-      for (const tokenTeamId of tokenTeamIds) {
-        const tokenInstallation = await getSlack().getInstallation(tokenTeamId)
-        if (!tokenInstallation) continue
-        const userBody = new URLSearchParams()
-        userBody.set('user', recipient.recipientProviderUserId)
-        const userResponse = await getSlack().withBotToken(tokenInstallation.botToken, () =>
-          fetch(`${env.SLACK_API_URL}/users.info`, {
-            body: userBody,
-            headers: { authorization: `Bearer ${tokenInstallation.botToken}` },
-            method: 'POST',
-          }),
-        )
-        const info = z.parse(
-          z.object({
-            ok: z.boolean().optional(),
-            user: z
-              .object({
-                id: z.string().optional(),
-                team_id: z.string().optional(),
-              })
-              .optional(),
-          }),
-          await userResponse.json(),
-        )
-        if (!info.ok || !info.user?.id || !info.user.team_id) continue
-        candidates.push({
-          providerUserId: info.user.id,
-          providerWorkspaceId: info.user.team_id,
-        })
-      }
-
-      const seen = new Set<string>()
-      const matches = [] as Array<{ providerUserId: string; providerWorkspaceId: string }>
-      for (const candidate of candidates) {
-        const key = `${candidate.providerWorkspaceId}:${candidate.providerUserId}`
-        if (seen.has(key)) continue
-        seen.add(key)
-        const candidateWorkspace = await ctx.db
-          .selectFrom('workspace')
-          .select('id')
-          .where('provider', '=', 'slack')
-          .where('provider_id', '=', candidate.providerWorkspaceId)
-          .executeTakeFirst()
-        if (!candidateWorkspace) continue
-        const candidateMember = await ctx.db
-          .selectFrom('member')
-          .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
-          .innerJoin('account', 'account.id', 'provider_identity.account_id')
-          .select('member.id')
-          .where('member.provider_user_id', '=', candidate.providerUserId)
-          .where('member.workspace_id', '=', candidateWorkspace.id)
-          .executeTakeFirst()
-        if (candidateMember) matches.push(candidate)
-      }
-      if (matches.length === 0) {
-        const connectedMembers = await ctx.db
-          .selectFrom('member')
-          .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
-          .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
-          .innerJoin('account', 'account.id', 'provider_identity.account_id')
-          .select([
-            'member.provider_user_id as providerUserId',
-            'workspace.provider_id as providerWorkspaceId',
-          ])
-          .where('member.provider_user_id', '=', recipient.recipientProviderUserId)
-          .where('workspace.provider', '=', 'slack')
-          .execute()
-        if (connectedMembers.length === 1) matches.push(connectedMembers[0]!)
-      }
-      if (matches.length !== 1)
-        return {
-          message:
-            matches.length === 0
-              ? `Payment not sent. <@${recipient.recipientProviderUserId}> needs to install or connect Tipbot in their Slack workspace before receiving Slack Connect payments.`
-              : `Payment not sent. <@${recipient.recipientProviderUserId}> could not be resolved safely across Slack workspaces.`,
-          ok: false,
-        }
-      value.push({ ...recipient, recipientProviderWorkspaceId: matches[0]!.providerWorkspaceId })
-    }
-    return { ok: true, value }
-  })()
-  if (!recipients.ok) {
-    await postPrivateReply(event, event.user, recipients.message)
-    return
-  }
-
-  if (options.threadTs)
-    void setSlackAssistantThreadStatus(event, ctx, options.threadTs, 'is sending a tip', {
-      loadingMessages: ['Sending tip'],
-    }).catch(() => {
-      // Best effort only. Payment flow must not depend on Slack assistant UI.
-    })
-  try {
-    const result = await (
-      parsed.recipients.length === 1
-        ? Tip.handleTipRequest(env, {
-            amount: parsed.amount,
-            idempotencyKey: options.idempotencyKey,
-            memo: parsed.memo,
-            provider: ctx.provider.type,
-            providerChannelId: event.channel.id,
-            providerId: ctx.provider.id,
-            providerThreadId: options.threadTs,
-            recipientProviderLabel: recipients.value[0]?.recipientProviderLabel,
-            recipientProviderUserId: recipients.value[0]!.recipientProviderUserId,
-            recipientProviderWorkspaceId: recipients.value[0]?.recipientProviderWorkspaceId,
-            senderProviderUserId: event.user.userId,
-            tokenAddress: tokenAddress ?? undefined,
-          })
-        : Tip.handleTipBatchRequest(env, {
-            amount: parsed.amount,
-            idempotencyKey: options.idempotencyKey,
-            memo: parsed.memo,
-            provider: ctx.provider.type,
-            providerChannelId: event.channel.id,
-            providerId: ctx.provider.id,
-            providerThreadId: options.threadTs,
-            recipients: recipients.value,
-            senderProviderUserId: event.user.userId,
-            source: options.mention ? 'mention' : 'command',
-            tokenAddress: tokenAddress ?? undefined,
-          })
-    ).catch(
-      (error) =>
-        ({
-          code: 'failed',
-          message: error instanceof Error ? error.message : 'Command failed.',
-          ok: false,
-        }) satisfies Tip.TipResult,
-    )
-
-    if (result.ok && result.status === 'sent' && 'recipients' in result) {
-      const amount = result.isDefaultToken
-        ? formatCurrencyAmount(result.amount, result.tokenCurrency)
-        : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
-      await postSlackReceiptMessage(
-        event,
-        ctx,
-        `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${result.recipients.map((recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`).join('\n')}`,
-        result.chainId,
-        result.transactionHash,
-        undefined,
-        result.feePayer === 'sender'
-          ? 'Fee sponsor unavailable; fee paid from your balance.'
-          : undefined,
-        options.threadTs,
-      )
-      if (result.memo && options.threadTs)
-        await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
-    } else if (result.ok && result.status === 'sent' && !('recipients' in result)) {
-      await postSlackReceiptMessage(
-        event,
-        ctx,
-        `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${event.channel.mentionUser(result.recipientProviderUserId)} ${result.isDefaultToken ? formatCurrencyAmount(result.amount, result.tokenCurrency) : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)}${result.memo ? ` for ${result.memo}` : ''}.`,
-        result.chainId,
-        result.transactionHash,
-        undefined,
-        result.feePayer === 'sender'
-          ? 'Fee sponsor unavailable; fee paid from your balance.'
-          : undefined,
-        options.threadTs,
-      )
-      if (result.memo && options.threadTs)
-        await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
-    } else if (result.ok)
-      await postSlackReceiptMessage(
-        event,
-        ctx,
-        'Payment sent.',
-        result.chainId,
-        result.transactionHash,
-        event.user,
-        result.feePayer === 'sender'
-          ? 'Fee sponsor unavailable; fee paid from your balance.'
-          : undefined,
-        options.threadTs,
-      )
-    else {
-      if (result.code === 'confirmation_required' && result.confirmUrl) {
-        const confirmUrlLabel = result.confirmUrl.replace(/(\/confirm\/.{8}).+$/, '$1...')
-        await postPrivateReply(event, event.user, {
-          card: chat.Card({
-            children: [
-              chat.CardText('Tipbot needs your approval to send this payment.'),
-              chat.Actions([
-                chat.LinkButton({
-                  label: 'Confirm payment',
-                  style: 'primary',
-                  url: result.confirmUrl,
-                }),
-                chat.Button({ id: 'confirm_cancel', label: 'Cancel' }),
-              ]),
-              chat.CardText(
-                `Link expires in 10 minutes. <${result.confirmUrl}|${confirmUrlLabel}>`,
-                {
-                  style: 'muted',
-                },
-              ),
-            ],
-          }),
-          fallbackText: `Tipbot needs your approval to send this payment.\nConfirm payment: ${result.confirmUrl}\nLink expires in 10 minutes.`,
-        })
-        return
-      }
-      if (result.code === 'sender_unconnected' || result.code === 'missing_sender_access_key') {
-        await postConnectLink(event, ctx)
-        return
-      }
-      const message = await (async () => {
-        if (result.code === 'self_tip')
-          return 'Payment not sent. Cannot send a payment to yourself.'
-        if (result.code === 'recipient_unconnected')
-          return `Payment not sent. ${event.channel.mentionUser(result.recipientProviderUserId ?? recipients.value[0]!.recipientProviderUserId)} needs to connect Tipbot before receiving payments.`
-        if (result.code === 'pending') return 'Payment still sending.'
-        if (result.code === 'insufficient_funds')
-          return 'Payment not sent. Your wallet has insufficient funds.'
-        return 'Payment failed.'
-      })()
-      if (result.code === 'insufficient_funds') {
-        await postSlackInsufficientFunds(
-          event,
-          ctx,
-          options.mention ? options.insufficientFundsThreadTs : options.threadTs,
-        )
-        return
-      }
-      if (
-        'chainId' in result &&
-        result.chainId &&
-        'transactionHash' in result &&
-        result.transactionHash
-      )
-        await postSlackReceiptMessage(
-          event,
-          ctx,
-          message,
-          result.chainId,
-          result.transactionHash,
-          event.user,
-          undefined,
-          options.threadTs,
-        )
-      else await postPrivateReply(event, event.user, message)
-    }
-  } finally {
-    // Clear Slack's assistant thread status after this request finishes or hands off to
-    // confirmation.
-    if (options.threadTs)
-      await setSlackAssistantThreadStatus(event, ctx, options.threadTs, '').catch(() => {
-        // Best effort only. Payment/error flow must not depend on Slack assistant UI cleanup.
-      })
-  }
-}
-
 async function setSlackAssistantThreadStatus(
   event: TipEvent,
   ctx: HandlerContext,
@@ -1347,6 +1407,16 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
 
   const installation = await getSlack().getInstallation(provider.id)
   if (!installation) return
+
+  if (await isExternalSlackConnectActor(provider.id, event.item.channel, event.user)) {
+    await postSlackEphemeral(
+      provider.id,
+      event.item.channel,
+      event.user,
+      `Tipbot isn't installed in your Slack workspace yet. Ask an admin to install Tipbot there, then try again.`,
+    )
+    return
+  }
 
   const conversation = await (async () => {
     const body = new URLSearchParams()
@@ -1515,7 +1585,7 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
       provider.id,
       event.item.channel,
       event.user,
-      `Payment not sent. Connect to Tipbot with \`${getSlackCommand(env.HOST)} connect\` and try again.`,
+      `Payment not sent. Connect to Tipbot with \`@${getSlackBotDisplayName(env.HOST)} connect\` or \`${getSlackCommand(env.HOST)} connect\` and try again.`,
     )
     return
   }
@@ -1735,6 +1805,69 @@ async function postSlackPrivateReply(
   if (!json.ok) throw Slack.slackApiError(method, json.error)
 }
 
+async function isExternalSlackConnectActor(
+  providerId: string,
+  channelId: string,
+  providerUserId: string,
+) {
+  const installation = await getSlack().getInstallation(providerId)
+  if (!installation) return false
+
+  const channelBody = new URLSearchParams()
+  channelBody.set('channel', channelId)
+  const channelResponse = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/conversations.info`, {
+      body: channelBody,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const channel = z.parse(
+    z.object({
+      channel: z
+        .object({
+          context_team_id: z.string().optional(),
+          is_ext_shared: z.boolean().optional(),
+          is_shared: z.boolean().optional(),
+          shared_team_ids: z.array(z.string()).optional(),
+        })
+        .optional(),
+      ok: z.boolean().optional(),
+    }),
+    await channelResponse.json(),
+  )
+  const isSharedChannel =
+    channel.channel?.is_ext_shared ||
+    channel.channel?.is_shared ||
+    channel.channel?.shared_team_ids?.some((teamId) => teamId !== channel.channel?.context_team_id)
+  if (!channel.ok || !channel.channel || !isSharedChannel) return false
+
+  const userBody = new URLSearchParams()
+  userBody.set('user', providerUserId)
+  const userResponse = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/users.info`, {
+      body: userBody,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const info = z.parse(
+    z.object({
+      ok: z.boolean().optional(),
+      user: z
+        .object({
+          team_id: z.string().optional(),
+        })
+        .optional(),
+    }),
+    await userResponse.json(),
+  )
+  if (!info.ok || !info.user?.team_id) return false
+
+  const localTeamIds = new Set([providerId, channel.channel.context_team_id].filter(Boolean))
+  return !localTeamIds.has(info.user.team_id)
+}
+
 function getProvider(event: chat.SlashCommandEvent): ProviderContext {
   const slackSlashCommandRaw = z.object({
     team_id: z.string().min(1),
@@ -1951,17 +2084,6 @@ function parseSlackMentionTipText(text: string) {
   return text.slice(mentions[0]!.index).trim()
 }
 
-function isSlackIntroduceYourselfText(text: string) {
-  return text.toLowerCase() === 'introduce yourself'
-}
-
-function isSlackSelfMentionChatter(rawText: string, botUserId: string, mentionText: string) {
-  const mentions = [...rawText.matchAll(/<@([A-Z0-9_]+)(?:\|[^>]+)?>/g)].map((match) => match[1])
-  if (mentions.filter((mention) => mention === botUserId).length < 2) return false
-  if (mentions.some((mention) => mention !== botUserId)) return false
-  return !hasInvalidMentionIntent(mentionText)
-}
-
 function hasInvalidMentionIntent(text: string) {
   return /\b(connect|configure|get started|install|link|mine|set ?up|start|tip|send|pay|sent|paid|for|thank you|thanks|ty|thx|thank u|creature|creatures|dragon|dragons|elf|elves|fae|fairy|goblin|goblins|gnome|gnomes|gremlin|gremlins|kobold|kobolds|monster|monsters|orc|orcs|troll|trolls)\b/i.test(
     text,
@@ -2068,7 +2190,7 @@ async function generateInvalidMentionReply(mentionText: string) {
     if (creatureMatch) return `${creatureMatch[0].toUpperCase()}? Now we are talking.`
     if (isThanksText) return 'Anytime.'
     if (isSetupText)
-      return `Run \`${getSlackCommand(env.HOST)} connect\`, then try \`@${getSlackBotDisplayName(env.HOST)} tip @account\`.`
+      return `Run \`@${getSlackBotDisplayName(env.HOST)} connect\`, then try \`@${getSlackBotDisplayName(env.HOST)} @account for coffee\`.`
     if (isTipText)
       return `Almost. Try \`@${getSlackBotDisplayName(env.HOST)} @account for coffee\`.`
     return 'Anytime.'
@@ -2104,36 +2226,6 @@ function isValidInvalidMentionAiReply(value: string) {
   if (value.includes(`@${getSlackBotDisplayName(env.HOST)}`) || /@Tipbot|<@[A-Z0-9_]+/i.test(value))
     return false
   return true
-}
-
-async function postSlackIntroduction(event: TipEvent, ctx: HandlerContext, threadTs: string) {
-  const installation = await getSlack().getInstallation(ctx.provider.id)
-  if (!installation) throw new Error('Tibot app not installed for this workspace.')
-
-  const text =
-    `I’m ${getSlackBotDisplayName(env.HOST)}: sometime tipper, sometime messenger, always bot.\n` +
-    `Connect with \`${getSlackCommand(env.HOST)} connect\`, then send stablecoins with \`@${getSlackBotDisplayName(env.HOST)} @account for coffee\`, \`@${getSlackBotDisplayName(env.HOST)} @account 0.005 for coffee\`, \`${getSlackCommand(env.HOST)} @account for coffee\`, or a 💸 reaction.`
-  const body = new URLSearchParams()
-  body.set('channel', event.channel.id.replace(/^slack:/, ''))
-  body.set('text', text)
-  body.set('thread_ts', threadTs)
-  body.set('unfurl_links', 'false')
-  body.set('unfurl_media', 'false')
-  const response = await getSlack().withBotToken(installation.botToken, () =>
-    fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
-      body,
-      headers: { authorization: `Bearer ${installation.botToken}` },
-      method: 'POST',
-    }),
-  )
-  const json = z.parse(
-    z.object({
-      error: z.string().optional(),
-      ok: z.boolean().optional(),
-    }),
-    await response.json(),
-  )
-  if (!json.ok) throw Slack.slackApiError('chat.postMessage', json.error)
 }
 
 async function postSlackInsufficientFunds(event: TipEvent, ctx: HandlerContext, threadTs?: string) {
@@ -2564,7 +2656,7 @@ function configCard(
 }
 
 async function postConfigEphemeral(
-  event: chat.SlashCommandEvent,
+  event: chat.SlashCommandEvent | TipEvent,
   ctx: HandlerContext,
   workspace: DB_gen.Selectable.workspace,
   options?: { canEdit?: boolean },

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -73,7 +73,8 @@ export function getChat() {
     const installation = await getSlack().getInstallation(providerId)
     if (!installation?.botUserId) throw new Error('Slack app installation missing bot user id.')
 
-    const event = { channel: thread.channel, user: message.author } satisfies TipEvent
+    const threadTs = raw.thread_ts ?? raw.ts
+    const event = { channel: thread.channel, threadTs, user: message.author } satisfies TipEvent
     if (await isExternalSlackConnectActor(providerId, raw.channel, raw.user)) {
       await postPrivateReply(
         event,
@@ -83,12 +84,12 @@ export function getChat() {
       return
     }
 
-    const threadTs = raw.thread_ts ?? raw.ts
     const mentionText = normalizeSlackMentionText(raw.text, installation.botUserId)
     const context = {
       db: DB.create(env.DB),
       provider: { id: providerId, type: 'slack' },
       text: parseSlackMentionTipText(mentionText) ?? '',
+      threadTs,
     } satisfies HandlerContext
 
     if (mentionText.toLowerCase() === 'introduce yourself') {
@@ -126,7 +127,7 @@ export function getChat() {
     const match = mentionText.match(commandPattern)
     if (match) {
       const name = z.parse(z.enum(commandNames), match[1])
-      await handlers[name](event, { ...context, text: match[2]?.trim() ?? '', threadTs })
+      await handlers[name](event, { ...context, text: match[2]?.trim() ?? '' })
       return
     }
 
@@ -153,7 +154,6 @@ export function getChat() {
         insufficientFundsThreadTs: raw.thread_ts,
         mention: true,
       },
-      threadTs,
     })
   })
   bot.onReaction(async (event) => {
@@ -657,6 +657,7 @@ const handlers = {
       event.channel.id.replace(/^slack:/, ''),
       event.user.userId,
       body,
+      { threadTs: ctx.threadTs },
     )
   },
   async leaderboard(event, ctx) {
@@ -688,7 +689,10 @@ const handlers = {
       workspaceId: workspace.id,
     })
     if (received.length === 0 && sent.length === 0) {
-      await event.channel.post('No confirmed tips yet.')
+      const channel = ctx.threadTs
+        ? getChat().channel(`slack:${getSlackChannelId(event.channel.id)}:${ctx.threadTs}`)
+        : event.channel
+      await channel.post('No confirmed tips yet.')
       return
     }
 
@@ -754,6 +758,7 @@ const handlers = {
     )
     body.set('unfurl_links', 'false')
     body.set('unfurl_media', 'false')
+    if (ctx.threadTs) body.set('thread_ts', ctx.threadTs)
     const response = await getSlack().withBotToken(installation.botToken, () =>
       fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
         body,
@@ -1347,6 +1352,7 @@ type ProviderContext = { id: string; type: 'slack' }
 
 type TipEvent = {
   channel: chat.Channel
+  threadTs?: string
   user: chat.Author
 }
 
@@ -1784,12 +1790,14 @@ async function postSlackPrivateReply(
   channelId: string,
   userId: string,
   body: URLSearchParams,
+  options: { threadTs?: string } = {},
 ) {
   const installation = await getSlack().getInstallation(providerId)
   if (!installation) return
 
   const method = isSlackDMChannelId(channelId) ? 'chat.postMessage' : 'chat.postEphemeral'
   if (method === 'chat.postEphemeral') body.set('user', userId)
+  if (options.threadTs && method === 'chat.postEphemeral') body.set('thread_ts', options.threadTs)
   const response = await getSlack().withBotToken(installation.botToken, () =>
     fetch(`${env.SLACK_API_URL}/${method}`, {
       body,
@@ -2146,6 +2154,7 @@ async function postInvalidUsage(
     event.channel.id.replace(/^slack:/, ''),
     event.user.userId,
     body,
+    { threadTs: options.threadTs ?? event.threadTs },
   )
 }
 
@@ -2274,6 +2283,7 @@ async function postSlackInsufficientFunds(event: TipEvent, ctx: HandlerContext, 
     event.channel.id.replace(/^slack:/, ''),
     event.user.userId,
     body,
+    { threadTs: ctx.threadTs },
   )
 }
 
@@ -2365,7 +2375,7 @@ async function postConnectLink(event: TipEvent, ctx: HandlerContext) {
           (workspace.default_token_address ?? Tempo.addressLookup.pathUsd).toLowerCase(),
     )
     if (accessKey) {
-      await postPrivateReply(event, event.user, 'Already connected')
+      await postPrivateReply(event, event.user, 'Already connected', { threadTs: ctx.threadTs })
       return
     }
   }
@@ -2403,35 +2413,49 @@ async function postConnectLink(event: TipEvent, ctx: HandlerContext) {
     })
     .execute()
 
-  await postPrivateReply(event, event.user, {
-    card: chat.Card({
-      children: [
-        chat.Actions([
-          chat.LinkButton({ label: linkButtonLabel, style: 'primary', url: linkUrl }),
-          chat.Button({ id: 'connect_cancel', label: 'Cancel' }),
-        ]),
-        chat.CardText(`${linkDescription} ${linkUrl}`, { style: 'muted' }),
-      ],
-    }),
-    fallbackText: linkText,
-  })
+  await postPrivateReply(
+    event,
+    event.user,
+    {
+      card: chat.Card({
+        children: [
+          chat.Actions([
+            chat.LinkButton({ label: linkButtonLabel, style: 'primary', url: linkUrl }),
+            chat.Button({ id: 'connect_cancel', label: 'Cancel' }),
+          ]),
+          chat.CardText(`${linkDescription} ${linkUrl}`, { style: 'muted' }),
+        ],
+      }),
+      fallbackText: linkText,
+    },
+    { threadTs: ctx.threadTs },
+  )
 }
 
 async function postPrivateReply(
   event: TipEvent,
   user: chat.Author,
   message: Parameters<TipEvent['channel']['postEphemeral']>[1],
+  options: { threadTs?: string } = {},
 ) {
+  const threadTs = options.threadTs ?? event.threadTs
   if (isSlackDMChannelId(event.channel.id)) {
     await event.channel.post(message)
     return
   }
 
-  await event.channel.postEphemeral(user, message, { fallbackToDM: false })
+  const channel = threadTs
+    ? getChat().channel(`slack:${getSlackChannelId(event.channel.id)}:${threadTs}`)
+    : event.channel
+  await channel.postEphemeral(user, message, { fallbackToDM: false })
 }
 
 function isSlackDMChannelId(channelId: string) {
-  return channelId.replace(/^slack:/, '').startsWith('D')
+  return getSlackChannelId(channelId).startsWith('D')
+}
+
+function getSlackChannelId(channelId: string) {
+  return channelId.replace(/^slack:/, '').split(':')[0] ?? ''
 }
 
 async function postSlackReceiptMessage(
@@ -2706,6 +2730,7 @@ async function postConfigEphemeral(
     event.channel.id.replace(/^slack:/, ''),
     event.user.userId,
     body,
+    { threadTs: ctx.threadTs },
   )
 }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -587,9 +587,14 @@ const handlers = {
       ],
     ]
     const mentionExampleRows = [
-      [`@${getSlackBotDisplayName(env.HOST)} connect`, 'Connect to Tipbot'],
-      [`@${getSlackBotDisplayName(env.HOST)} help`, 'Show help message'],
       [`@${getSlackBotDisplayName(env.HOST)} @account`, 'Send default amount'],
+      [`@${getSlackBotDisplayName(env.HOST)} balance`, 'Show wallet balance'],
+      [`@${getSlackBotDisplayName(env.HOST)} connect`, 'Connect to Tipbot'],
+      [`@${getSlackBotDisplayName(env.HOST)} disconnect`, 'Disconnect from Tipbot'],
+      [`@${getSlackBotDisplayName(env.HOST)} help`, 'Show help message'],
+      [`@${getSlackBotDisplayName(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
+      [`@${getSlackBotDisplayName(env.HOST)} stats`, 'Show your tip stats'],
+      [`@${getSlackBotDisplayName(env.HOST)} status`, 'Check connection status'],
       [`@${getSlackBotDisplayName(env.HOST)} @account for coffee`, 'Send default amount with memo'],
       [
         `@${getSlackBotDisplayName(env.HOST)} @account 0.005 for coffee`,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -758,7 +758,26 @@ test('@Tipbot mention supports connect command for local workspace accounts', as
 
   expect(response.status).toBe(200)
   expect(token).toEqual(expect.any(Object))
-  await expectSlackMessage('Link expires in 10 minutes.')
+  await expectSlackThreadMessage(messageTs, 'Link expires in 10 minutes.', { wait: true })
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention supports connect command from thread', async () => {
+  const parent = await memberSlack.chat.postMessage({
+    channel: Constants.slack.channelId,
+    text: 'connect from this thread',
+  })
+  if (!parent.ts) throw new Error('Expected Slack parent message timestamp.')
+  const messageTs = `1700000020.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> connect`,
+    threadTs: parent.ts,
+    userId: unconnectedProviderUserId,
+  })
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(parent.ts, 'Link expires in 10 minutes.', { wait: true })
 }, 20_000) // 20 seconds
 
 test('@Tipbot mention supports connect command for single channel guests', async () => {
@@ -784,7 +803,7 @@ test('@Tipbot mention supports connect command for single channel guests', async
   })
   expect(response.status).toBe(200)
   expect(token).toEqual(expect.any(Object))
-  await expectSlackMessage('Link expires in 10 minutes.')
+  await expectSlackThreadMessage(messageTs, 'Link expires in 10 minutes.', { wait: true })
 }, 20_000) // 20 seconds
 
 test('@Tipbot mention connect link completion connects local workspace account', async () => {
@@ -795,7 +814,7 @@ test('@Tipbot mention connect link completion connects local workspace account',
     text: `<@${Constants.slack.botUserId}> connect`,
     userId: unconnectedProviderUserId,
   })
-  const token = await getLatestConnectToken()
+  const token = await getLatestConnectToken(messageTs)
   const link = await db
     .selectFrom('account_link_token')
     .innerJoin('member', 'member.id', 'account_link_token.member_id')
@@ -851,13 +870,13 @@ test('@Tipbot mention supports help command', async () => {
   })
 
   expect(response.status).toBe(200)
-  await expectSlackMessage('@Tipbot balance')
-  await expectSlackMessage('@Tipbot connect')
-  await expectSlackMessage('@Tipbot disconnect')
-  await expectSlackMessage('@Tipbot leaderboard')
-  await expectSlackMessage('@Tipbot stats')
-  await expectSlackMessage('@Tipbot status')
-  await expectSlackMessage('@Tipbot @account for coffee')
+  await expectSlackThreadMessage(messageTs, '@Tipbot balance', { wait: true })
+  await expectSlackThreadMessage(messageTs, '@Tipbot connect')
+  await expectSlackThreadMessage(messageTs, '@Tipbot disconnect')
+  await expectSlackThreadMessage(messageTs, '@Tipbot leaderboard')
+  await expectSlackThreadMessage(messageTs, '@Tipbot stats')
+  await expectSlackThreadMessage(messageTs, '@Tipbot status')
+  await expectSlackThreadMessage(messageTs, '@Tipbot @account for coffee')
 })
 
 test('@Tipbot mention supports disconnect command for local workspace accounts', async () => {
@@ -879,7 +898,7 @@ test('@Tipbot mention supports disconnect command for local workspace accounts',
 
   expect(response.status).toBe(200)
   expect(member.account_id).toBeNull()
-  await expectSlackMessage('Disconnected')
+  await expectSlackThreadMessage(messageTs, 'Disconnected', { wait: true })
 })
 
 test.each([
@@ -926,7 +945,14 @@ test.each([
     expect(accountLinkTokens).toEqual([])
     expect(members).toEqual([])
     expect(tips).toEqual([])
-    await expectSlackMessage("Tipbot isn't installed in your Slack workspace yet.", { channelId })
+    await expectSlackThreadMessage(
+      messageTs,
+      "Tipbot isn't installed in your Slack workspace yet.",
+      {
+        channelId,
+        wait: true,
+      },
+    )
   },
   20_000,
 )
@@ -1372,7 +1398,9 @@ test('@Tipbot mention shows confirmation action when approval is required', asyn
   })
 
   expect(response.status).toBe(200)
-  await expectSlackMessage('Tipbot needs your approval to send this payment.')
+  await expectSlackThreadMessage(messageTs, 'Tipbot needs your approval to send this payment.', {
+    wait: true,
+  })
   await expectSlackThreadMessageNotContaining(messageTs, 'Receipt')
 }, 20_000) // 20 seconds
 
@@ -1402,7 +1430,7 @@ test('@Tipbot mention shows add funds action when sender has insufficient funds'
       return (
         url.endsWith('/chat.postEphemeral') &&
         params.get('text')?.includes('Payment not sent. Your wallet has insufficient funds.') &&
-        !params.has('thread_ts')
+        params.get('thread_ts') === messageTs
       )
     }),
   ).toBe(true)
@@ -1464,7 +1492,7 @@ test('@Tipbot mention clears assistant status after payment failure', async () =
   })
 
   expect(response.status).toBe(200)
-  await expectSlackMessage('Payment failed.')
+  await expectSlackThreadMessage(messageTs, 'Payment failed.', { wait: true })
   await expectSlackAssistantStatusCall(fetchSpy, messageTs, '')
   handleTipRequest.mockRestore()
   fetchSpy.mockRestore()
@@ -1488,7 +1516,7 @@ test('@Tipbot mention explains memo length failures', async () => {
   expect(response.status).toBe(200)
   expect(handleTipRequest).not.toHaveBeenCalled()
   expect(aiRunMock).toHaveBeenCalledOnce()
-  await expectSlackMessage('Try: `best pages internet`.')
+  await expectSlackThreadMessage(messageTs, 'Try: `best pages internet`.', { wait: true })
   await expectSlackAssistantStatusCall(fetchSpy, messageTs, '')
   handleTipRequest.mockRestore()
   fetchSpy.mockRestore()
@@ -1511,8 +1539,10 @@ test('@Tipbot mention omits memo suggestion when AI returns an invalid memo', as
 
   expect(response.status).toBe(200)
   expect(aiRunMock).toHaveBeenCalledOnce()
-  await expectSlackMessage('Payment not sent. Memo must be at most 32 bytes')
-  await expectSlackMessageNotContaining('Try:')
+  await expectSlackThreadMessage(messageTs, 'Payment not sent. Memo must be at most 32 bytes', {
+    wait: true,
+  })
+  await expectSlackThreadMessageNotContaining(messageTs, 'Try:')
   await expectSlackAssistantStatusCall(fetchSpy, messageTs, '')
   handleTipRequest.mockRestore()
   fetchSpy.mockRestore()
@@ -3617,8 +3647,10 @@ async function getLatestConfirmToken() {
   return token
 }
 
-async function getLatestConnectToken() {
-  const history = await slack.conversations.history({ channel: Constants.slack.channelId })
+async function getLatestConnectToken(threadTs?: string) {
+  const history = threadTs
+    ? await slack.conversations.replies({ channel: Constants.slack.channelId, ts: threadTs })
+    : await slack.conversations.history({ channel: Constants.slack.channelId })
   const message = history.messages?.find((message) => message.text?.includes('/connect/'))
   const token = message?.text?.match(/\/connect\/([A-Za-z0-9_-]+)/)?.[1]
   if (!token) throw new Error('Expected connection token in Slack message.')

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -8,7 +8,7 @@ import * as Tip from '#/lib/tip.ts'
 import { WebClient } from '@slack/web-api'
 import { env } from 'cloudflare:workers'
 import { testClient } from 'hono/testing'
-import { AbiFunction } from 'ox'
+import { AbiFunction, Address } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { createClient, http, parseUnits } from 'viem'
 import { Account, Actions } from 'viem/tempo'
@@ -702,6 +702,230 @@ test('@Tipbot mention sends tip in thread', async () => {
   fetchSpy.mockRestore()
 }, 20_000) // 20 seconds
 
+test('@Tipbot mention sends tip from single channel guest', async () => {
+  await connectTipAccounts({ senderProviderUserId: Constants.slack.singleChannelGuestUserId })
+  const messageTs = `1700000017.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    userId: Constants.slack.singleChannelGuestUserId,
+  })
+  const tip = await db
+    .selectFrom('tip')
+    .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
+    .innerJoin('member as recipient', 'recipient.id', 'tip.recipient_member_id')
+    .innerJoin('workspace', 'workspace.id', 'tip.workspace_id')
+    .select([
+      'recipient.provider_user_id as recipient_provider_user_id',
+      'sender.provider_user_id as sender_provider_user_id',
+      'tip.confirmed_at',
+    ])
+    .where('workspace.provider_id', '=', providerId)
+    .where(
+      'tip.idempotency_key',
+      '=',
+      `mention:${providerId}:${Constants.slack.channelId}:${messageTs}`,
+    )
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(tip).toMatchObject({
+    recipient_provider_user_id: Constants.slack.memberUserId,
+    sender_provider_user_id: Constants.slack.singleChannelGuestUserId,
+  })
+  expect(tip.confirmed_at).toEqual(expect.any(String))
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slack.singleChannelGuestUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+  )
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention supports connect command for local workspace accounts', async () => {
+  const messageTs = `1700000012.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> connect`,
+    userId: unconnectedProviderUserId,
+  })
+  const token = await db
+    .selectFrom('account_link_token')
+    .innerJoin('member', 'member.id', 'account_link_token.member_id')
+    .select(['account_link_token.id', 'member.provider_user_id'])
+    .where('member.provider_user_id', '=', unconnectedProviderUserId)
+    .executeTakeFirst()
+
+  expect(response.status).toBe(200)
+  expect(token).toEqual(expect.any(Object))
+  await expectSlackMessage('Link expires in 10 minutes.')
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention supports connect command for single channel guests', async () => {
+  const messageTs = `1700000018.${Nanoid.generate().slice(0, 6)}`
+  const guest = await slack.users.info({ user: Constants.slack.singleChannelGuestUserId })
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> connect`,
+    userId: Constants.slack.singleChannelGuestUserId,
+  })
+  const token = await db
+    .selectFrom('account_link_token')
+    .innerJoin('member', 'member.id', 'account_link_token.member_id')
+    .select(['account_link_token.id', 'member.provider_user_id'])
+    .where('member.provider_user_id', '=', Constants.slack.singleChannelGuestUserId)
+    .executeTakeFirst()
+
+  expect(guest.user).toMatchObject({
+    id: Constants.slack.singleChannelGuestUserId,
+    is_restricted: true,
+    is_ultra_restricted: true,
+  })
+  expect(response.status).toBe(200)
+  expect(token).toEqual(expect.any(Object))
+  await expectSlackMessage('Link expires in 10 minutes.')
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention connect link completion connects local workspace account', async () => {
+  const messageTs = `1700000016.${Nanoid.generate().slice(0, 6)}`
+
+  const connectResponse = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> connect`,
+    userId: unconnectedProviderUserId,
+  })
+  const token = await getLatestConnectToken()
+  const link = await db
+    .selectFrom('account_link_token')
+    .innerJoin('member', 'member.id', 'account_link_token.member_id')
+    .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+    .select([
+      'account_link_token.id',
+      'account_link_token.access_key_address',
+      'account_link_token.access_key_expires_at',
+      'member.provider_identity_id',
+      'workspace.chain_id',
+      'workspace.default_token_address',
+    ])
+    .where('member.provider_user_id', '=', unconnectedProviderUserId)
+    .where('workspace.provider_id', '=', providerId)
+    .executeTakeFirstOrThrow()
+  const root = Account.fromSecp256k1(
+    '0x3333333333333333333333333333333333333333333333333333333333333333',
+  )
+  const keyAuthorization = await AccountLink.signKeyAuthorization(root, {
+    accessKeyAddress: link.access_key_address,
+    chainId: link.chain_id,
+    expiresAt: link.access_key_expires_at,
+    tokenAddress: Address.checksum(link.default_token_address ?? Tempo.addressLookup.pathUsd),
+  })
+
+  const completeResponse = await client.api.account.link[':token'].$post({
+    json: { address: root.address, keyAuthorization },
+    param: { token },
+  })
+  await drainWaitUntil()
+  const identity = await db
+    .selectFrom('provider_identity')
+    .innerJoin('account', 'account.id', 'provider_identity.account_id')
+    .select(['account.address', 'provider_identity.provider_user_id'])
+    .where('provider_identity.id', '=', link.provider_identity_id)
+    .executeTakeFirstOrThrow()
+
+  expect(connectResponse.status).toBe(200)
+  expect(completeResponse.status).toBe(200)
+  expect(identity).toMatchObject({
+    address: root.address,
+    provider_user_id: unconnectedProviderUserId,
+  })
+  await expectSlackMessage('Connected')
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention supports help command', async () => {
+  const messageTs = `1700000013.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> help`,
+  })
+
+  expect(response.status).toBe(200)
+  await expectSlackMessage('@Tipbot connect')
+  await expectSlackMessage('@Tipbot @account for coffee')
+})
+
+test('@Tipbot mention supports disconnect command for local workspace accounts', async () => {
+  await connectTipAccounts()
+  const messageTs = `1700000014.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> disconnect`,
+  })
+  const member = await db
+    .selectFrom('member')
+    .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+    .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+    .select('provider_identity.account_id')
+    .where('workspace.provider_id', '=', providerId)
+    .where('member.provider_user_id', '=', Constants.slack.adminUserId)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(member.account_id).toBeNull()
+  await expectSlackMessage('Disconnected')
+})
+
+test.each([
+  { name: 'connect command', text: `<@${Constants.slack.botUserId}> connect` },
+  { name: 'balance command', text: `<@${Constants.slack.botUserId}> balance` },
+  { name: 'disconnect command', text: `<@${Constants.slack.botUserId}> disconnect` },
+  { name: 'status command', text: `<@${Constants.slack.botUserId}> status` },
+  { name: 'tip text', text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>` },
+])(
+  '@Tipbot mention blocks Slack Connect external actor $name',
+  async (input) => {
+    const channelId = await getSlackConnectChannelId()
+    const messageTs = `1700000015.${Nanoid.generate().slice(0, 6)}`
+
+    const response = await postSlackAppMention({
+      channelId,
+      messageTs,
+      text: input.text,
+      userId: Constants.slackConnect.userId,
+    })
+    const members = await db
+      .selectFrom('member')
+      .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+      .select(['member.id', 'workspace.provider_id'])
+      .where('workspace.provider_id', '=', providerId)
+      .where('member.provider_user_id', '=', Constants.slackConnect.userId)
+      .execute()
+    const tips = await db
+      .selectFrom('tip')
+      .innerJoin('workspace', 'workspace.id', 'tip.workspace_id')
+      .select('tip.id')
+      .where('workspace.provider_id', '=', providerId)
+      .execute()
+    const accountLinkTokens = await db
+      .selectFrom('account_link_token')
+      .innerJoin('member', 'member.id', 'account_link_token.member_id')
+      .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+      .select('account_link_token.id')
+      .where('workspace.provider_id', '=', providerId)
+      .where('member.provider_user_id', '=', Constants.slackConnect.userId)
+      .execute()
+
+    expect(response.status).toBe(200)
+    expect(accountLinkTokens).toEqual([])
+    expect(members).toEqual([])
+    expect(tips).toEqual([])
+    await expectSlackMessage("Tipbot isn't installed in your Slack workspace yet.", { channelId })
+  },
+  20_000,
+)
+
 test('@Tipbot mention sends Slack Connect tip to recipient home workspace member', async () => {
   await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
     botToken: Constants.slackConnect.teamBotToken,
@@ -895,7 +1119,7 @@ test('@Tipbot mention introduces itself', async () => {
   )
   await expectSlackThreadMessage(
     messageTs,
-    'Connect with `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `@Tipbot @account 0.005 for coffee`, `/tip @account for coffee`, or a 💸 reaction.',
+    'Connect with `@Tipbot connect` or `/tip connect`, then send stablecoins with `@Tipbot @account for coffee`, `@Tipbot @account 0.005 for coffee`, `/tip @account for coffee`, or a 💸 reaction.',
   )
   expect(tips).toHaveLength(0)
 })
@@ -1685,7 +1909,83 @@ test('reaction tipping reports unconnected sender', async () => {
   expect(reactionTips).toHaveLength(0)
   await expectSlackPostEphemeralCall(
     fetchSpy,
-    'Payment not sent. Connect to Tipbot with `/tip connect` and try again.',
+    'Payment not sent. Connect to Tipbot with `@Tipbot connect` or `/tip connect` and try again.',
+  )
+  await expectSlackThreadMessageNotContaining(message.ts, 'tipped', { channelId })
+  fetchSpy.mockRestore()
+})
+
+test('reaction tipping sends tip from single channel guest', async () => {
+  await connectTipAccounts({ senderProviderUserId: Constants.slack.singleChannelGuestUserId })
+  const channelId = await createSlackTestChannel('rt')
+  const message = await memberSlack.chat.postMessage({
+    channel: channelId,
+    text: 'single channel guest should reaction tip',
+  })
+  if (!message.ts) throw new Error('Expected Slack message timestamp.')
+
+  const response = await postSlackReaction({
+    channelId,
+    messageTs: message.ts,
+    reaction: 'money_with_wings',
+    userId: Constants.slack.singleChannelGuestUserId,
+  })
+
+  expect(response.status).toBe(200)
+  await expect
+    .poll(
+      async () =>
+        await db
+          .selectFrom('tip')
+          .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
+          .innerJoin('member as recipient', 'recipient.id', 'tip.recipient_member_id')
+          .innerJoin('workspace', 'workspace.id', 'tip.workspace_id')
+          .select([
+            'recipient.provider_user_id as recipient_provider_user_id',
+            'sender.provider_user_id as sender_provider_user_id',
+            'tip.confirmed_at',
+          ])
+          .where('workspace.provider_id', '=', providerId)
+          .where('tip.idempotency_key', 'like', `${Chat.reactionTipIdempotencyPrefix}%`)
+          .executeTakeFirst(),
+      { timeout: 5_000 }, // 5 seconds
+    )
+    .toMatchObject({
+      confirmed_at: expect.any(String),
+      recipient_provider_user_id: Constants.slack.memberUserId,
+      sender_provider_user_id: Constants.slack.singleChannelGuestUserId,
+    })
+  await expectSlackThreadMessage(message.ts, 'tipped', { channelId })
+}, 20_000) // 20 seconds
+
+test('reaction tipping blocks Slack Connect external sender', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  await connectTipAccounts()
+  const channelId = await getSlackConnectChannelId()
+  const message = await memberSlack.chat.postMessage({
+    channel: channelId,
+    text: 'external sender should not reaction tip',
+  })
+  if (!message.ts) throw new Error('Expected Slack message timestamp.')
+
+  const response = await postSlackReaction({
+    channelId,
+    messageTs: message.ts,
+    reaction: 'money_with_wings',
+    userId: Constants.slackConnect.userId,
+  })
+  const reactionTips = await db
+    .selectFrom('reaction_tip')
+    .innerJoin('workspace', 'workspace.id', 'reaction_tip.workspace_id')
+    .selectAll('reaction_tip')
+    .where('workspace.provider_id', '=', providerId)
+    .execute()
+
+  expect(response.status).toBe(200)
+  expect(reactionTips).toHaveLength(0)
+  await expectSlackPostEphemeralCall(
+    fetchSpy,
+    "Tipbot isn't installed in your Slack workspace yet.",
   )
   await expectSlackThreadMessageNotContaining(message.ts, 'tipped', { channelId })
   fetchSpy.mockRestore()
@@ -2681,7 +2981,9 @@ describe('/tip balance', () => {
     const response = await postSlashCommand('balance')
 
     expect(response.status).toBe(200)
-    await expectSlackMessage('No account connected. Run `/tip connect` first.')
+    await expectSlackMessage(
+      'No account connected. Run `<@Tipbot> connect` or `/tip connect` first.',
+    )
   })
 
   test('handles missing workspace', async () => {
@@ -2871,7 +3173,12 @@ describe('/tip usage', () => {
 ////////////////////////////////////////////////////////////////////////////
 
 async function connectTipAccounts(
-  options: { memoScope?: boolean; recipient?: boolean; tokenAddress?: `0x${string}` } = {},
+  options: {
+    memoScope?: boolean
+    recipient?: boolean
+    senderProviderUserId?: string
+    tokenAddress?: `0x${string}`
+  } = {},
 ) {
   const workspace = await db
     .selectFrom('workspace')
@@ -2889,7 +3196,7 @@ async function connectTipAccounts(
   await db.deleteFrom('access_key').where('account_id', '=', senderAccount.id).execute()
   const senderMember = await insertMember({
     account_id: senderAccount.id,
-    provider_user_id: Constants.slack.adminUserId,
+    provider_user_id: options.senderProviderUserId ?? Constants.slack.adminUserId,
     workspace_id: workspace.id,
   })
   const recipientMember =
@@ -3092,15 +3399,17 @@ async function expectSlackPostEphemeralCall(
 ) {
   await expect
     .poll(
-      () =>
-        fetchSpy.mock.calls.some((call) => {
+      async () => {
+        for (const call of fetchSpy.mock.calls) {
           const input = call[0]
           const url =
             typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-          const params = slackFetchBodyParams(call[1]?.body)
+          const params = await slackFetchCallBodyParams(...call)
           const callText = `${params.get('text') ?? ''} ${params.get('blocks') ?? ''}`
-          return url.endsWith('/chat.postEphemeral') && callText.includes(text)
-        }),
+          if (url.endsWith('/chat.postEphemeral') && callText.includes(text)) return true
+        }
+        return false
+      },
       {
         message: fetchSpy.mock.calls
           .map((call) => {
@@ -3285,6 +3594,14 @@ async function getLatestConfirmToken() {
   return token
 }
 
+async function getLatestConnectToken() {
+  const history = await slack.conversations.history({ channel: Constants.slack.channelId })
+  const message = history.messages?.find((message) => message.text?.includes('/connect/'))
+  const token = message?.text?.match(/\/connect\/([A-Za-z0-9_-]+)/)?.[1]
+  if (!token) throw new Error('Expected connection token in Slack message.')
+  return token
+}
+
 async function createSlackTestChannel(prefix: string) {
   const channel = await slack.conversations.create({
     name: `${prefix}${Nanoid.generate()
@@ -3375,6 +3692,7 @@ async function postSlackReaction(options: {
   channelId?: string
   eventId?: string
   eventTs?: string
+  itemUserId?: string
   messageTs: string
   reaction: string
   userId: string
@@ -3387,7 +3705,7 @@ async function postSlackReaction(options: {
         ts: options.messageTs,
         type: 'message',
       },
-      item_user: Constants.slack.memberUserId,
+      item_user: options.itemUserId ?? Constants.slack.memberUserId,
       reaction: options.reaction,
       type: 'reaction_added',
       user: options.userId,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -851,7 +851,12 @@ test('@Tipbot mention supports help command', async () => {
   })
 
   expect(response.status).toBe(200)
+  await expectSlackMessage('@Tipbot balance')
   await expectSlackMessage('@Tipbot connect')
+  await expectSlackMessage('@Tipbot disconnect')
+  await expectSlackMessage('@Tipbot leaderboard')
+  await expectSlackMessage('@Tipbot stats')
+  await expectSlackMessage('@Tipbot status')
   await expectSlackMessage('@Tipbot @account for coffee')
 })
 
@@ -1955,7 +1960,7 @@ test('reaction tipping sends tip from single channel guest', async () => {
       recipient_provider_user_id: Constants.slack.memberUserId,
       sender_provider_user_id: Constants.slack.singleChannelGuestUserId,
     })
-  await expectSlackThreadMessage(message.ts, 'tipped', { channelId })
+  await expectSlackThreadMessage(message.ts, 'tipped', { channelId, wait: true })
 }, 20_000) // 20 seconds
 
 test('reaction tipping blocks Slack Connect external sender', async () => {
@@ -3353,8 +3358,26 @@ async function expectSlackMessage(text: string, options: { channelId?: string } 
 async function expectSlackThreadMessage(
   messageTs: string,
   text: string,
-  options: { channelId?: string } = {},
+  options: { channelId?: string; wait?: boolean } = {},
 ) {
+  if (options.wait) {
+    await expect
+      .poll(
+        async () => {
+          const history = await slack.conversations.replies({
+            channel: options.channelId ?? Constants.slack.channelId,
+            ts: messageTs,
+          })
+          return Boolean(
+            history.ok && history.messages?.some((message) => message.text?.includes(text)),
+          )
+        },
+        { interval: 25, timeout: 5_000 }, // 25 milliseconds, 5 seconds
+      )
+      .toBe(true)
+    return
+  }
+
   const history = await slack.conversations.replies({
     channel: options.channelId ?? Constants.slack.channelId,
     ts: messageTs,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -17,6 +17,9 @@ export const slack = {
   memberUserName: 'member',
   missingChannelId: 'C000000404',
   missingUserId: 'U000000404',
+  singleChannelGuestUserEmail: 'single-channel-guest@example.com',
+  singleChannelGuestUserId: 'U000000003',
+  singleChannelGuestUserName: 'singlechannelguest',
   teamDomain: 'emulate',
   teamId: 'T000000001',
   teamName: 'Emulate',
@@ -81,6 +84,13 @@ export const seed = {
       {
         email: slack.memberUserEmail,
         name: slack.memberUserName,
+      },
+      {
+        email: slack.singleChannelGuestUserEmail,
+        is_restricted: true,
+        is_ultra_restricted: true,
+        name: slack.singleChannelGuestUserName,
+        user_id: slack.singleChannelGuestUserId,
       },
       {
         email: slackConnect.userEmail,


### PR DESCRIPTION
Adds support for single-channel guests via `@Tipbot [command]` (single-channel guests cannot use slash commands, e.g. `/tip`)