### PR TITLE
Support two reaction tip amounts

### DIFF
--- a/src/api.workers.test.ts
+++ b/src/api.workers.test.ts
@@ -596,7 +596,7 @@ describe('/api/confirm/:token', () => {
       channel_id: apiChannelId,
       idempotency_key: idempotencyKey,
       message_ts: parent.ts,
-      reaction: 'money_with_wings',
+      reaction: 'moneybag',
       recipient_member_id: confirmation.recipientMember.id,
       sender_member_id: confirmation.senderMember.id,
       thread_ts: parent.ts,

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -179,7 +179,7 @@ export function getChat() {
         .where('provider_id', '=', reaction.team_id)
         .executeTakeFirst()
       if (!workspace) return
-      if (reaction.reaction !== workspace.reaction_tip_emoji) return
+      if (getReactionTipAmount(reaction.reaction) === null) return
       return {
         db,
         provider: { id: reaction.team_id, type: 'slack' },
@@ -638,13 +638,6 @@ const handlers = {
     await postPrivateReply(event, event.user, 'Disconnected')
   },
   async help(event, ctx) {
-    const workspace = await ctx.db
-      .selectFrom('workspace')
-      .selectAll()
-      .where('provider', '=', ctx.provider.type)
-      .where('provider_id', '=', ctx.provider.id)
-      .executeTakeFirst()
-
     const commandRows = [
       [`${getSlackCommand(env.HOST)} @account [amount] [token] [for memo]`, 'Send payment'],
       [`${getSlackCommand(env.HOST)} balance`, 'Show wallet balance'],
@@ -681,10 +674,7 @@ const handlers = {
         `@${getSlackBotDisplayName(env.HOST)} @account 0.005 for coffee`,
         'Send custom amount with memo',
       ],
-      [
-        `[emoji] :${workspace?.reaction_tip_emoji ?? 'money_with_wings'}:`,
-        'Send default amount by reacting to a message',
-      ],
+      ['[emoji] :money_with_wings: / :moneybag:', 'Send $0.001 / $0.01 by reacting to a message'],
     ]
     const body = new URLSearchParams()
     body.set('channel', event.channel.id.replace(/^slack:/, ''))
@@ -1371,6 +1361,17 @@ type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
 
+const reactionTipAmounts = {
+  money_with_wings: 1_000,
+  moneybag: 10_000,
+} as const
+
+function getReactionTipAmount(reaction: string) {
+  return reaction in reactionTipAmounts
+    ? reactionTipAmounts[reaction as keyof typeof reactionTipAmounts]
+    : null
+}
+
 export function isReactionTipIdempotencyKey(value: string) {
   return value.startsWith(reactionTipIdempotencyPrefix)
 }
@@ -1947,7 +1948,11 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
   })()
   if (!inserted) return
 
+  const amount = getReactionTipAmount(event.reaction)
+  if (amount === null) return
+
   const result = await Tip.handleTipBatchRequest(env, {
+    amount,
     idempotencyKey,
     memo: null,
     provider: provider.type,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1837,14 +1837,14 @@ test('reaction tipping sends default tip and updates aggregate thread reply', as
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const readdResponse = await postSlackReaction({
     channelId,
     eventTs: `${message.ts}-readd`,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const tips = await db
@@ -1858,10 +1858,10 @@ test('reaction tipping sends default tip and updates aggregate thread reply', as
   expect(response.status).toBe(200)
   expect(readdResponse.status).toBe(200)
   expect(tips).toHaveLength(1)
-  expect(tips[0]).toMatchObject({ amount: 1000, confirmed_at: expect.any(String) })
+  expect(tips[0]).toMatchObject({ amount: 10_000, confirmed_at: expect.any(String) })
   await expectSlackThreadMessage(
     message.ts,
-    `:money_with_wings: Reaction tips received on this message:\n\n<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${message.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.001 · <`,
+    `:moneybag: Reaction tips received on this message:\n\n<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${message.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.01 · <`,
     { channelId },
   )
 })
@@ -1906,7 +1906,7 @@ for (const subtype of ['thread_broadcast', 'reply_broadcast']) {
     const response = await postSlackReaction({
       channelId,
       messageTs: reply.ts,
-      reaction: 'money_with_wings',
+      reaction: 'moneybag',
       userId: Constants.slack.adminUserId,
     })
     let reactionTip = await db
@@ -1987,7 +1987,7 @@ test('reaction tipping updates one aggregate reply for multiple tipped messages 
     channel_id: channelId,
     idempotency_key: firstTip.idempotency_key,
     message_ts: parent.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     recipient_member_id: connected.recipientMember.id,
     sender_member_id: connected.senderMember.id,
     thread_ts: parent.ts,
@@ -1996,7 +1996,7 @@ test('reaction tipping updates one aggregate reply for multiple tipped messages 
   })
   await Chat.updateReactionTipAggregate(providerId, {
     channelId,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     threadTs: parent.ts,
     workspaceId: connected.workspace.id,
   })
@@ -2034,7 +2034,7 @@ test('reaction tipping updates one aggregate reply for multiple tipped messages 
     channel_id: channelId,
     idempotency_key: secondTip.idempotency_key,
     message_ts: reply.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     recipient_member_id: connected.recipientMember.id,
     sender_member_id: connected.senderMember.id,
     thread_ts: parent.ts,
@@ -2043,21 +2043,21 @@ test('reaction tipping updates one aggregate reply for multiple tipped messages 
   })
   await Chat.updateReactionTipAggregate(providerId, {
     channelId,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     threadTs: parent.ts,
     workspaceId: connected.workspace.id,
   })
   const thread = await slack.conversations.replies({ channel: channelId, ts: parent.ts })
   const aggregates = thread.messages?.filter((message) =>
-    message.text?.includes(':money_with_wings: Reaction tips received in this thread:'),
+    message.text?.includes(':moneybag: Reaction tips received in this thread:'),
   )
 
   expect(aggregates, JSON.stringify(thread.messages)).toHaveLength(1)
   expect(aggregates?.[0]?.text).toContain(
-    `<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${parent.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.001 · <`,
+    `<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${parent.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.01 · <`,
   )
   expect(aggregates?.[0]?.text).toContain(
-    `<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${reply.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.001 · <`,
+    `<@${Constants.slack.memberUserId}> received a tip on <slack://channel?team=${providerId}&id=${channelId}&message=${reply.ts}|this> message:\n• <@${Constants.slack.adminUserId}> tipped $0.01 · <`,
   )
 })
 
@@ -2117,7 +2117,7 @@ test('reaction tipping ignores duplicate signed Slack event deliveries', async (
     eventId,
     eventTs: `${message.ts}-reaction`,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const secondResponse = await postSlackReaction({
@@ -2125,7 +2125,7 @@ test('reaction tipping ignores duplicate signed Slack event deliveries', async (
     eventId,
     eventTs: `${message.ts}-reaction`,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const tips = await db
@@ -2154,7 +2154,7 @@ test('reaction tipping reports unconnected sender', async () => {
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: unconnectedProviderUserId,
   })
   const reactionTips = await db
@@ -2186,7 +2186,7 @@ test('reaction tipping sends tip from single channel guest', async () => {
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.singleChannelGuestUserId,
   })
 
@@ -2230,7 +2230,7 @@ test('reaction tipping blocks Slack Connect external sender', async () => {
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slackConnect.userId,
   })
   const reactionTips = await db
@@ -2263,7 +2263,7 @@ test('reaction tipping reports unconnected recipient', async () => {
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const reactionTips = await db
@@ -2297,7 +2297,7 @@ test('reaction tipping reports approval required', async () => {
   const response = await postSlackReaction({
     channelId,
     messageTs: message.ts,
-    reaction: 'money_with_wings',
+    reaction: 'moneybag',
     userId: Constants.slack.adminUserId,
   })
   const reactionTips = await db
@@ -2948,8 +2948,8 @@ describe('/tip help', () => {
     await expectSlackMessage('@Tipbot @account')
     await expectSlackMessage('@Tipbot @account for coffee')
     await expectSlackMessage('@Tipbot @account 0.005 for coffee')
-    await expectSlackMessage('[emoji] :money_with_wings:')
-    await expectSlackMessage('Send default amount by reacting to a message')
+    await expectSlackMessage('[emoji] :money_with_wings: / :moneybag:')
+    await expectSlackMessage('Send $0.001 / $0.01 by reacting to a message')
     await expectSlackMessageNotContaining('Payment examples')
     await expectSlackMessage('/tip config')
     await expectSlackMessage('/tip connect')

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -124,6 +124,7 @@ export async function handleTipRequest(
           id,
           provider: input.provider,
           provider_id: input.providerId,
+          reaction_tip_emoji: 'money_with_wings',
           updated_at: now,
         })
         .execute()
@@ -260,6 +261,7 @@ export async function handleTipBatchRequest(
           id,
           provider: input.provider,
           provider_id: input.providerId,
+          reaction_tip_emoji: 'money_with_wings',
           updated_at: now,
         })
         .execute()


### PR DESCRIPTION
## Summary
- support fixed Slack reaction tip tiers: :money_with_wings: $0.001 and :moneybag: $0.01
- route reaction-tip amount from the emoji instead of the workspace default/configured reaction
- update reaction-tip tests and help copy

## Testing
- PATH=/home/agent/bin:$PATH pnpm check
- PATH=/home/agent/bin:$PATH pnpm test --project unit src/lib/tip.test.ts src/lib/format.test.ts

## Note
- Worker integration tests were attempted but the local Tempo harness failed during global setup before tests ran: eth_getTransactionCount returned HTTP 400 while minting test funds.