### PR TITLE
feat: support Slack usergroup tips

### DIFF
--- a/config/patches/emulate@0.5.0.patch
+++ b/config/patches/emulate@0.5.0.patch
@@ -2,7 +2,15 @@ diff --git a/dist/dist-CE6BUCWQ.js b/dist/dist-CE6BUCWQ.js
 index 6876d0e..57d3549 100644
 --- a/dist/dist-CE6BUCWQ.js
 +++ b/dist/dist-CE6BUCWQ.js
-@@ -76,6 +76,38 @@ function authRoutes(ctx) {
+@@ -11,6 +11,7 @@
+   return {
+     teams: store.collection("slack.teams", ["team_id"]),
+     users: store.collection("slack.users", ["user_id", "email"]),
++    usergroups: store.collection("slack.usergroups", ["usergroup_id", "handle"]),
+     channels: store.collection("slack.channels", ["channel_id", "name"]),
+     messages: store.collection("slack.messages", ["ts", "channel_id"]),
+     bots: store.collection("slack.bots", ["bot_id"]),
+@@ -76,6 +77,39 @@
  function chatRoutes(ctx) {
    const { app, store, webhooks } = ctx;
    const ss = () => getSlackStore(store);
@@ -28,6 +36,7 @@ index 6876d0e..57d3549 100644
 +      text,
 +      type: "message",
 +      subtype: "ephemeral",
++      blocks: typeof body.blocks === "string" ? JSON.parse(body.blocks) : Array.isArray(body.blocks) ? body.blocks : void 0,
 +      thread_ts,
 +      reply_count: 0,
 +      reply_users: [],
@@ -41,7 +50,7 @@ index 6876d0e..57d3549 100644
    app.post("/api/chat.postMessage", async (c) => {
      const authUser = c.get("authUser");
      if (!authUser) return slackError(c, "not_authed");
-@@ -336,6 +368,15 @@ function formatChannel(ch) {
+@@ -336,6 +370,15 @@
      is_channel: ch.is_channel,
      is_private: ch.is_private,
      is_archived: ch.is_archived,
@@ -57,7 +66,15 @@ index 6876d0e..57d3549 100644
      topic: ch.topic,
      purpose: ch.purpose,
      creator: ch.creator,
-@@ -415,6 +456,8 @@ function formatUser(u) {
+@@ -350,6 +393,7 @@
+     text: msg.text,
+     ts: msg.ts,
+     ...msg.subtype ? { subtype: msg.subtype } : {},
++    ...Array.isArray(msg.blocks) ? { blocks: msg.blocks } : {},
+     ...msg.thread_ts ? { thread_ts: msg.thread_ts } : {},
+     ...msg.reply_count > 0 ? { reply_count: msg.reply_count, reply_users: msg.reply_users } : {},
+     ...msg.reactions.length > 0 ? { reactions: msg.reactions } : {}
+@@ -404,11 +448,29 @@
      name: u.name,
      real_name: u.real_name,
      is_admin: u.is_admin,
@@ -66,7 +83,28 @@ index 6876d0e..57d3549 100644
      is_bot: u.is_bot,
      deleted: u.deleted,
      profile: u.profile
-@@ -1322,16 +1365,48 @@ function seedFromConfig(store, _baseUrl, config) {
+   };
+ }
++function usergroupsRoutes(ctx) {
++  const { app, store } = ctx;
++  const ss = () => getSlackStore(store);
++  app.post("/api/usergroups.users.list", async (c) => {
++    const authUser = c.get("authUser");
++    if (!authUser) return slackError(c, "not_authed");
++    const body = await parseSlackBody(c);
++    const usergroupId = typeof body.usergroup === "string" ? body.usergroup : "";
++    const usergroup = ss().usergroups.findOneBy("usergroup_id", usergroupId) ?? ss().usergroups.findOneBy("handle", usergroupId.replace(/^@/, ""));
++    if (!usergroup) return slackError(c, "usergroup_not_found");
++    return slackOk(c, {
++      users: Array.isArray(usergroup.users) ? usergroup.users : [],
++      response_metadata: { next_cursor: "" }
++    });
++  });
++}
+ function reactionsRoutes(ctx) {
+   const { app, store, webhooks } = ctx;
+   const ss = () => getSlackStore(store);
+@@ -1322,17 +1384,49 @@
    const teamId = team?.team_id ?? "T000000001";
    if (config.users) {
      for (const u of config.users) {
@@ -119,7 +157,8 @@ index 6876d0e..57d3549 100644
 +        is_ultra_restricted: u.is_ultra_restricted ?? false,
          is_bot: false,
          deleted: false,
-@@ -1347,18 +1420,42 @@ function seedFromConfig(store, _baseUrl, config) {
+         profile: {
+@@ -1347,18 +1441,42 @@
    }
    if (config.channels) {
      for (const ch of config.channels) {
@@ -166,3 +205,49 @@ index 6876d0e..57d3549 100644
          topic: { value: ch.topic ?? "", creator, last_set: now },
          purpose: { value: ch.purpose ?? "", creator, last_set: now },
          members: ss.users.all().map((u) => u.user_id),
+@@ -1367,6 +1485,30 @@
+       });
+     }
+   }
++  if (config.usergroups) {
++    for (const ug of config.usergroups) {
++      const existing = ug.usergroup_id ? ss.usergroups.findOneBy("usergroup_id", ug.usergroup_id) : ss.usergroups.findOneBy("handle", ug.handle);
++      if (existing) {
++        ss.usergroups.update(existing.id, {
++          handle: ug.handle ?? existing.handle,
++          is_disabled: ug.is_disabled ?? existing.is_disabled,
++          name: ug.name ?? existing.name,
++          team_id: ug.team_id ?? existing.team_id,
++          usergroup_id: ug.usergroup_id ?? existing.usergroup_id,
++          users: ug.users ?? existing.users
++        });
++        continue;
++      }
++      ss.usergroups.insert({
++        usergroup_id: ug.usergroup_id ?? generateSlackId("S"),
++        team_id: ug.team_id ?? teamId,
++        handle: ug.handle,
++        name: ug.name ?? ug.handle,
++        is_disabled: ug.is_disabled ?? false,
++        users: ug.users ?? []
++      });
++    }
++  }
+   if (config.bots) {
+     for (const b of config.bots) {
+       const existing = ss.bots.all().find((eb) => eb.name === b.name);
+@@ -1418,6 +1560,7 @@
+     chatRoutes(ctx);
+     conversationsRoutes(ctx);
+     usersRoutes(ctx);
++    usergroupsRoutes(ctx);
+     reactionsRoutes(ctx);
+     teamRoutes(ctx);
+     oauthRoutes(ctx);
+@@ -1435,4 +1578,4 @@
+   seedFromConfig,
+   slackPlugin
+ };
+-//# sourceMappingURL=dist-CE6BUCWQ.js.map
+\ No newline at end of file
++//# sourceMappingURL=dist-CE6BUCWQ.js.map

--- a/config/vite.ts
+++ b/config/vite.ts
@@ -78,6 +78,7 @@ const slackScopes = [
   'groups:read',
   'reactions:read',
   'reactions:write',
+  'usergroups:read',
   'users:read',
 ]
 
@@ -94,6 +95,20 @@ const emulatorConfig = {
           {
             email: 'member@example.com',
             name: 'member',
+            user_id: 'U000000002',
+          },
+          {
+            email: 'unconnected@example.com',
+            name: 'unconnected',
+            user_id: 'U000000003',
+          },
+        ],
+        usergroups: [
+          {
+            handle: 'engineering',
+            name: 'engineering',
+            usergroup_id: 'SENGINEERING',
+            users: ['U000000001', 'U000000002', 'U000000003'],
           },
         ],
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ patchedDependencies:
   '@chat-adapter/slack@4.27.0': f129c43965d79b15a626b2f5e493aee5ae9b5638ff12257bd4cf6cecb048d1dd
   '@slack/web-api@7.15.2': 97b9149f438abff67b083a9f281917a3b7e1d3133ca6b8be85c6e6ba78b591ae
   '@tanstack/react-start@1.167.65': c2ace716aae8d228b9e34c7f0029a2c2471417d45b6c7823b22943889cfba6a2
-  emulate@0.5.0: 81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691
+  emulate@0.5.0: 5487ebdec35d0647d4040b82c9de0ddf4e699e46224af33e558a8b67340adec9
   prool@0.2.4: 242ad315de9eb06e5a654896de221f947e3f0f5f318b55d898191bfad0a9530f
 
 importers:
@@ -138,7 +138,7 @@ importers:
         version: 12.9.0
       emulate:
         specifier: 0.5.0
-        version: 0.5.0(patch_hash=81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691)(hono@4.12.18)
+        version: 0.5.0(patch_hash=5487ebdec35d0647d4040b82c9de0ddf4e699e46224af33e558a8b67340adec9)(hono@4.12.18)
       msw:
         specifier: 2.13.6
         version: 2.13.6(@types/node@22.19.17)(typescript@6.0.3)
@@ -6018,7 +6018,7 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  emulate@0.5.0(patch_hash=81e2f05216044c2ae5b3eafb6e094b3c5e288911a903f3429d2b705a89b15691)(hono@4.12.18):
+  emulate@0.5.0(patch_hash=5487ebdec35d0647d4040b82c9de0ddf4e699e46224af33e558a8b67340adec9)(hono@4.12.18):
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       commander: 14.0.3

--- a/scripts/slack.ts
+++ b/scripts/slack.ts
@@ -21,6 +21,7 @@ const scopeReasons = {
     'Read messages Tipbot is asked to act on in private channels where Tipbot has been added.',
   'groups:read': 'Check private channel metadata where Tipbot has been added.',
   'reactions:read': 'Detect configured tip reaction emoji and identify the message being tipped.',
+  'usergroups:read': 'Expand Slack user groups like @engineering into eligible tip recipients.',
   'users:read': 'Resolve Slack users for mentions, admin checks, and connected account status.',
 } as const
 const eventReasons = {
@@ -108,6 +109,7 @@ function createManifest() {
           'groups:history',
           'groups:read',
           'reactions:read',
+          'usergroups:read',
           'users:read',
         ],
       },

--- a/src/api.ts
+++ b/src/api.ts
@@ -390,6 +390,7 @@ export const api = new Hono<{
         accessKeyPublicKey: data.accessKey.publicKey as `0x${string}`,
         amount: formatAmount(data.payload.amount),
         chainId: data.payload.chainId,
+        groupLabel: data.payload.groupLabel,
         kind: data.payload.kind,
         memo: data.payload.memo,
         ok: true as const,
@@ -401,6 +402,7 @@ export const api = new Hono<{
             recipientProviderUserId: data.payload.recipientProviderUserId,
           },
         ],
+        skippedRecipients: data.payload.skippedRecipients ?? [],
         tokenAddress: Address.checksum(data.payload.tokenAddress),
         tokenCurrency: metadata.currency,
         tokenSymbol: metadata.symbol,
@@ -506,7 +508,22 @@ export const api = new Hono<{
                 : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
               const text =
                 'recipients' in result
-                  ? `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} ${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${result.recipients.map((recipient) => `• <@${recipient.recipientProviderUserId}>`).join('\n')}`
+                  ? `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} ${data.payload.groupLabel ? `@${data.payload.groupLabel} ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
+                      ...result.recipients.map(
+                        (recipient) => `• <@${recipient.recipientProviderUserId}>`,
+                      ),
+                      ...(data.payload.skippedRecipients ?? [])
+                        .slice(0, 10)
+                        .map(
+                          (recipient) =>
+                            `• <@${recipient.recipientProviderUserId}> (${recipient.reason === 'you' ? 'you' : 'not connected yet'})`,
+                        ),
+                      ...((data.payload.skippedRecipients?.length ?? 0) > 10
+                        ? [
+                            `…and ${(data.payload.skippedRecipients?.length ?? 0) - 10} more not connected yet`,
+                          ]
+                        : []),
+                    ].join('\n')}`
                   : `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} <@${result.recipientProviderUserId}> ${amount}${result.memo ? ` for ${result.memo}` : ''}.`
               const receiptText = text.replace(/\.$/, '')
               const receiptLink = `<${Tempo.formatTxLink(result.chainId, result.transactionHash)}|Receipt>`
@@ -859,6 +876,7 @@ export const api = new Hono<{
         'groups:history',
         'groups:read',
         'reactions:read',
+        'usergroups:read',
         'users:read',
       ].join(','),
     )

--- a/src/api.ts
+++ b/src/api.ts
@@ -390,6 +390,7 @@ export const api = new Hono<{
         accessKeyPublicKey: data.accessKey.publicKey as `0x${string}`,
         amount: formatAmount(data.payload.amount),
         chainId: data.payload.chainId,
+        groupId: data.payload.groupId,
         groupLabel: data.payload.groupLabel,
         kind: data.payload.kind,
         memo: data.payload.memo,
@@ -508,7 +509,7 @@ export const api = new Hono<{
                 : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
               const text =
                 'recipients' in result
-                  ? `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} ${data.payload.groupLabel ? `@${data.payload.groupLabel} ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
+                  ? `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} ${data.payload.groupId ? `<!subteam^${data.payload.groupId}${data.payload.groupLabel ? `|@${data.payload.groupLabel}` : ''}> ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
                       ...result.recipients.map(
                         (recipient) => `• <@${recipient.recipientProviderUserId}>`,
                       ),

--- a/src/api.workers.test.ts
+++ b/src/api.workers.test.ts
@@ -218,7 +218,7 @@ describe('/api/chat/slack/install', () => {
       `https://${env.HOST}/api/chat/slack/oauth/callback`,
     )
     expect(url.searchParams.get('scope')).toBe(
-      'app_mentions:read,assistant:write,channels:history,channels:read,chat:write,commands,emoji:read,groups:history,groups:read,reactions:read,users:read',
+      'app_mentions:read,assistant:write,channels:history,channels:read,chat:write,commands,emoji:read,groups:history,groups:read,reactions:read,usergroups:read,users:read',
     )
     expect(url.searchParams.get('state')).toMatch(/^[^.]+\.[^.]+$/)
   })

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -367,6 +367,7 @@ const actions = {
       skippedRecipients: pending.skippedRecipients,
       source: pending.source,
       tokenAddress: pending.tokenAddress,
+      usergroupId: pending.usergroupId,
       usergroupLabel: pending.usergroupLabel,
     }).catch(
       (error) =>
@@ -1116,6 +1117,7 @@ const handlers = {
         skippedRecipients: plan.skippedRecipients,
         source: options.mention ? 'mention' : 'command',
         tokenAddress: tokenAddress ?? undefined,
+        usergroupId: plan.usergroupId,
         usergroupLabel: plan.usergroupLabel,
       })
       return
@@ -1129,7 +1131,7 @@ const handlers = {
       })
     try {
       const result = await (
-        plan.recipients.length === 1 && !plan.usergroupLabel
+        plan.recipients.length === 1 && !plan.usergroupId
           ? Tip.handleTipRequest(env, {
               amount: parsed.amount,
               idempotencyKey: options.idempotencyKey,
@@ -1157,6 +1159,7 @@ const handlers = {
               skippedRecipients: plan.skippedRecipients,
               source: options.mention ? 'mention' : 'command',
               tokenAddress: tokenAddress ?? undefined,
+              usergroupId: plan.usergroupId,
               usergroupLabel: plan.usergroupLabel,
             })
       ).catch(
@@ -1171,6 +1174,7 @@ const handlers = {
       if (result.ok && result.status === 'sent' && 'recipients' in result) {
         await postTipResult(event, ctx, result, {
           skippedRecipients: plan.skippedRecipients,
+          usergroupId: plan.usergroupId,
           usergroupLabel: plan.usergroupLabel,
         })
       } else if (result.ok && result.status === 'sent' && !('recipients' in result)) {
@@ -1350,6 +1354,7 @@ type PendingSlackTip = {
   skippedRecipients?: Tip.TipSkippedRecipient[]
   source: 'command' | 'mention' | 'reaction'
   tokenAddress?: string
+  usergroupId?: string
   usergroupLabel?: string
 }
 
@@ -1412,6 +1417,7 @@ async function resolveSlackTipPlan(
       previewRequired: boolean
       recipients: Tip.TipRecipientInput[]
       skippedRecipients: Tip.TipSkippedRecipient[]
+      usergroupId?: string
       usergroupLabel?: string
     }
   | { message: string; ok: false }
@@ -1513,11 +1519,10 @@ async function resolveSlackTipPlan(
   }
 
   if (recipients.length === 0) {
-    const usergroupLabel =
-      parsed.usergroups?.[0]?.providerUsergroupLabel ?? parsed.usergroups?.[0]?.providerUsergroupId
+    const usergroup = parsed.usergroups?.[0]
     return {
-      message: usergroupLabel
-        ? `Payment not sent. None of the members of @${usergroupLabel} are connected to Tipbot yet.`
+      message: usergroup
+        ? `Payment not sent. None of the members of ${formatSlackUsergroupMention(usergroup.providerUsergroupId, usergroup.providerUsergroupLabel)} are connected to Tipbot yet.`
         : 'Payment not sent. None of the mentioned accounts are connected to Tipbot yet.',
       ok: false,
     }
@@ -1539,8 +1544,8 @@ async function resolveSlackTipPlan(
       groupPreviewRequired || (!parsed.usergroups?.length && skippedRecipients.length > 0),
     recipients,
     skippedRecipients,
-    usergroupLabel:
-      parsed.usergroups?.[0]?.providerUsergroupLabel ?? parsed.usergroups?.[0]?.providerUsergroupId,
+    usergroupId: parsed.usergroups?.[0]?.providerUsergroupId,
+    usergroupLabel: parsed.usergroups?.[0]?.providerUsergroupLabel,
   }
 }
 
@@ -2374,6 +2379,10 @@ function parseSlackMentionTipText(text: string) {
   return text.slice(target.index).trim()
 }
 
+function formatSlackUsergroupMention(usergroupId: string, usergroupLabel?: string) {
+  return `<!subteam^${usergroupId}${usergroupLabel ? `|@${usergroupLabel}` : ''}>`
+}
+
 function hasInvalidMentionIntent(text: string) {
   return /\b(connect|configure|get started|install|link|mine|set ?up|start|tip|send|pay|sent|paid|for|thank you|thanks|ty|thx|thank u|creature|creatures|dragon|dragons|elf|elves|fae|fairy|goblin|goblins|gnome|gnomes|gremlin|gremlins|kobold|kobolds|monster|monsters|orc|orcs|troll|trolls)\b/i.test(
     text,
@@ -2759,7 +2768,7 @@ async function postSlackTipPreview(
       children: [
         chat.CardText(
           [
-            `You’re about to tip ${pending.usergroupLabel ? `@${pending.usergroupLabel} ` : ''}${pending.recipients.length} accounts ${pending.amountText} each${pending.memo ? ` for ${pending.memo}` : ''}.`,
+            `You’re about to tip ${pending.usergroupId ? `${formatSlackUsergroupMention(pending.usergroupId, pending.usergroupLabel)} ` : ''}${pending.recipients.length} accounts ${pending.amountText} each${pending.memo ? ` for ${pending.memo}` : ''}.`,
             ...(totalAmount ? [`Total: ${totalAmount}`] : []),
             '',
             '*Recipients:*',
@@ -2783,7 +2792,11 @@ async function postTipResult(
   event: TipEvent,
   ctx: HandlerContext,
   result: Tip.TipBatchResult,
-  options: { skippedRecipients?: Tip.TipSkippedRecipient[]; usergroupLabel?: string } = {},
+  options: {
+    skippedRecipients?: Tip.TipSkippedRecipient[]
+    usergroupId?: string
+    usergroupLabel?: string
+  } = {},
 ) {
   if (!result.ok) {
     if (result.code === 'confirmation_required' && result.confirmUrl) {
@@ -2842,7 +2855,7 @@ async function postTipResult(
     await postSlackReceiptMessage(
       event,
       ctx,
-      `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${options.usergroupLabel ? `@${options.usergroupLabel} ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
+      `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${options.usergroupId ? `${formatSlackUsergroupMention(options.usergroupId, options.usergroupLabel)} ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
         ...result.recipients.map(
           (recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`,
         ),

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1494,11 +1494,6 @@ async function resolveSlackTipPlan(
     if (target.recipient.recipientProviderUserId === event.user.userId) {
       if (target.source === 'explicit')
         return { message: 'Payment not sent. Cannot send a payment to yourself.', ok: false }
-      skippedRecipients.push({
-        reason: 'you',
-        recipientProviderLabel: target.recipient.recipientProviderLabel,
-        recipientProviderUserId: target.recipient.recipientProviderUserId,
-      })
       continue
     }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -318,6 +318,80 @@ const actions = {
   async confirm_cancel(event) {
     await event.adapter.deleteMessage(event.threadId, event.messageId)
   },
+  async confirm_tip(event) {
+    const token = z.safeParse(z.string().min(1), event.value)
+    if (!token.success) return
+
+    const pending = await (async () => {
+      // Load the pending preview created by the Slack confirmation prompt.
+      const state = createCloudflareState({
+        name: 'tipbot',
+        namespace: env.CHAT_STATE,
+        shardKey(threadId) {
+          return threadId.split(':', 1)[0] || 'default'
+        },
+      })
+      await state.connect()
+      const value = await state.get<PendingSlackTip>(`pending_tip:${token.data}`)
+      await state.disconnect()
+      return value
+    })()
+    if (!pending) {
+      await event.adapter.deleteMessage(event.threadId, event.messageId)
+      return
+    }
+    if (pending.senderProviderUserId !== event.user.userId) return
+
+    await event.adapter.deleteMessage(event.threadId, event.messageId)
+    const tipEvent = {
+      channel: getChat().channel(pending.providerChannelId),
+      threadTs: pending.providerThreadId,
+      user: event.user,
+    } satisfies TipEvent
+    const ctx = {
+      db: DB.create(env.DB),
+      provider: { id: pending.providerId, type: 'slack' },
+      text: '',
+      threadTs: pending.providerThreadId,
+    } satisfies HandlerContext
+    const result = await Tip.handleTipBatchRequest(env, {
+      amount: pending.amount,
+      idempotencyKey: pending.idempotencyKey,
+      memo: pending.memo,
+      provider: 'slack',
+      providerChannelId: pending.providerChannelId,
+      providerId: pending.providerId,
+      providerThreadId: pending.providerThreadId,
+      recipients: pending.recipients,
+      senderProviderUserId: pending.senderProviderUserId,
+      skippedRecipients: pending.skippedRecipients,
+      source: pending.source,
+      tokenAddress: pending.tokenAddress,
+      usergroupLabel: pending.usergroupLabel,
+    }).catch(
+      (error) =>
+        ({
+          code: 'failed',
+          message: error instanceof Error ? error.message : 'Command failed.',
+          ok: false,
+        }) satisfies Tip.TipBatchResult,
+    )
+    await (async () => {
+      // Delete the pending preview after one confirmation attempt so stale Slack buttons cannot
+      // be retried.
+      const state = createCloudflareState({
+        name: 'tipbot',
+        namespace: env.CHAT_STATE,
+        shardKey(threadId) {
+          return threadId.split(':', 1)[0] || 'default'
+        },
+      })
+      await state.connect()
+      await state.delete(`pending_tip:${token.data}`)
+      await state.disconnect()
+    })()
+    await postTipResult(tipEvent, ctx, result, pending)
+  },
 } as const satisfies Record<
   (typeof actionNames)[number],
   (event: chat.ActionEvent) => Promise<void>
@@ -690,7 +764,7 @@ const handlers = {
     })
     if (received.length === 0 && sent.length === 0) {
       const channel = ctx.threadTs
-        ? getChat().channel(`slack:${getSlackChannelId(event.channel.id)}:${ctx.threadTs}`)
+        ? getChat().channel(`slack:${Slack.getChannelId(event.channel.id)}:${ctx.threadTs}`)
         : event.channel
       await channel.post('No confirmed tips yet.')
       return
@@ -1001,141 +1075,49 @@ const handlers = {
         })
       return
     }
-    const recipients = await (async (): Promise<
-      { ok: true; value: Tip.TipRecipientInput[] } | { message: string; ok: false }
-    > => {
-      if (ctx.provider.type !== 'slack') return { ok: true, value: parsed.recipients }
-      const installation = await getSlack().getInstallation(ctx.provider.id)
-      if (!installation) return { ok: true, value: parsed.recipients }
-
-      const body = new URLSearchParams()
-      body.set('channel', event.channel.id.replace(/^slack:/, ''))
-      const response = await getSlack().withBotToken(installation.botToken, () =>
-        fetch(`${env.SLACK_API_URL}/conversations.info`, {
-          body,
-          headers: { authorization: `Bearer ${installation.botToken}` },
-          method: 'POST',
-        }),
-      )
-      const conversation = z.parse(
-        z.object({
-          channel: z
-            .object({
-              context_team_id: z.string().optional(),
-              is_ext_shared: z.boolean().optional(),
-              is_shared: z.boolean().optional(),
-              shared_team_ids: z.array(z.string()).optional(),
-            })
-            .optional(),
-          ok: z.boolean().optional(),
-        }),
-        await response.json(),
-      )
-      const isSharedChannel =
-        conversation.channel?.is_ext_shared ||
-        conversation.channel?.is_shared ||
-        conversation.channel?.shared_team_ids?.some(
-          (teamId) => teamId !== conversation.channel?.context_team_id,
-        )
-      if (!conversation.ok || !conversation.channel || !isSharedChannel)
-        return { ok: true, value: parsed.recipients }
-
-      const tokenTeamIds = new Set(
-        [
-          ctx.provider.id,
-          conversation.channel.context_team_id,
-          ...(conversation.channel.shared_team_ids ?? []),
-        ].filter((teamId) => teamId !== undefined),
-      )
-      const value = [] as Tip.TipRecipientInput[]
-      for (const recipient of parsed.recipients) {
-        const candidates = [...tokenTeamIds].map((tokenTeamId) => ({
-          providerUserId: recipient.recipientProviderUserId,
-          providerWorkspaceId: tokenTeamId,
-        }))
-        for (const tokenTeamId of tokenTeamIds) {
-          const tokenInstallation = await getSlack().getInstallation(tokenTeamId)
-          if (!tokenInstallation) continue
-          const userBody = new URLSearchParams()
-          userBody.set('user', recipient.recipientProviderUserId)
-          const userResponse = await getSlack().withBotToken(tokenInstallation.botToken, () =>
-            fetch(`${env.SLACK_API_URL}/users.info`, {
-              body: userBody,
-              headers: { authorization: `Bearer ${tokenInstallation.botToken}` },
-              method: 'POST',
-            }),
-          )
-          const info = z.parse(
-            z.object({
-              ok: z.boolean().optional(),
-              user: z
-                .object({
-                  id: z.string().optional(),
-                  team_id: z.string().optional(),
-                })
-                .optional(),
-            }),
-            await userResponse.json(),
-          )
-          if (!info.ok || !info.user?.id || !info.user.team_id) continue
-          candidates.push({
-            providerUserId: info.user.id,
-            providerWorkspaceId: info.user.team_id,
-          })
+    const shouldResolvePlan =
+      parsed.recipients.length !== 1 ||
+      Boolean(parsed.usergroups?.length) ||
+      (await (async () => {
+        // Single-recipient Slack Connect tips still need workspace-safe recipient resolution.
+        const installation = await getSlack().getInstallation(ctx.provider.id)
+        if (!installation) return false
+        return (await getSlackConversationInfo(installation.botToken, event.channel.id)).isShared
+      })().catch(() => false))
+    const plan = !shouldResolvePlan
+      ? {
+          ok: true as const,
+          previewRequired: false,
+          recipients: parsed.recipients,
+          skippedRecipients: [],
         }
-
-        const seen = new Set<string>()
-        const matches = [] as Array<{ providerUserId: string; providerWorkspaceId: string }>
-        for (const candidate of candidates) {
-          const key = `${candidate.providerWorkspaceId}:${candidate.providerUserId}`
-          if (seen.has(key)) continue
-          seen.add(key)
-          const candidateWorkspace = await ctx.db
-            .selectFrom('workspace')
-            .select('id')
-            .where('provider', '=', 'slack')
-            .where('provider_id', '=', candidate.providerWorkspaceId)
-            .executeTakeFirst()
-          if (!candidateWorkspace) continue
-          const candidateMember = await ctx.db
-            .selectFrom('member')
-            .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
-            .innerJoin('account', 'account.id', 'provider_identity.account_id')
-            .select('member.id')
-            .where('member.provider_user_id', '=', candidate.providerUserId)
-            .where('member.workspace_id', '=', candidateWorkspace.id)
-            .executeTakeFirst()
-          if (candidateMember) matches.push(candidate)
-        }
-        if (matches.length === 0) {
-          const connectedMembers = await ctx.db
-            .selectFrom('member')
-            .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
-            .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
-            .innerJoin('account', 'account.id', 'provider_identity.account_id')
-            .select([
-              'member.provider_user_id as providerUserId',
-              'workspace.provider_id as providerWorkspaceId',
-            ])
-            .where('member.provider_user_id', '=', recipient.recipientProviderUserId)
-            .where('workspace.provider', '=', 'slack')
-            .execute()
-          if (connectedMembers.length === 1) matches.push(connectedMembers[0]!)
-        }
-        if (matches.length !== 1)
-          return {
-            message:
-              matches.length === 0
-                ? `Payment not sent. <@${recipient.recipientProviderUserId}> needs to install or connect Tipbot in their Slack workspace before receiving Slack Connect payments.`
-                : `Payment not sent. <@${recipient.recipientProviderUserId}> could not be resolved safely across Slack workspaces.`,
-            ok: false,
-          }
-        value.push({ ...recipient, recipientProviderWorkspaceId: matches[0]!.providerWorkspaceId })
-      }
-      return { ok: true, value }
-    })()
-    if (!recipients.ok) {
-      await postPrivateReply(event, event.user, recipients.message)
+      : await resolveSlackTipPlan(event, ctx, parsed, {
+          amountEach: parsed.amount ?? workspace?.default_amount,
+        })
+    if (!plan.ok) {
+      await postPrivateReply(event, event.user, plan.message)
+      return
+    }
+    if (plan.previewRequired) {
+      await postSlackTipPreview(event, {
+        amount: parsed.amount,
+        amountText: parsed.amount
+          ? formatCurrencyAmount(formatAmount(parsed.amount), 'USD')
+          : workspace?.default_amount
+            ? formatCurrencyAmount(formatAmount(workspace.default_amount), 'USD')
+            : 'the default amount',
+        idempotencyKey: options.idempotencyKey,
+        memo: parsed.memo,
+        providerChannelId: event.channel.id,
+        providerId: ctx.provider.id,
+        providerThreadId: options.threadTs,
+        recipients: plan.recipients,
+        senderProviderUserId: event.user.userId,
+        skippedRecipients: plan.skippedRecipients,
+        source: options.mention ? 'mention' : 'command',
+        tokenAddress: tokenAddress ?? undefined,
+        usergroupLabel: plan.usergroupLabel,
+      })
       return
     }
 
@@ -1147,7 +1129,7 @@ const handlers = {
       })
     try {
       const result = await (
-        parsed.recipients.length === 1
+        plan.recipients.length === 1 && !plan.usergroupLabel
           ? Tip.handleTipRequest(env, {
               amount: parsed.amount,
               idempotencyKey: options.idempotencyKey,
@@ -1156,9 +1138,9 @@ const handlers = {
               providerChannelId: event.channel.id,
               providerId: ctx.provider.id,
               providerThreadId: options.threadTs,
-              recipientProviderLabel: recipients.value[0]?.recipientProviderLabel,
-              recipientProviderUserId: recipients.value[0]!.recipientProviderUserId,
-              recipientProviderWorkspaceId: recipients.value[0]?.recipientProviderWorkspaceId,
+              recipientProviderLabel: plan.recipients[0]?.recipientProviderLabel,
+              recipientProviderUserId: plan.recipients[0]!.recipientProviderUserId,
+              recipientProviderWorkspaceId: plan.recipients[0]?.recipientProviderWorkspaceId,
               senderProviderUserId: event.user.userId,
               tokenAddress: tokenAddress ?? undefined,
             })
@@ -1170,10 +1152,12 @@ const handlers = {
               providerChannelId: event.channel.id,
               providerId: ctx.provider.id,
               providerThreadId: options.threadTs,
-              recipients: recipients.value,
+              recipients: plan.recipients,
               senderProviderUserId: event.user.userId,
+              skippedRecipients: plan.skippedRecipients,
               source: options.mention ? 'mention' : 'command',
               tokenAddress: tokenAddress ?? undefined,
+              usergroupLabel: plan.usergroupLabel,
             })
       ).catch(
         (error) =>
@@ -1185,23 +1169,10 @@ const handlers = {
       )
 
       if (result.ok && result.status === 'sent' && 'recipients' in result) {
-        const amount = result.isDefaultToken
-          ? formatCurrencyAmount(result.amount, result.tokenCurrency)
-          : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
-        await postSlackReceiptMessage(
-          event,
-          ctx,
-          `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${result.recipients.map((recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`).join('\n')}`,
-          result.chainId,
-          result.transactionHash,
-          undefined,
-          result.feePayer === 'sender'
-            ? 'Fee sponsor unavailable; fee paid from your balance.'
-            : undefined,
-          options.threadTs,
-        )
-        if (result.memo && options.threadTs)
-          await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
+        await postTipResult(event, ctx, result, {
+          skippedRecipients: plan.skippedRecipients,
+          usergroupLabel: plan.usergroupLabel,
+        })
       } else if (result.ok && result.status === 'sent' && !('recipients' in result)) {
         await postSlackReceiptMessage(
           event,
@@ -1265,11 +1236,11 @@ const handlers = {
           if (result.code === 'self_tip')
             return 'Payment not sent. Cannot send a payment to yourself.'
           if (result.code === 'recipient_unconnected')
-            return `Payment not sent. ${event.channel.mentionUser(result.recipientProviderUserId ?? recipients.value[0]!.recipientProviderUserId)} needs to connect Tipbot before receiving payments.`
+            return `Payment not sent. ${event.channel.mentionUser(result.recipientProviderUserId ?? plan.recipients[0]!.recipientProviderUserId)} needs to connect Tipbot before receiving payments.`
           if (result.code === 'pending') return 'Payment still sending.'
           if (result.code === 'insufficient_funds')
             return 'Payment not sent. Your wallet has insufficient funds.'
-          return 'Payment failed.'
+          return result.message ?? 'Payment failed.'
         })()
         if (result.code === 'insufficient_funds') {
           await postSlackInsufficientFunds(
@@ -1322,7 +1293,7 @@ const commandNames = [
   'status',
 ] as const
 const commandPattern = new RegExp(`^(${commandNames.join('|')})(?:\\s+([\\s\\S]*))?$`)
-const actionNames = ['config_edit', 'connect_cancel', 'confirm_cancel'] as const
+const actionNames = ['config_edit', 'connect_cancel', 'confirm_cancel', 'confirm_tip'] as const
 const modalSubmitNames = ['config_edit'] as const
 const tokenOptions = [
   { address: Tempo.addressLookup.pathUsd, label: 'PathUSD', value: 'pathUSD' },
@@ -1366,6 +1337,23 @@ type LeaderboardRow = {
   providerUserId: string
   tipCount: number
 }
+
+type PendingSlackTip = {
+  amount?: number
+  idempotencyKey: string
+  memo: string | null
+  providerChannelId: string
+  providerId: string
+  providerThreadId?: string
+  recipients: Tip.TipRecipientInput[]
+  senderProviderUserId: string
+  skippedRecipients?: Tip.TipSkippedRecipient[]
+  source: 'command' | 'mention' | 'reaction'
+  tokenAddress?: string
+  usergroupLabel?: string
+}
+
+type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
 
@@ -1411,6 +1399,297 @@ async function setSlackAssistantThreadStatus(
     headers: { authorization: `Bearer ${installation.botToken}` },
     method: 'POST',
   })
+}
+
+async function resolveSlackTipPlan(
+  event: TipEvent,
+  ctx: HandlerContext,
+  parsed: ParsedTipBatch,
+  options: { amountEach?: number } = {},
+): Promise<
+  | {
+      ok: true
+      previewRequired: boolean
+      recipients: Tip.TipRecipientInput[]
+      skippedRecipients: Tip.TipSkippedRecipient[]
+      usergroupLabel?: string
+    }
+  | { message: string; ok: false }
+> {
+  if (ctx.provider.type !== 'slack')
+    return {
+      ok: true,
+      previewRequired: false,
+      recipients: parsed.recipients,
+      skippedRecipients: [],
+    }
+  if (
+    parsed.recipients.some((recipient) => recipient.recipientProviderUserId === event.user.userId)
+  )
+    return { message: 'Payment not sent. Cannot send a payment to yourself.', ok: false }
+
+  const installation = await getSlack().getInstallation(ctx.provider.id)
+  if (!installation)
+    return {
+      ok: true,
+      previewRequired: false,
+      recipients: parsed.recipients,
+      skippedRecipients: [],
+    }
+
+  const conversation = await getSlackConversationInfo(installation.botToken, event.channel.id)
+  if (parsed.usergroups?.length && conversation.isShared)
+    return {
+      message:
+        'Group tips are not supported in Slack Connect channels yet; mention individual recipients instead.',
+      ok: false,
+    }
+
+  const targets: Array<{ recipient: Tip.TipRecipientInput; source: 'explicit' | 'usergroup' }> =
+    parsed.recipients.map((recipient) => ({
+      recipient,
+      source: 'explicit' as const,
+    }))
+  for (const usergroup of parsed.usergroups ?? []) {
+    const response = await getSlack().withBotToken(installation.botToken, () => {
+      const body = new URLSearchParams()
+      body.set('usergroup', usergroup.providerUsergroupId)
+      return fetch(`${env.SLACK_API_URL}/usergroups.users.list`, {
+        body,
+        headers: { authorization: `Bearer ${installation.botToken}` },
+        method: 'POST',
+      })
+    })
+    const json = z.parse(
+      z.object({
+        ok: z.boolean().optional(),
+        users: z.array(z.string()).optional(),
+      }),
+      await response.json(),
+    )
+    if (!json.ok)
+      return {
+        message: `Payment not sent. I could not read @${usergroup.providerUsergroupLabel ?? usergroup.providerUsergroupId}.`,
+        ok: false,
+      }
+    // Slack usergroups.users.list is treated as authoritative flat membership; no recursive
+    // usergroup expansion.
+    for (const providerUserId of json.users ?? []) {
+      if (!/^[UW][A-Z0-9_]+$/.test(providerUserId)) continue
+      const user = await getSlackUserInfo(installation.botToken, providerUserId)
+      if (!user || user.deleted || user.is_app_user || user.is_bot) continue
+      targets.push({
+        recipient: { recipientProviderUserId: providerUserId },
+        source: 'usergroup' as const,
+      })
+    }
+  }
+
+  const recipients = [] as Tip.TipRecipientInput[]
+  const skippedRecipients = [] as Tip.TipSkippedRecipient[]
+  const seen = new Set<string>()
+  for (const target of targets) {
+    if (seen.has(target.recipient.recipientProviderUserId)) continue
+    seen.add(target.recipient.recipientProviderUserId)
+    if (target.recipient.recipientProviderUserId === event.user.userId) {
+      if (target.source === 'explicit')
+        return { message: 'Payment not sent. Cannot send a payment to yourself.', ok: false }
+      skippedRecipients.push({
+        reason: 'you',
+        recipientProviderLabel: target.recipient.recipientProviderLabel,
+        recipientProviderUserId: target.recipient.recipientProviderUserId,
+      })
+      continue
+    }
+
+    const recipient = conversation.isShared
+      ? await resolveSlackConnectRecipient(ctx, conversation.teamIds, target.recipient)
+      : await resolveLocalSlackRecipient(ctx, target.recipient)
+    if ('message' in recipient) return { message: recipient.message, ok: false }
+    if (!recipient.value) {
+      skippedRecipients.push({
+        reason: 'not_connected',
+        recipientProviderLabel: target.recipient.recipientProviderLabel,
+        recipientProviderUserId: target.recipient.recipientProviderUserId,
+      })
+      continue
+    }
+    recipients.push(recipient.value)
+  }
+
+  if (recipients.length === 0) {
+    const usergroupLabel =
+      parsed.usergroups?.[0]?.providerUsergroupLabel ?? parsed.usergroups?.[0]?.providerUsergroupId
+    return {
+      message: usergroupLabel
+        ? `Payment not sent. None of the members of @${usergroupLabel} are connected to Tipbot yet.`
+        : 'Payment not sent. None of the mentioned accounts are connected to Tipbot yet.',
+      ok: false,
+    }
+  }
+  if (recipients.length > Tip.maxTipBatchRecipients)
+    return {
+      message: `Payment not sent. This tip has ${recipients.length} connected recipients; multi-tip currently supports up to ${Tip.maxTipBatchRecipients}.`,
+      ok: false,
+    }
+  const groupPreviewRequired = Boolean(
+    // Small group tips send immediately; require Slack confirmation only for larger groups or
+    // more expensive total sends.
+    parsed.usergroups?.length &&
+    (recipients.length > 10 || (options.amountEach ?? 0) * recipients.length > 10_000_000),
+  )
+  return {
+    ok: true,
+    previewRequired:
+      groupPreviewRequired || (!parsed.usergroups?.length && skippedRecipients.length > 0),
+    recipients,
+    skippedRecipients,
+    usergroupLabel:
+      parsed.usergroups?.[0]?.providerUsergroupLabel ?? parsed.usergroups?.[0]?.providerUsergroupId,
+  }
+}
+
+async function getSlackConversationInfo(botToken: string, channelId: string) {
+  const body = new URLSearchParams()
+  body.set('channel', channelId.replace(/^slack:/, ''))
+  const response = await getSlack().withBotToken(botToken, () =>
+    fetch(`${env.SLACK_API_URL}/conversations.info`, {
+      body,
+      headers: { authorization: `Bearer ${botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      channel: z
+        .object({
+          context_team_id: z.string().optional(),
+          is_ext_shared: z.boolean().optional(),
+          is_shared: z.boolean().optional(),
+          shared_team_ids: z.array(z.string()).optional(),
+        })
+        .optional(),
+      ok: z.boolean().optional(),
+    }),
+    await response.json(),
+  )
+  const isShared = Boolean(
+    json.channel?.is_ext_shared ||
+    json.channel?.is_shared ||
+    json.channel?.shared_team_ids?.some((teamId) => teamId !== json.channel?.context_team_id),
+  )
+  return {
+    isShared: Boolean(json.ok && json.channel && isShared),
+    teamIds: new Set(
+      [json.channel?.context_team_id, ...(json.channel?.shared_team_ids ?? [])].filter(
+        (teamId) => teamId !== undefined,
+      ),
+    ),
+  }
+}
+
+async function getSlackUserInfo(botToken: string, providerUserId: string) {
+  const body = new URLSearchParams()
+  body.set('user', providerUserId)
+  const response = await getSlack().withBotToken(botToken, () =>
+    fetch(`${env.SLACK_API_URL}/users.info`, {
+      body,
+      headers: { authorization: `Bearer ${botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      ok: z.boolean().optional(),
+      user: z
+        .object({
+          deleted: z.boolean().optional(),
+          id: z.string().optional(),
+          is_app_user: z.boolean().optional(),
+          is_bot: z.boolean().optional(),
+          team_id: z.string().optional(),
+        })
+        .optional(),
+    }),
+    await response.json(),
+  )
+  return json.ok ? json.user : undefined
+}
+
+async function resolveLocalSlackRecipient(ctx: HandlerContext, recipient: Tip.TipRecipientInput) {
+  const workspace = await ctx.db
+    .selectFrom('workspace')
+    .select('id')
+    .where('workspace.provider', '=', 'slack')
+    .where('workspace.provider_id', '=', ctx.provider.id)
+    .executeTakeFirst()
+  if (!workspace) return { value: null }
+  const member = await ctx.db
+    .selectFrom('member')
+    .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+    .innerJoin('account', 'account.id', 'provider_identity.account_id')
+    .select('member.id')
+    .where('member.provider_user_id', '=', recipient.recipientProviderUserId)
+    .where('member.workspace_id', '=', workspace.id)
+    .executeTakeFirst()
+  return { value: member ? recipient : null }
+}
+
+async function resolveSlackConnectRecipient(
+  ctx: HandlerContext,
+  teamIds: Set<string>,
+  recipient: Tip.TipRecipientInput,
+) {
+  const candidates = [...teamIds, ctx.provider.id].map((providerWorkspaceId) => ({
+    providerUserId: recipient.recipientProviderUserId,
+    providerWorkspaceId,
+  }))
+  for (const tokenTeamId of teamIds) {
+    const tokenInstallation = await getSlack().getInstallation(tokenTeamId)
+    if (!tokenInstallation) continue
+    const info = await getSlackUserInfo(
+      tokenInstallation.botToken,
+      recipient.recipientProviderUserId,
+    )
+    if (!info?.id || !info.team_id) continue
+    candidates.push({ providerUserId: info.id, providerWorkspaceId: info.team_id })
+  }
+
+  const seen = new Set<string>()
+  const matches = [] as Array<{ providerUserId: string; providerWorkspaceId: string }>
+  for (const candidate of candidates) {
+    const key = `${candidate.providerWorkspaceId}:${candidate.providerUserId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const candidateWorkspace = await ctx.db
+      .selectFrom('workspace')
+      .select('id')
+      .where('provider', '=', 'slack')
+      .where('provider_id', '=', candidate.providerWorkspaceId)
+      .executeTakeFirst()
+    if (!candidateWorkspace) continue
+    const candidateMember = await ctx.db
+      .selectFrom('member')
+      .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+      .innerJoin('account', 'account.id', 'provider_identity.account_id')
+      .select('member.id')
+      .where('member.provider_user_id', '=', candidate.providerUserId)
+      .where('member.workspace_id', '=', candidateWorkspace.id)
+      .executeTakeFirst()
+    if (candidateMember) matches.push(candidate)
+  }
+  if (matches.length > 1)
+    return {
+      message: `Payment not sent. <@${recipient.recipientProviderUserId}> could not be resolved safely across Slack workspaces.`,
+    }
+  if (matches.length === 0) return { value: null }
+  return {
+    value: {
+      ...recipient,
+      recipientProviderUserId: matches[0]!.providerUserId,
+      recipientProviderWorkspaceId: matches[0]!.providerWorkspaceId,
+    },
+  }
 }
 
 async function handleSlackReactionTip(event: SlackReactionEvent, context: ReactionHandlerContext) {
@@ -1795,7 +2074,7 @@ async function postSlackPrivateReply(
   const installation = await getSlack().getInstallation(providerId)
   if (!installation) return
 
-  const method = isSlackDMChannelId(channelId) ? 'chat.postMessage' : 'chat.postEphemeral'
+  const method = Slack.isDMChannelId(channelId) ? 'chat.postMessage' : 'chat.postEphemeral'
   if (method === 'chat.postEphemeral') body.set('user', userId)
   if (options.threadTs && method === 'chat.postEphemeral') body.set('thread_ts', options.threadTs)
   const response = await getSlack().withBotToken(installation.botToken, () =>
@@ -2085,26 +2364,25 @@ function isUniqueConstraintError(error: unknown) {
 }
 
 function normalizeSlackMentionText(value: string, botUserId: string) {
-  const botMentionPattern = new RegExp(`<@${escapeRegex(botUserId)}(?:\\|[^>]+)?>`, 'g')
+  const botMentionPattern = new RegExp(
+    `<@${botUserId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\|[^>]+)?>`,
+    'g',
+  )
   return value.replace(botMentionPattern, ' ').replace(/\s+/g, ' ').trim()
 }
 
 function parseSlackMentionTipText(text: string) {
-  const mentions = [...text.matchAll(/<@([A-Z0-9_]+)(?:\|[^>]+)?>/g)]
-  if (mentions.length < 1) return null
-  const prefix = text.slice(0, mentions[0]!.index).trim().toLowerCase()
+  const target = text.match(/<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>/)
+  if (!target) return null
+  const prefix = text.slice(0, target.index).trim().toLowerCase()
   if (prefix && !['pay', 'send', 'tip'].includes(prefix)) return null
-  return text.slice(mentions[0]!.index).trim()
+  return text.slice(target.index).trim()
 }
 
 function hasInvalidMentionIntent(text: string) {
   return /\b(connect|configure|get started|install|link|mine|set ?up|start|tip|send|pay|sent|paid|for|thank you|thanks|ty|thx|thank u|creature|creatures|dragon|dragons|elf|elves|fae|fairy|goblin|goblins|gnome|gnomes|gremlin|gremlins|kobold|kobolds|monster|monsters|orc|orcs|troll|trolls)\b/i.test(
     text,
   )
-}
-
-function escapeRegex(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 async function getLeaderboardRows(
@@ -2439,23 +2717,155 @@ async function postPrivateReply(
   options: { threadTs?: string } = {},
 ) {
   const threadTs = options.threadTs ?? event.threadTs
-  if (isSlackDMChannelId(event.channel.id)) {
+  if (Slack.isDMChannelId(event.channel.id)) {
     await event.channel.post(message)
     return
   }
 
   const channel = threadTs
-    ? getChat().channel(`slack:${getSlackChannelId(event.channel.id)}:${threadTs}`)
+    ? getChat().channel(`slack:${Slack.getChannelId(event.channel.id)}:${threadTs}`)
     : event.channel
   await channel.postEphemeral(user, message, { fallbackToDM: false })
 }
 
-function isSlackDMChannelId(channelId: string) {
-  return getSlackChannelId(channelId).startsWith('D')
+async function postSlackTipPreview(
+  event: TipEvent,
+  pending: PendingSlackTip & { amountText: string },
+) {
+  const token = Nanoid.generate()
+  await (async () => {
+    // Store Slack confirmation state briefly; the button value only carries the opaque token.
+    const state = createCloudflareState({
+      name: 'tipbot',
+      namespace: env.CHAT_STATE,
+      shardKey(threadId) {
+        return threadId.split(':', 1)[0] || 'default'
+      },
+    })
+    await state.connect()
+    await state.set(`pending_tip:${token}`, pending, 10 * 60 * 1000) // 10 minutes
+    await state.disconnect()
+  })()
+  const skippedLines = pending.skippedRecipients?.length
+    ? [
+        '',
+        '*Skipped:*',
+        ...pending.skippedRecipients.map(
+          (recipient) =>
+            `• ${event.channel.mentionUser(recipient.recipientProviderUserId)} (${recipient.reason === 'you' ? 'you' : 'not connected yet'})`,
+        ),
+      ]
+    : []
+  const totalAmount = pending.amount
+    ? formatCurrencyAmount(formatAmount(pending.amount * pending.recipients.length), 'USD')
+    : undefined
+  await postPrivateReply(event, event.user, {
+    card: chat.Card({
+      children: [
+        chat.CardText(
+          [
+            `You’re about to tip ${pending.usergroupLabel ? `@${pending.usergroupLabel} ` : ''}${pending.recipients.length} accounts ${pending.amountText} each${pending.memo ? ` for ${pending.memo}` : ''}.`,
+            ...(totalAmount ? [`Total: ${totalAmount}`] : []),
+            '',
+            '*Recipients:*',
+            ...pending.recipients.map(
+              (recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`,
+            ),
+            ...skippedLines,
+          ].join('\n'),
+        ),
+        chat.Actions([
+          chat.Button({ id: 'confirm_tip', label: 'Confirm tip', style: 'primary', value: token }),
+          chat.Button({ id: 'confirm_cancel', label: 'Cancel' }),
+        ]),
+      ],
+    }),
+    fallbackText: `Confirm tip: ${pending.recipients.length} accounts ${pending.amountText} each.`,
+  })
 }
 
-function getSlackChannelId(channelId: string) {
-  return channelId.replace(/^slack:/, '').split(':')[0] ?? ''
+async function postTipResult(
+  event: TipEvent,
+  ctx: HandlerContext,
+  result: Tip.TipBatchResult,
+  options: { skippedRecipients?: Tip.TipSkippedRecipient[]; usergroupLabel?: string } = {},
+) {
+  if (!result.ok) {
+    if (result.code === 'confirmation_required' && result.confirmUrl) {
+      const confirmUrlLabel = result.confirmUrl.replace(/(\/confirm\/.{8}).+$/, '$1...')
+      await postPrivateReply(event, event.user, {
+        card: chat.Card({
+          children: [
+            chat.CardText('Tipbot needs wallet approval to send this payment.'),
+            chat.Actions([
+              chat.LinkButton({
+                label: 'Review and approve',
+                style: 'primary',
+                url: result.confirmUrl,
+              }),
+              chat.Button({ id: 'confirm_cancel', label: 'Cancel' }),
+            ]),
+            chat.CardText(`Link expires in 10 minutes. <${result.confirmUrl}|${confirmUrlLabel}>`, {
+              style: 'muted',
+            }),
+          ],
+        }),
+        fallbackText: `Tipbot needs wallet approval to send this payment. Confirm payment: ${result.confirmUrl}`,
+      })
+      return
+    }
+    if (result.code === 'sender_unconnected' || result.code === 'missing_sender_access_key') {
+      await postConnectLink(event, ctx)
+      return
+    }
+    if (result.code === 'insufficient_funds') {
+      await postSlackInsufficientFunds(event, ctx, event.threadTs)
+      return
+    }
+    await postPrivateReply(
+      event,
+      event.user,
+      result.code === 'pending' ? 'Payment still sending.' : (result.message ?? 'Payment failed.'),
+    )
+    return
+  }
+  if (result.status === 'sent') {
+    const amount = result.isDefaultToken
+      ? formatCurrencyAmount(result.amount, result.tokenCurrency)
+      : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
+    const skippedRecipients = result.skippedRecipients ?? options.skippedRecipients ?? []
+    const skippedLines = skippedRecipients
+      .slice(0, 10)
+      .map(
+        (recipient) =>
+          `• ${event.channel.mentionUser(recipient.recipientProviderUserId)} (${recipient.reason === 'you' ? 'you' : 'not connected yet'})`,
+      )
+    if (skippedRecipients.length > skippedLines.length)
+      skippedLines.push(
+        `…and ${skippedRecipients.length - skippedLines.length} more not connected yet`,
+      )
+    await postSlackReceiptMessage(
+      event,
+      ctx,
+      `${event.channel.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${options.usergroupLabel ? `@${options.usergroupLabel} ` : ''}${result.recipients.length} accounts ${amount} each${result.memo ? ` for ${result.memo}` : ''}.\n${[
+        ...result.recipients.map(
+          (recipient) => `• ${event.channel.mentionUser(recipient.recipientProviderUserId)}`,
+        ),
+        ...skippedLines,
+      ].join('\n')}`,
+      result.chainId,
+      result.transactionHash,
+      undefined,
+      result.feePayer === 'sender'
+        ? 'Fee sponsor unavailable; fee paid from your balance.'
+        : undefined,
+      event.threadTs,
+    )
+    if (result.memo && event.threadTs)
+      await postSlackMemoReply(event, ctx, result.memo, event.threadTs)
+    return
+  }
+  await postPrivateReply(event, event.user, 'Payment already sent.')
 }
 
 async function postSlackReceiptMessage(
@@ -2475,18 +2885,39 @@ async function postSlackReceiptMessage(
   const body = new URLSearchParams()
   body.set(
     'blocks',
-    JSON.stringify(createReceiptBlocks(receiptText, chainId, transactionHash, context)),
+    JSON.stringify(
+      (() => {
+        const receiptLink = `<${Tempo.formatTxLink(chainId, transactionHash)}|Receipt>`
+        return [
+          {
+            text: {
+              text: formatReceiptText(receiptText, receiptLink),
+              type: 'mrkdwn',
+            },
+            type: 'section',
+          },
+          ...(context
+            ? [
+                {
+                  elements: [{ text: context, type: 'mrkdwn' }],
+                  type: 'context',
+                },
+              ]
+            : []),
+        ]
+      })(),
+    ),
   )
   body.set('channel', event.channel.id.replace(/^slack:/, ''))
   body.set('text', formatReceiptText(`${receiptText}${context ? ` ${context}` : ''}`, 'Receipt'))
   if (threadTs) body.set('thread_ts', threadTs)
-  if (user && !isSlackDMChannelId(event.channel.id)) body.set('user', user.userId)
+  if (user && !Slack.isDMChannelId(event.channel.id)) body.set('user', user.userId)
   else {
     body.set('unfurl_links', 'false')
     body.set('unfurl_media', 'false')
   }
   const method =
-    user && !isSlackDMChannelId(event.channel.id) ? 'chat.postEphemeral' : 'chat.postMessage'
+    user && !Slack.isDMChannelId(event.channel.id) ? 'chat.postEphemeral' : 'chat.postMessage'
   const response = await getSlack().withBotToken(installation.botToken, () =>
     fetch(`${env.SLACK_API_URL}/${method}`, {
       body,
@@ -2567,32 +2998,6 @@ async function postSlackMemoReply(
     .catch((error: unknown) => {
       console.error('Failed to post memo reply:', error)
     })
-}
-
-function createReceiptBlocks(
-  text: string,
-  chainId: number,
-  transactionHash: string,
-  context?: string,
-) {
-  const receiptLink = `<${Tempo.formatTxLink(chainId, transactionHash)}|Receipt>`
-  return [
-    {
-      text: {
-        text: formatReceiptText(text, receiptLink),
-        type: 'mrkdwn',
-      },
-      type: 'section',
-    },
-    ...(context
-      ? [
-          {
-            elements: [{ text: context, type: 'mrkdwn' }],
-            type: 'context',
-          },
-        ]
-      : []),
-  ]
 }
 
 function formatReceiptText(text: string, receipt: string) {
@@ -2705,7 +3110,26 @@ async function postConfigEphemeral(
             slackTableCell('Default amount'),
             slackTableCell(formatAmount(workspace.default_amount)),
           ],
-          [slackTableCell('Reaction'), slackTableReactionCell(workspace.reaction_tip_emoji)],
+          [
+            slackTableCell('Reaction'),
+            {
+              elements: [
+                {
+                  elements: [
+                    { name: workspace.reaction_tip_emoji, type: 'emoji' },
+                    { text: ' ', type: 'text' },
+                    {
+                      style: { code: true },
+                      text: `:${workspace.reaction_tip_emoji}:`,
+                      type: 'text',
+                    },
+                  ],
+                  type: 'rich_text_section',
+                },
+              ],
+              type: 'rich_text',
+            },
+          ],
         ],
         type: 'table',
       },
@@ -2762,26 +3186,6 @@ function slackTableCell(text: string, style?: { code?: boolean }) {
     elements: [
       {
         elements: [style ? { style, text, type: 'text' } : { text, type: 'text' }],
-        type: 'rich_text_section',
-      },
-    ],
-    type: 'rich_text',
-  }
-}
-
-function slackTableReactionCell(emojiName: string) {
-  return slackTableRichCell([
-    { name: emojiName, type: 'emoji' },
-    { text: ' ', type: 'text' },
-    { style: { code: true }, text: `:${emojiName}:`, type: 'text' },
-  ])
-}
-
-function slackTableRichCell(elements: unknown[]) {
-  return {
-    elements: [
-      {
-        elements,
         type: 'rich_text_section',
       },
     ],

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -197,6 +197,153 @@ describe('/tip @account', () => {
     ])
   }, 20_000) // 20 seconds
 
+  test('sends small group tip immediately with skipped recipients', async () => {
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!subteam^SENGINEERING|engineering> 0.001 for coffee')
+    const batch = await db
+      .selectFrom('tip_batch')
+      .selectAll()
+      .where('idempotency_key', 'like', `command:${providerId}:%`)
+      .executeTakeFirstOrThrow()
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      `<@${Constants.slack.adminUserId}> sent @engineering 1 accounts $0.001 each for coffee · Receipt`,
+    )
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
+    await expectSlackMessage(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining('You’re about to tip')
+    expect(batch).toMatchObject({ recipient_count: 1, status: 'confirmed' })
+  }, 20_000) // 20 seconds
+
+  test('sends ten-recipient group tip immediately', async () => {
+    const accounts = await connectTipAccounts()
+    for (const providerUserId of Constants.slackBigUserIds.slice(0, 10)) {
+      await insertMember({
+        account_id: (await factory.account.insert({})).id,
+        provider_user_id: providerUserId,
+        workspace_id: accounts.workspace.id,
+      })
+    }
+
+    const response = await postSlashCommand('<!subteam^SSMALLTEAM|smallteam> 0.001')
+    const batch = await db
+      .selectFrom('tip_batch')
+      .selectAll()
+      .where('idempotency_key', 'like', `command:${providerId}:%`)
+      .executeTakeFirstOrThrow()
+    const tips = await db.selectFrom('tip').select('id').where('batch_id', '=', batch.id).execute()
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      `<@${Constants.slack.adminUserId}> tipped @smallteam 10 accounts $0.001 each · Receipt`,
+    )
+    await expectSlackMessageNotContaining('D1_ERROR')
+    expect(batch).toMatchObject({ recipient_count: 10, status: 'confirmed' })
+    expect(tips).toHaveLength(10)
+  }, 20_000) // 20 seconds
+
+  test('previews large group tip', async () => {
+    const accounts = await connectTipAccounts()
+    for (const providerUserId of Constants.slackBigUserIds.slice(0, 11)) {
+      await insertMember({
+        account_id: (await factory.account.insert({})).id,
+        provider_user_id: providerUserId,
+        workspace_id: accounts.workspace.id,
+      })
+    }
+
+    const response = await postSlashCommand('<!subteam^SREVIEWTEAM|reviewteam> 0.001 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip @reviewteam 11 accounts $0.001 each for coffee.')
+    await expectSlackMessageNotContaining('Receipt')
+  }, 20_000) // 20 seconds
+
+  test('previews small group tip when total is more than $10', async () => {
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!subteam^SENGINEERING|engineering> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip @engineering 1 accounts $11.00 each for coffee.')
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
+    await expectSlackMessage(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining('Receipt')
+  })
+
+  test('shows group tip failure message', async () => {
+    const handleTipBatchRequest = vi.spyOn(Tip, 'handleTipBatchRequest').mockResolvedValue({
+      code: 'failed',
+      message: 'Debuggable failure reason.',
+      ok: false,
+    })
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!subteam^SENGINEERING|engineering> 0.001')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('Debuggable failure reason.')
+    await expectSlackMessageNotContaining('Payment failed.')
+    handleTipBatchRequest.mockRestore()
+  })
+
+  test('previews explicit batch tip with skipped unconnected recipient', async () => {
+    await connectTipAccounts()
+
+    const response = await postSlashCommand(
+      `<@${Constants.slack.memberUserId}> <@${unconnectedProviderUserId}> for coffee`,
+    )
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip 1 accounts $0.001 each for coffee.')
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
+    await expectSlackMessageNotContaining('Receipt')
+  })
+
+  test('rejects group tips in Slack Connect channels', async () => {
+    const channelId = await getSlackConnectChannelId()
+
+    const response = await postSlashCommand('<!subteam^SENGINEERING|engineering>', { channelId })
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Group tips are not supported in Slack Connect channels yet; mention individual recipients instead.',
+      { channelId },
+    )
+  })
+
+  test('rejects explicit self mention even when mixed with group', async () => {
+    const response = await postSlashCommand(
+      `<@${Constants.slack.adminUserId}> <!subteam^SENGINEERING|engineering>`,
+    )
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('Payment not sent. Cannot send a payment to yourself.')
+  })
+
+  test('rejects group tip with more than 100 connected recipients', async () => {
+    const accounts = await connectTipAccounts({ recipient: false })
+    for (const providerUserId of Constants.slackBigUserIds) {
+      await insertMember({
+        account_id: (await factory.account.insert({})).id,
+        provider_user_id: providerUserId,
+        workspace_id: accounts.workspace.id,
+      })
+    }
+
+    const response = await postSlashCommand('<!subteam^SBIGTEAM|bigteam>')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Payment not sent. This tip has 101 connected recipients; multi-tip currently supports up to 100.',
+    )
+  }, 20_000) // 20 seconds
+
   test('deduplicates duplicate multi-recipient tip requests', async () => {
     const accounts = await connectTipAccounts()
     const secondRecipientAccount = await findOrCreateAccount(
@@ -270,8 +417,8 @@ describe('/tip @account', () => {
     expect(json.transactionRequest?.calls).toHaveLength(20)
   }, 20_000) // 20 seconds
 
-  test('rejects 21 recipients', async () => {
-    const recipients = Array.from({ length: 21 }, (_value, index) => ({
+  test('rejects 101 recipients', async () => {
+    const recipients = Array.from({ length: 101 }, (_value, index) => ({
       recipientProviderUserId: `U${String(index + 10).padStart(8, '0')}`,
     }))
 
@@ -288,7 +435,7 @@ describe('/tip @account', () => {
 
     expect(result).toEqual({
       code: 'failed',
-      message: 'Multi-tip supports up to 20 recipients.',
+      message: 'Multi-tip supports up to 100 recipients.',
       ok: false,
     })
   })
@@ -700,6 +847,35 @@ test('@Tipbot mention sends tip in thread', async () => {
   })
   expect(tip.confirmed_at).toEqual(expect.any(String))
   fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention sends small group tip in thread', async () => {
+  await connectTipAccounts()
+  const messageTs = `1700000000.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <!subteam^SENGINEERING|engineering>`,
+  })
+  const batch = await db
+    .selectFrom('tip_batch')
+    .selectAll()
+    .where(
+      'idempotency_key',
+      '=',
+      `mention:${providerId}:${Constants.slack.channelId}:${messageTs}`,
+    )
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slack.adminUserId}> tipped @engineering 1 accounts $0.001 each · Receipt`,
+  )
+  await expectSlackThreadMessage(messageTs, `• <@${Constants.slack.memberUserId}>`)
+  await expectSlackThreadMessage(messageTs, `• <@${unconnectedProviderUserId}> (not connected yet)`)
+  await expectSlackThreadMessage(messageTs, `• <@${Constants.slack.adminUserId}> (you)`)
+  expect(batch).toMatchObject({ recipient_count: 1, status: 'confirmed' })
 }, 20_000) // 20 seconds
 
 test('@Tipbot mention sends tip from single channel guest', async () => {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -209,7 +209,7 @@ describe('/tip @account', () => {
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      `<@${Constants.slack.adminUserId}> sent @engineering 1 accounts $0.001 each for coffee · Receipt`,
+      `<@${Constants.slack.adminUserId}> sent <!subteam^SENGINEERING|@engineering> 1 accounts $0.001 each for coffee · Receipt`,
     )
     await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
     await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
@@ -238,7 +238,7 @@ describe('/tip @account', () => {
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      `<@${Constants.slack.adminUserId}> tipped @smallteam 10 accounts $0.001 each · Receipt`,
+      `<@${Constants.slack.adminUserId}> tipped <!subteam^SSMALLTEAM|@smallteam> 10 accounts $0.001 each · Receipt`,
     )
     await expectSlackMessageNotContaining('D1_ERROR')
     expect(batch).toMatchObject({ recipient_count: 10, status: 'confirmed' })
@@ -258,7 +258,9 @@ describe('/tip @account', () => {
     const response = await postSlashCommand('<!subteam^SREVIEWTEAM|reviewteam> 0.001 for coffee')
 
     expect(response.status).toBe(200)
-    await expectSlackMessage('You’re about to tip @reviewteam 11 accounts $0.001 each for coffee.')
+    await expectSlackMessage(
+      'You’re about to tip <!subteam^SREVIEWTEAM|@reviewteam> 11 accounts $0.001 each for coffee.',
+    )
     await expectSlackMessageNotContaining('Receipt')
   }, 20_000) // 20 seconds
 
@@ -268,7 +270,9 @@ describe('/tip @account', () => {
     const response = await postSlashCommand('<!subteam^SENGINEERING|@engineering> $11 for coffee')
 
     expect(response.status).toBe(200)
-    await expectSlackMessage('You’re about to tip @engineering 1 accounts $11.00 each for coffee.')
+    await expectSlackMessage(
+      'You’re about to tip <!subteam^SENGINEERING|@engineering> 1 accounts $11.00 each for coffee.',
+    )
     await expectSlackMessageNotContaining('@@engineering')
     await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
     await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
@@ -856,7 +860,7 @@ test('@Tipbot mention sends small group tip in thread', async () => {
 
   const response = await postSlackAppMention({
     messageTs,
-    text: `<@${Constants.slack.botUserId}> <!subteam^SENGINEERING|engineering>`,
+    text: `<@${Constants.slack.botUserId}> <!subteam^SENGINEERING>`,
   })
   const batch = await db
     .selectFrom('tip_batch')
@@ -871,7 +875,7 @@ test('@Tipbot mention sends small group tip in thread', async () => {
   expect(response.status).toBe(200)
   await expectSlackThreadMessage(
     messageTs,
-    `<@${Constants.slack.adminUserId}> tipped @engineering 1 accounts $0.001 each · Receipt`,
+    `<@${Constants.slack.adminUserId}> tipped <!subteam^SENGINEERING> 1 accounts $0.001 each · Receipt`,
   )
   await expectSlackThreadMessage(messageTs, `• <@${Constants.slack.memberUserId}>`)
   await expectSlackThreadMessage(messageTs, `• <@${unconnectedProviderUserId}> (not connected yet)`)

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -213,7 +213,7 @@ describe('/tip @account', () => {
     )
     await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
     await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
-    await expectSlackMessage(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
     await expectSlackMessageNotContaining('You’re about to tip')
     expect(batch).toMatchObject({ recipient_count: 1, status: 'confirmed' })
   }, 20_000) // 20 seconds
@@ -265,13 +265,14 @@ describe('/tip @account', () => {
   test('previews small group tip when total is more than $10', async () => {
     await connectTipAccounts()
 
-    const response = await postSlashCommand('<!subteam^SENGINEERING|engineering> $11 for coffee')
+    const response = await postSlashCommand('<!subteam^SENGINEERING|@engineering> $11 for coffee')
 
     expect(response.status).toBe(200)
     await expectSlackMessage('You’re about to tip @engineering 1 accounts $11.00 each for coffee.')
+    await expectSlackMessageNotContaining('@@engineering')
     await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
     await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
-    await expectSlackMessage(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
     await expectSlackMessageNotContaining('Receipt')
   })
 
@@ -874,7 +875,10 @@ test('@Tipbot mention sends small group tip in thread', async () => {
   )
   await expectSlackThreadMessage(messageTs, `• <@${Constants.slack.memberUserId}>`)
   await expectSlackThreadMessage(messageTs, `• <@${unconnectedProviderUserId}> (not connected yet)`)
-  await expectSlackThreadMessage(messageTs, `• <@${Constants.slack.adminUserId}> (you)`)
+  await expectSlackThreadMessageNotContaining(
+    messageTs,
+    `• <@${Constants.slack.adminUserId}> (you)`,
+  )
   expect(batch).toMatchObject({ recipient_count: 1, status: 'confirmed' })
 }, 20_000) // 20 seconds
 

--- a/src/lib/confirmation.ts
+++ b/src/lib/confirmation.ts
@@ -7,6 +7,7 @@ export const payloadSchema = z.object({
   amount: z.number().int().positive(),
   chainId: z.number().int().positive(),
   expiresAt: z.string().min(1),
+  groupId: z.string().min(1).optional(),
   groupLabel: z.string().min(1).optional(),
   idempotencyKey: z.string().min(1),
   kind: z.enum(['reusable_access_key', 'onetime_payment']),

--- a/src/lib/confirmation.ts
+++ b/src/lib/confirmation.ts
@@ -7,6 +7,7 @@ export const payloadSchema = z.object({
   amount: z.number().int().positive(),
   chainId: z.number().int().positive(),
   expiresAt: z.string().min(1),
+  groupLabel: z.string().min(1).optional(),
   idempotencyKey: z.string().min(1),
   kind: z.enum(['reusable_access_key', 'onetime_payment']),
   memo: z.string().nullable(),
@@ -28,6 +29,15 @@ export const payloadSchema = z.object({
     )
     .optional(),
   senderProviderUserId: z.string().min(1),
+  skippedRecipients: z
+    .array(
+      z.object({
+        reason: z.enum(['not_connected', 'you']),
+        recipientProviderLabel: z.string().min(1).optional(),
+        recipientProviderUserId: z.string().min(1),
+      }),
+    )
+    .optional(),
   tokenAddress: z.string().min(1),
   workspaceId: z.string().min(1),
 })

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -25,3 +25,10 @@ test('classifies oversized Slack payloads as non-retryable payload errors', () =
     retryable: false,
   })
 })
+
+test('normalizes Slack adapter channel ids', () => {
+  expect(Slack.getChannelId('slack:C123:1700000000.000100')).toBe('C123')
+  expect(Slack.getChannelId('D123')).toBe('D123')
+  expect(Slack.isDMChannelId('slack:D123:1700000000.000100')).toBe(true)
+  expect(Slack.isDMChannelId('slack:C123')).toBe(false)
+})

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -116,6 +116,14 @@ export function slackApiError(method: string, error: string | undefined) {
   return value
 }
 
+export function getChannelId(channelId: string) {
+  return channelId.replace(/^slack:/, '').split(':')[0] ?? ''
+}
+
+export function isDMChannelId(channelId: string) {
+  return getChannelId(channelId).startsWith('D')
+}
+
 function stringValue(value: unknown) {
   if (typeof value === 'string') return value
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -174,6 +174,13 @@ test('parses multi-recipient tip mentions', () => {
     token: null,
     usergroups: [{ providerUsergroupId: 'SENGINEERING', providerUsergroupLabel: 'engineering' }],
   })
+  expect(Tip.parseTipBatchText('<!subteam^SENGINEERING|@engineering>')).toEqual({
+    amount: undefined,
+    memo: null,
+    recipients: [],
+    token: null,
+    usergroups: [{ providerUsergroupId: 'SENGINEERING', providerUsergroupLabel: 'engineering' }],
+  })
   expect(Tip.parseTipBatchText('<@UFOO> for <@UBAR>')).toBe(null)
 })
 

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -167,6 +167,13 @@ test('parses multi-recipient tip mentions', () => {
     recipients: [{ recipientProviderUserId: 'UFOO' }, { recipientProviderUserId: 'UBAR' }],
     token: null,
   })
+  expect(Tip.parseTipBatchText('<!subteam^SENGINEERING|engineering> 0.001 for coffee')).toEqual({
+    amount: 1000,
+    memo: 'coffee',
+    recipients: [],
+    token: null,
+    usergroups: [{ providerUsergroupId: 'SENGINEERING', providerUsergroupLabel: 'engineering' }],
+  })
   expect(Tip.parseTipBatchText('<@UFOO> for <@UBAR>')).toBe(null)
 })
 

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -236,6 +236,7 @@ export async function handleTipBatchRequest(
     skippedRecipients?: TipSkippedRecipient[]
     source: 'command' | 'mention' | 'reaction'
     tokenAddress?: string
+    usergroupId?: string
     usergroupLabel?: string
   },
 ): Promise<TipBatchResult> {
@@ -366,6 +367,7 @@ export async function handleTipBatchRequest(
         recipients,
         senderProviderUserId: input.senderProviderUserId,
         skippedRecipients: input.skippedRecipients,
+        usergroupId: input.usergroupId,
         usergroupLabel: input.usergroupLabel,
       },
       workspace,
@@ -396,6 +398,7 @@ export async function handleTipBatchRequest(
     skippedRecipients: input.skippedRecipients,
     source: input.source,
     tokenAddress,
+    usergroupId: input.usergroupId,
     usergroupLabel: input.usergroupLabel,
     workspace,
   })
@@ -737,6 +740,7 @@ export async function confirmTipRequest(
       skippedRecipients: payload.skippedRecipients,
       source: 'command',
       tokenAddress: Address.checksum(payload.tokenAddress),
+      usergroupId: payload.groupId,
       usergroupLabel: payload.groupLabel,
       workspace,
     })
@@ -984,6 +988,7 @@ async function createConfirmationRequired(
     recipients?: TipRecipientInput[]
     senderProviderUserId: string
     skippedRecipients?: TipSkippedRecipient[]
+    usergroupId?: string
     usergroupLabel?: string
   },
   workspace: Database.Selectable.workspace,
@@ -1006,6 +1011,7 @@ async function createConfirmationRequired(
       : {}),
     ...(input.recipients ? { recipients: input.recipients } : {}),
     ...(input.skippedRecipients?.length ? { skippedRecipients: input.skippedRecipients } : {}),
+    ...(input.usergroupId ? { groupId: input.usergroupId } : {}),
     ...(input.usergroupLabel ? { groupLabel: input.usergroupLabel } : {}),
     amount,
     chainId: workspace.chain_id,
@@ -1056,6 +1062,7 @@ async function submitTipBatch(
     skippedRecipients?: TipSkippedRecipient[]
     source: 'command' | 'mention' | 'reaction'
     tokenAddress: string
+    usergroupId?: string
     usergroupLabel?: string
     workspace: Database.Selectable.workspace
   },

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -504,7 +504,9 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
     if (!usergroup) break
     if (!usergroups.some((item) => item.providerUsergroupId === usergroup[1]))
       usergroups.push({
-        ...(usergroup[2]?.trim() ? { providerUsergroupLabel: usergroup[2].trim() } : {}),
+        ...(usergroup[2]?.trim()
+          ? { providerUsergroupLabel: usergroup[2].trim().replace(/^@+/, '') }
+          : {}),
         providerUsergroupId: usergroup[1]!,
       })
     remaining = remaining.slice(usergroup[0].length)

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -60,6 +60,7 @@ export type TipBatchResult =
       ok: true
       recipients: Array<{ recipientProviderLabel?: string; recipientProviderUserId: string }>
       senderProviderUserId: string
+      skippedRecipients?: TipSkippedRecipient[]
       status: 'duplicate' | 'sent'
       tokenCurrency: string
       tokenSymbol: string
@@ -72,6 +73,19 @@ export type TipRecipientInput = {
   recipientProviderUserId: string
   recipientProviderWorkspaceId?: string
 }
+
+export type TipSkippedRecipient = {
+  reason: 'not_connected' | 'you'
+  recipientProviderLabel?: string
+  recipientProviderUserId: string
+}
+
+export type TipUsergroupInput = {
+  providerUsergroupId: string
+  providerUsergroupLabel?: string
+}
+
+export const maxTipBatchRecipients = 100
 
 export async function handleTipRequest(
   env: Env,
@@ -219,8 +233,10 @@ export async function handleTipBatchRequest(
     providerThreadId?: string
     recipients: TipRecipientInput[]
     senderProviderUserId: string
+    skippedRecipients?: TipSkippedRecipient[]
     source: 'command' | 'mention' | 'reaction'
     tokenAddress?: string
+    usergroupLabel?: string
   },
 ): Promise<TipBatchResult> {
   const db = DB.create(env.DB)
@@ -252,11 +268,15 @@ export async function handleTipBatchRequest(
         .where('id', '=', id)
         .executeTakeFirstOrThrow()
     })())
-  const recipients = input.recipients.slice(0, 20)
+  const recipients = input.recipients.slice(0, maxTipBatchRecipients)
   if (input.recipients.length === 0)
     return { code: 'failed', message: 'Payment must have at least one recipient.', ok: false }
-  if (input.recipients.length > 20)
-    return { code: 'failed', message: 'Multi-tip supports up to 20 recipients.', ok: false }
+  if (input.recipients.length > maxTipBatchRecipients)
+    return {
+      code: 'failed',
+      message: `Multi-tip supports up to ${maxTipBatchRecipients} recipients.`,
+      ok: false,
+    }
   if (
     recipients.some(
       (recipient) =>
@@ -345,6 +365,8 @@ export async function handleTipBatchRequest(
         recipientProviderWorkspaceId: recipients[0]?.recipientProviderWorkspaceId,
         recipients,
         senderProviderUserId: input.senderProviderUserId,
+        skippedRecipients: input.skippedRecipients,
+        usergroupLabel: input.usergroupLabel,
       },
       workspace,
       amount,
@@ -371,8 +393,10 @@ export async function handleTipBatchRequest(
     recipients,
     sender,
     senderProviderUserId: input.senderProviderUserId,
+    skippedRecipients: input.skippedRecipients,
     source: input.source,
     tokenAddress,
+    usergroupLabel: input.usergroupLabel,
     workspace,
   })
 }
@@ -462,22 +486,34 @@ export function parseTipText(value: string, options: { chainId?: number } = {}) 
 export function parseTipBatchText(value: string, options: { chainId?: number } = {}) {
   const text = value.trim()
   const recipients: TipRecipientInput[] = []
+  const usergroups: TipUsergroupInput[] = []
   let remaining = text
   for (;;) {
     const mention = remaining.match(/^<@([A-Z0-9_]+)(?:\|([^>]+))?>\s*/)
-    if (!mention) break
-    if (!recipients.some((recipient) => recipient.recipientProviderUserId === mention[1]))
-      recipients.push({
-        ...(mention[2]?.trim() ? { recipientProviderLabel: mention[2].trim() } : {}),
-        recipientProviderUserId: mention[1]!,
+    if (mention) {
+      if (!recipients.some((recipient) => recipient.recipientProviderUserId === mention[1]))
+        recipients.push({
+          ...(mention[2]?.trim() ? { recipientProviderLabel: mention[2].trim() } : {}),
+          recipientProviderUserId: mention[1]!,
+        })
+      remaining = remaining.slice(mention[0].length)
+      continue
+    }
+
+    const usergroup = remaining.match(/^<!subteam\^([A-Z0-9_]+)(?:\|([^>]+))?>\s*/)
+    if (!usergroup) break
+    if (!usergroups.some((item) => item.providerUsergroupId === usergroup[1]))
+      usergroups.push({
+        ...(usergroup[2]?.trim() ? { providerUsergroupLabel: usergroup[2].trim() } : {}),
+        providerUsergroupId: usergroup[1]!,
       })
-    remaining = remaining.slice(mention[0].length)
+    remaining = remaining.slice(usergroup[0].length)
   }
-  if (recipients.length === 0) return null
-  if (/<@[A-Z0-9_]+(?:\|[^>]+)?>/.test(remaining)) return null
+  if (recipients.length === 0 && usergroups.length === 0) return null
+  if (/<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>/.test(remaining)) return null
 
   const parsed = parseTipText(
-    `<@${recipients[0]!.recipientProviderUserId}${recipients[0]!.recipientProviderLabel ? `|${recipients[0]!.recipientProviderLabel}` : ''}> ${remaining}`,
+    `<@${recipients[0]?.recipientProviderUserId ?? 'U000000000'}${recipients[0]?.recipientProviderLabel ? `|${recipients[0].recipientProviderLabel}` : ''}> ${remaining}`,
     options,
   )
   if (!parsed) return null
@@ -486,6 +522,7 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
     memo: parsed.memo,
     recipients,
     token: parsed.token,
+    ...(usergroups.length ? { usergroups } : {}),
   }
 }
 
@@ -695,8 +732,10 @@ export async function confirmTipRequest(
       recipients,
       sender,
       senderProviderUserId: payload.senderProviderUserId,
+      skippedRecipients: payload.skippedRecipients,
       source: 'command',
       tokenAddress: Address.checksum(payload.tokenAddress),
+      usergroupLabel: payload.groupLabel,
       workspace,
     })
 
@@ -942,6 +981,8 @@ async function createConfirmationRequired(
     recipientProviderWorkspaceId?: string
     recipients?: TipRecipientInput[]
     senderProviderUserId: string
+    skippedRecipients?: TipSkippedRecipient[]
+    usergroupLabel?: string
   },
   workspace: Database.Selectable.workspace,
   amount: number,
@@ -962,6 +1003,8 @@ async function createConfirmationRequired(
         }
       : {}),
     ...(input.recipients ? { recipients: input.recipients } : {}),
+    ...(input.skippedRecipients?.length ? { skippedRecipients: input.skippedRecipients } : {}),
+    ...(input.usergroupLabel ? { groupLabel: input.usergroupLabel } : {}),
     amount,
     chainId: workspace.chain_id,
     expiresAt,
@@ -1008,8 +1051,10 @@ async function submitTipBatch(
     recipients: TipRecipientInput[]
     sender: ConnectedMember
     senderProviderUserId: string
+    skippedRecipients?: TipSkippedRecipient[]
     source: 'command' | 'mention' | 'reaction'
     tokenAddress: string
+    usergroupLabel?: string
     workspace: Database.Selectable.workspace
   },
 ): Promise<TipBatchResult> {
@@ -1081,7 +1126,14 @@ async function submitTipBatch(
         workspace_id: input.workspace.id,
       })
       .execute()
-    if (tipRows.length) await db.insertInto('tip').values(tipRows).execute()
+    for (let index = 0; index < tipRows.length; index += 4) {
+      // D1 has a low SQL variable limit; each tip row has many columns, so keep multi-row inserts
+      // small even when a group tip has up to 100 paid recipients.
+      await db
+        .insertInto('tip')
+        .values(tipRows.slice(index, index + 4))
+        .execute()
+    }
   } catch (error) {
     if (!isUniqueConstraintError(error)) throw error
     const existing = await getExistingTipBatchResult(env, db, input, input.tokenAddress)
@@ -1197,6 +1249,7 @@ async function submitTipBatch(
       ok: true,
       recipients: input.recipients,
       senderProviderUserId: input.senderProviderUserId,
+      skippedRecipients: input.skippedRecipients,
       status: 'sent',
       tokenCurrency: tokenMetadata.currency,
       tokenSymbol: tokenMetadata.symbol,
@@ -1439,6 +1492,7 @@ async function submitSignedTipBatch(
       ok: true,
       recipients: input.recipients,
       senderProviderUserId: input.payload.senderProviderUserId,
+      skippedRecipients: input.payload.skippedRecipients,
       status: 'sent',
       tokenCurrency: tokenMetadata.currency,
       tokenSymbol: tokenMetadata.symbol,

--- a/src/routes/confirm/$token.tsx
+++ b/src/routes/confirm/$token.tsx
@@ -72,6 +72,11 @@ function ConfirmPanel(props: {
       recipientProviderUserId: data.recipientProviderUserId,
     },
   ]
+  const skippedRecipients: Array<{
+    reason: 'not_connected' | 'you'
+    recipientProviderLabel?: string | null
+    recipientProviderUserId: string
+  }> = data.skippedRecipients ?? []
   const totalAmount = String(Number(data.amount) * recipients.length)
 
   async function confirm() {
@@ -204,6 +209,14 @@ function ConfirmPanel(props: {
               <div className="space-y-5 border-b border-gray5 py-6">
                 <h3 className="text-lg font-bold text-gray10">Payment details</h3>
                 <div className="divide-y divide-gray5 rounded-xl border border-gray5 bg-bg1">
+                  {data.groupLabel ? (
+                    <div className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-5">
+                      <span className="text-base font-bold text-gray8 sm:text-lg">Group</span>
+                      <span className="text-lg font-bold text-gray10 sm:text-end sm:text-xl">
+                        @{data.groupLabel}
+                      </span>
+                    </div>
+                  ) : null}
                   <div className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-5">
                     <span className="text-base font-bold text-gray8 sm:text-lg">Amount</span>
                     <span className="text-lg font-bold text-gray10 sm:text-end sm:text-xl">
@@ -237,6 +250,23 @@ function ConfirmPanel(props: {
                       <span className="text-lg font-bold text-gray10 sm:text-end sm:text-xl">
                         {data.memo}
                       </span>
+                    </div>
+                  ) : null}
+                  {skippedRecipients.length ? (
+                    <div className="flex flex-col gap-2 p-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6 sm:p-5">
+                      <span className="text-base font-bold text-gray8 sm:text-lg">Skipped</span>
+                      <div className="text-lg font-bold text-gray10 sm:text-end sm:text-xl">
+                        {skippedRecipients.map((recipient) => (
+                          <div key={recipient.recipientProviderUserId}>
+                            {recipient.recipientProviderLabel
+                              ? `@${recipient.recipientProviderLabel}`
+                              : recipient.recipientProviderUserId}{' '}
+                            <span className="text-gray8">
+                              ({recipient.reason === 'you' ? 'you' : 'not connected yet'})
+                            </span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   ) : null}
                 </div>

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -23,9 +23,17 @@ export const slack = {
   teamDomain: 'emulate',
   teamId: 'T000000001',
   teamName: 'Emulate',
+  usergroupEngineeringId: 'SENGINEERING',
+  usergroupEngineeringName: 'engineering',
   unconnectedUserEmail: 'unconnected@example.com',
+  unconnectedUserId: 'U000000004',
   unconnectedUserName: 'unconnected',
 } as const
+
+export const slackBigUserIds = Array.from(
+  { length: 101 },
+  (_value, index) => `UGROUP${String(index).padStart(3, '0')}`,
+)
 
 export const slackConnect = {
   channelId: 'C0000000SC',
@@ -52,6 +60,7 @@ const slackScopes = [
   'groups:history',
   'groups:read',
   'reactions:read',
+  'usergroups:read',
   'users:read',
 ]
 
@@ -84,6 +93,7 @@ export const seed = {
       {
         email: slack.memberUserEmail,
         name: slack.memberUserName,
+        user_id: slack.memberUserId,
       },
       {
         email: slack.singleChannelGuestUserEmail,
@@ -102,6 +112,38 @@ export const seed = {
       {
         email: slack.unconnectedUserEmail,
         name: slack.unconnectedUserName,
+        user_id: slack.unconnectedUserId,
+      },
+      ...slackBigUserIds.map((providerUserId) => ({
+        email: `${providerUserId.toLowerCase()}@example.com`,
+        name: providerUserId.toLowerCase(),
+        user_id: providerUserId,
+      })),
+    ],
+    usergroups: [
+      {
+        handle: slack.usergroupEngineeringName,
+        name: slack.usergroupEngineeringName,
+        usergroup_id: slack.usergroupEngineeringId,
+        users: [slack.memberUserId, slack.unconnectedUserId, slack.adminUserId],
+      },
+      {
+        handle: 'bigteam',
+        name: 'bigteam',
+        usergroup_id: 'SBIGTEAM',
+        users: slackBigUserIds,
+      },
+      {
+        handle: 'reviewteam',
+        name: 'reviewteam',
+        usergroup_id: 'SREVIEWTEAM',
+        users: slackBigUserIds.slice(0, 11),
+      },
+      {
+        handle: 'smallteam',
+        name: 'smallteam',
+        usergroup_id: 'SSMALLTEAM',
+        users: slackBigUserIds.slice(0, 10),
       },
     ],
   },

--- a/test/e2e/confirm.test.ts
+++ b/test/e2e/confirm.test.ts
@@ -81,6 +81,51 @@ test('slack member opens valid multi-recipient confirmation link', async ({ app,
   await expect(page.getByText('team lunch')).toBeVisible()
 })
 
+test('slack member opens group confirmation link with skipped recipients', async ({
+  app,
+  page,
+}) => {
+  const token = await Confirmation.encrypt(app.env, {
+    accessKeyExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days
+    accessKeyLimit: '3000000',
+    amount: 1_000,
+    chainId: Tempo.chainLookup.localnet,
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(), // 10 minutes
+    groupLabel: 'engineering',
+    idempotencyKey: `confirm:${crypto.randomUUID()}`,
+    kind: 'reusable_access_key',
+    memo: 'coffee',
+    nonce: crypto.randomUUID(),
+    provider: 'slack',
+    providerChannelId: 'C000000001',
+    providerId: 'T000000001',
+    recipientProviderLabel: 'foo',
+    recipientProviderUserId: 'U000000002',
+    recipients: [
+      { recipientProviderLabel: 'foo', recipientProviderUserId: 'U000000002' },
+      { recipientProviderLabel: 'bar', recipientProviderUserId: 'U000000003' },
+    ],
+    senderProviderUserId: 'U000000001',
+    skippedRecipients: [
+      { reason: 'not_connected', recipientProviderLabel: 'boo', recipientProviderUserId: 'UBOO' },
+      { reason: 'you', recipientProviderLabel: 'joshie', recipientProviderUserId: 'UJOSHIE' },
+    ],
+    tokenAddress: Tempo.addressLookup.pathUsd,
+    workspaceId: crypto.randomUUID(),
+  })
+
+  await page.goto(app.url({ params: { token }, to: '/confirm/$token' }))
+
+  await expect(page.getByText('Group')).toBeVisible()
+  await expect(page.getByText('@engineering')).toBeVisible()
+  await expect(page.getByText('Skipped')).toBeVisible()
+  await expect(page.getByText('@boo (not connected yet)')).toBeVisible()
+  await expect(page.getByText('@joshie (you)')).toBeVisible()
+  await expect(page.getByText('$0.001 PathUSD each')).toBeVisible()
+  await expect(page.getByText('$0.002 PathUSD')).toBeVisible()
+  await expect(page.getByText('coffee')).toBeVisible()
+})
+
 test('slack member confirms payment with wallet approval', async ({ app, page }) => {
   const root = Account.fromSecp256k1(
     '0x0000000000000000000000000000000000000000000000000000000000000001',


### PR DESCRIPTION
Adds Slack usergroup tipping by expanding @engineering-style mentions into eligible connected recipients, previewing skipped members, and confirming from Slack when an access key can cover the payment.

Also raises multi-tip support to 100 recipients and updates Slack/web confirmation receipts for group and skipped-recipient metadata.