### PR TITLE
feat: support Slack Connect external senders

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -475,7 +475,7 @@ export const api = new Hono<{
                   'reaction_tip.workspace_id',
                   'tip.id as tip_id',
                 ])
-                .where('workspace.provider_id', '=', data.payload.providerId)
+                .where('reaction_tip.workspace_id', '=', data.payload.workspaceId)
                 .where('reaction_tip.idempotency_key', '=', data.payload.idempotencyKey)
                 .where('tip.confirmed_at', 'is not', null)
                 .executeTakeFirst()

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -92,8 +92,66 @@ export function getChat() {
           db: DB.create(env.DB),
           externalSlackConnect: true,
           provider: { id: slackConnectActor.providerId, type: 'slack' },
+          settingsProviderId: providerId,
           text: match[2]?.trim() ?? '',
           threadTs: privateThreadTs,
+        })
+        return
+      }
+      if (slackConnectActor.external && !match) {
+        const db = DB.create(env.DB)
+        const workspace = await db
+          .selectFrom('workspace')
+          .select(['id', 'installed_at'])
+          .where('provider', '=', 'slack')
+          .where('provider_id', '=', slackConnectActor.providerId)
+          .executeTakeFirst()
+        if (!workspace) {
+          await postPrivateReply(
+            event,
+            event.user,
+            `Payment not sent. Connect with \`@${getSlackBotDisplayName(env.HOST)} connect\` first.`,
+          )
+          return
+        }
+        if (workspace.installed_at) {
+          await postPrivateReply(
+            event,
+            event.user,
+            'Payment not sent. Use your workspace’s Tipbot app to send payments here.',
+          )
+          return
+        }
+        const member = await db
+          .selectFrom('member')
+          .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+          .select('member.id')
+          .where('member.workspace_id', '=', workspace.id)
+          .where('member.provider_user_id', '=', raw.user)
+          .where('provider_identity.account_id', 'is not', null)
+          .executeTakeFirst()
+        if (!member) {
+          await postPrivateReply(
+            event,
+            event.user,
+            `Payment not sent. Connect with \`@${getSlackBotDisplayName(env.HOST)} connect\` first.`,
+          )
+          return
+        }
+        await handlers.default(event, {
+          channelProviderId: providerId,
+          db,
+          externalSlackConnect: true,
+          provider: { id: slackConnectActor.providerId, type: 'slack' },
+          settingsProviderId: providerId,
+          text: parseSlackMentionTipText(mentionText) ?? '',
+          threadTs: privateThreadTs,
+          defaultTip: {
+            idempotencyKey: `mention:${providerId}:${raw.channel}:${raw.ts}`,
+            insufficientFundsThreadTs: raw.thread_ts,
+            mention: true,
+            threadTs: publicThreadTs,
+          },
         })
         return
       }
@@ -386,11 +444,13 @@ const actions = {
       providerThreadId: pending.providerThreadId,
       recipients: pending.recipients,
       senderProviderUserId: pending.senderProviderUserId,
+      settingsProviderId: pending.settingsProviderId,
       skippedRecipients: pending.skippedRecipients,
       source: pending.source,
       tokenAddress: pending.tokenAddress,
       usergroupId: pending.usergroupId,
       usergroupLabel: pending.usergroupLabel,
+      workspaceProviderId: pending.workspaceProviderId,
     }).catch(
       (error) =>
         ({
@@ -523,7 +583,7 @@ const handlers = {
       .selectFrom('workspace')
       .selectAll()
       .where('provider', '=', ctx.provider.type)
-      .where('provider_id', '=', ctx.provider.id)
+      .where('provider_id', '=', ctx.settingsProviderId ?? ctx.provider.id)
       .executeTakeFirst()
     if (!workspace) {
       await postPrivateReply(
@@ -595,7 +655,7 @@ const handlers = {
       .selectFrom('workspace')
       .selectAll()
       .where('provider', '=', ctx.provider.type)
-      .where('provider_id', '=', ctx.provider.id)
+      .where('provider_id', '=', ctx.settingsProviderId ?? ctx.provider.id)
       .executeTakeFirst()
     if (!workspace) {
       await postPrivateReply(
@@ -1059,7 +1119,7 @@ const handlers = {
       .selectFrom('workspace')
       .selectAll()
       .where('provider', '=', ctx.provider.type)
-      .where('provider_id', '=', ctx.provider.id)
+      .where('provider_id', '=', ctx.settingsProviderId ?? ctx.provider.id)
       .executeTakeFirst()
     const parsed = Tip.parseTipBatchText(ctx.text, {
       chainId: workspace?.chain_id ?? Tempo.chainLookup.mainnet,
@@ -1135,7 +1195,9 @@ const handlers = {
       Boolean(parsed.usergroups?.length) ||
       (await (async () => {
         // Single-recipient Slack Connect tips still need workspace-safe recipient resolution.
-        const installation = await getSlack().getInstallation(ctx.provider.id)
+        const installation = await getSlack().getInstallation(
+          ctx.channelProviderId ?? ctx.provider.id,
+        )
         if (!installation) return false
         return (await getSlackConversationInfo(installation.botToken, event.channel.id)).isShared
       })().catch(() => false))
@@ -1164,15 +1226,17 @@ const handlers = {
         idempotencyKey: options.idempotencyKey,
         memo: parsed.memo,
         providerChannelId: event.channel.id,
-        providerId: ctx.provider.id,
+        providerId: ctx.channelProviderId ?? ctx.provider.id,
         providerThreadId: options.threadTs,
         recipients: plan.recipients,
         senderProviderUserId: event.user.userId,
+        settingsProviderId: ctx.settingsProviderId,
         skippedRecipients: plan.skippedRecipients,
         source: options.mention ? 'mention' : 'command',
         tokenAddress: tokenAddress ?? undefined,
         usergroupId: plan.usergroupId,
         usergroupLabel: plan.usergroupLabel,
+        workspaceProviderId: ctx.provider.id,
       })
       return
     }
@@ -1192,13 +1256,15 @@ const handlers = {
               memo: parsed.memo,
               provider: ctx.provider.type,
               providerChannelId: event.channel.id,
-              providerId: ctx.provider.id,
+              providerId: ctx.channelProviderId ?? ctx.provider.id,
               providerThreadId: options.threadTs,
               recipientProviderLabel: plan.recipients[0]?.recipientProviderLabel,
               recipientProviderUserId: plan.recipients[0]!.recipientProviderUserId,
               recipientProviderWorkspaceId: plan.recipients[0]?.recipientProviderWorkspaceId,
               senderProviderUserId: event.user.userId,
+              settingsProviderId: ctx.settingsProviderId,
               tokenAddress: tokenAddress ?? undefined,
+              workspaceProviderId: ctx.provider.id,
             })
           : Tip.handleTipBatchRequest(env, {
               amount: parsed.amount,
@@ -1206,15 +1272,17 @@ const handlers = {
               memo: parsed.memo,
               provider: ctx.provider.type,
               providerChannelId: event.channel.id,
-              providerId: ctx.provider.id,
+              providerId: ctx.channelProviderId ?? ctx.provider.id,
               providerThreadId: options.threadTs,
               recipients: plan.recipients,
               senderProviderUserId: event.user.userId,
+              settingsProviderId: ctx.settingsProviderId,
               skippedRecipients: plan.skippedRecipients,
               source: options.mention ? 'mention' : 'command',
               tokenAddress: tokenAddress ?? undefined,
               usergroupId: plan.usergroupId,
               usergroupLabel: plan.usergroupLabel,
+              workspaceProviderId: ctx.provider.id,
             })
       ).catch(
         (error) =>
@@ -1368,6 +1436,7 @@ type HandlerContext = {
   db: DB.Type
   externalSlackConnect?: boolean
   provider: ProviderContext
+  settingsProviderId?: string
   text: string
   threadTs?: string
 }
@@ -1400,11 +1469,13 @@ type PendingSlackTip = {
   providerThreadId?: string
   recipients: Tip.TipRecipientInput[]
   senderProviderUserId: string
+  settingsProviderId?: string
   skippedRecipients?: Tip.TipSkippedRecipient[]
   source: 'command' | 'mention' | 'reaction'
   tokenAddress?: string
   usergroupId?: string
   usergroupLabel?: string
+  workspaceProviderId?: string
 }
 
 type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
@@ -1439,7 +1510,7 @@ async function setSlackAssistantThreadStatus(
   status: string,
   options?: { loadingMessages?: readonly string[] },
 ) {
-  const installation = await getSlack().getInstallation(ctx.provider.id)
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
   if (!installation) return
 
   const body = new URLSearchParams()
@@ -1483,7 +1554,7 @@ async function resolveSlackTipPlan(
   )
     return { message: 'Payment not sent. Cannot send a payment to yourself.', ok: false }
 
-  const installation = await getSlack().getInstallation(ctx.provider.id)
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
   if (!installation)
     return {
       ok: true,
@@ -1689,14 +1760,16 @@ async function resolveLocalSlackRecipient(ctx: HandlerContext, recipient: Tip.Ti
 }
 
 async function resolveSlackConnectRecipient(
-  ctx: Pick<HandlerContext, 'db' | 'provider'>,
+  ctx: Pick<HandlerContext, 'channelProviderId' | 'db' | 'provider'>,
   teamIds: Set<string>,
   recipient: Tip.TipRecipientInput,
 ) {
-  const candidates = [...teamIds, ctx.provider.id].map((providerWorkspaceId) => ({
-    providerUserId: recipient.recipientProviderUserId,
-    providerWorkspaceId,
-  }))
+  const candidates = [...teamIds, ctx.channelProviderId, ctx.provider.id]
+    .filter((providerWorkspaceId) => providerWorkspaceId !== undefined)
+    .map((providerWorkspaceId) => ({
+      providerUserId: recipient.recipientProviderUserId,
+      providerWorkspaceId,
+    }))
   for (const tokenTeamId of teamIds) {
     const tokenInstallation = await getSlack().getInstallation(tokenTeamId)
     if (!tokenInstallation) continue
@@ -1746,19 +1819,45 @@ async function resolveSlackConnectRecipient(
 }
 
 async function handleSlackReactionTip(event: SlackReactionEvent, context: ReactionHandlerContext) {
-  const { db, provider, workspace } = context
+  const { db, provider } = context
+  let workspace = context.workspace
 
   const installation = await getSlack().getInstallation(provider.id)
   if (!installation) return
 
-  if (await isExternalSlackConnectActor(provider.id, event.item.channel, event.user)) {
-    await postSlackEphemeral(
-      provider.id,
-      event.item.channel,
-      event.user,
-      `Tipbot can connect your account here, but payments in Slack Connect channels aren’t supported yet unless you install the Tipbot app to your workspace.`,
-    )
-    return
+  const slackConnectActor = await resolveSlackConnectActor(
+    provider.id,
+    event.item.channel,
+    event.user,
+  )
+  if (slackConnectActor.blocked) return
+  if (slackConnectActor.external) {
+    const senderWorkspace = await db
+      .selectFrom('workspace')
+      .selectAll()
+      .where('provider', '=', 'slack')
+      .where('provider_id', '=', slackConnectActor.providerId)
+      .executeTakeFirst()
+    if (!senderWorkspace) return
+    if (senderWorkspace.installed_at) {
+      await postSlackEphemeral(
+        provider.id,
+        event.item.channel,
+        event.user,
+        'Payment not sent. Use your workspace’s Tipbot app to send payments here.',
+      )
+      return
+    }
+    const sender = await db
+      .selectFrom('member')
+      .innerJoin('provider_identity', 'provider_identity.id', 'member.provider_identity_id')
+      .select('member.id')
+      .where('member.workspace_id', '=', senderWorkspace.id)
+      .where('member.provider_user_id', '=', event.user)
+      .where('provider_identity.account_id', 'is not', null)
+      .executeTakeFirst()
+    if (!sender) return
+    workspace = senderWorkspace
   }
 
   const conversation = await getSlackConversationInfo(installation.botToken, event.item.channel)
@@ -1991,7 +2090,9 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
     providerId: provider.id,
     recipients: [recipient.input],
     senderProviderUserId: sender.providerUserId,
+    settingsProviderId: provider.id,
     source: 'reaction',
+    workspaceProviderId: workspace.provider_id,
   }).catch(
     (error) =>
       ({
@@ -2197,15 +2298,6 @@ async function postSlackPrivateReply(
     await response.json(),
   )
   if (!json.ok) throw Slack.slackApiError(method, json.error)
-}
-
-async function isExternalSlackConnectActor(
-  providerId: string,
-  channelId: string,
-  providerUserId: string,
-) {
-  const actor = await resolveSlackConnectActor(providerId, channelId, providerUserId)
-  return actor.blocked || actor.external
 }
 
 async function resolveSlackConnectActor(
@@ -2571,7 +2663,7 @@ async function postInvalidUsage(
   )
   if (options.threadTs) body.set('thread_ts', options.threadTs)
   await postSlackPrivateReply(
-    ctx.provider.id,
+    ctx.channelProviderId ?? ctx.provider.id,
     event.channel.id.replace(/^slack:/, ''),
     event.user.userId,
     body,
@@ -2585,7 +2677,7 @@ async function postInvalidMentionReply(
   mentionText: string,
   threadTs: string,
 ) {
-  const installation = await getSlack().getInstallation(ctx.provider.id)
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
   if (!installation) throw new Error('Tibot app not installed for this workspace.')
 
   const body = new URLSearchParams()
@@ -2709,7 +2801,7 @@ async function postSlackInsufficientFunds(event: TipEvent, ctx: HandlerContext, 
 }
 
 async function postConnectLink(event: TipEvent, ctx: HandlerContext) {
-  const workspace =
+  let workspace =
     (await ctx.db
       .selectFrom('workspace')
       .selectAll()
@@ -2748,6 +2840,27 @@ async function postConnectLink(event: TipEvent, ctx: HandlerContext) {
       'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
     )
     return
+  }
+  if (ctx.settingsProviderId && !workspace.installed_at) {
+    const settingsWorkspace = await ctx.db
+      .selectFrom('workspace')
+      .select(['chain_id', 'default_amount', 'default_token_address'])
+      .where('provider', '=', ctx.provider.type)
+      .where('provider_id', '=', ctx.settingsProviderId)
+      .executeTakeFirst()
+    if (settingsWorkspace) {
+      await ctx.db
+        .updateTable('workspace')
+        .set({
+          chain_id: settingsWorkspace.chain_id,
+          default_amount: settingsWorkspace.default_amount,
+          default_token_address: settingsWorkspace.default_token_address,
+          updated_at: new Date().toISOString(),
+        })
+        .where('id', '=', workspace.id)
+        .execute()
+      workspace = { ...workspace, ...settingsWorkspace }
+    }
   }
 
   let member = await ctx.db
@@ -3050,7 +3163,7 @@ async function postSlackReceiptMessage(
   context?: string,
   threadTs?: string,
 ) {
-  const installation = await getSlack().getInstallation(ctx.provider.id)
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
   if (!installation) throw new Error('Tibot app not installed for this workspace.')
 
   const receiptText = text.replace(/\.$/, '')
@@ -3116,7 +3229,7 @@ async function postSlackMemoReply(
   const creatureMatch = memo.match(creaturePattern)
   if (!creatureMatch) return
 
-  const installation = await getSlack().getInstallation(ctx.provider.id)
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
   if (!installation) return
 
   const fallback = `${creatureMatch[0].toUpperCase()}? Now we are talking.`

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -2948,7 +2948,7 @@ async function postSlackInsufficientFunds(event: TipEvent, ctx: HandlerContext, 
   body.set('text', message)
   if (threadTs) body.set('thread_ts', threadTs)
   await postSlackPrivateReply(
-    ctx.provider.id,
+    ctx.channelProviderId ?? ctx.provider.id,
     event.channel.id.replace(/^slack:/, ''),
     event.user.userId,
     body,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2027,46 +2027,78 @@ test('@Tipbot mention posts Slack Connect confirmation with host workspace insta
   fetchSpy.mockRestore()
 }, 20_000) // 20 seconds
 
+test('@Tipbot mention confirms Slack Connect external sender tip from sender workspace', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  await deleteSlackConnectWorkspace()
+  const channelId = await getSlackConnectChannelId()
+  const connected = await connectSlackConnectSender()
+  await db.deleteFrom('access_key').where('account_id', '=', connected.senderAccount.id).execute()
+  const messageTs = `1700000033.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    userId: Constants.slackConnect.userId,
+  })
+  const call = await getSlackPostEphemeralCall(
+    fetchSpy,
+    'Tipbot needs your approval to send this payment.',
+  )
+  const params = await slackFetchCallBodyParams(...call)
+  const token = params.get('text')?.match(/\/confirm\/(0x[0-9a-f]+\.0x[0-9a-f]+)/i)?.[1]
+  if (!token) throw new Error('Expected confirmation token in Slack message.')
+  const confirmation = await client.api.confirm[':token'].$get({ param: { token } })
+  const confirmationJson = await confirmation.json()
+  if (!confirmationJson.ok) throw new Error('Expected confirmation metadata.')
+  const root = Account.fromSecp256k1(Constants.tip.senderRootPrivateKey)
+  const keyAuthorization = await AccountLink.signKeyAuthorization(root, {
+    accessKeyAddress: confirmationJson.accessKeyAddress,
+    chainId: confirmationJson.chainId,
+    expiresAt: confirmationJson.accessKeyExpiry,
+    tokenAddress: confirmationJson.tokenAddress,
+  })
+
+  const confirmResponse = await client.api.confirm[':token'].$post({
+    json: { address: root.address, keyAuthorization },
+    param: { token },
+  })
+  await drainWaitUntil()
+  const tip = await waitForTipByIdempotencyKey(`mention:${providerId}:${channelId}:${messageTs}`)
+  const tipDetails = await db
+    .selectFrom('tip')
+    .select(['amount', 'confirmed_at', 'recipient_member_id', 'sender_member_id', 'workspace_id'])
+    .where('id', '=', tip.id)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(confirmation.status).toBe(200)
+  expect(confirmationJson).toMatchObject({
+    amount: '0.001',
+    kind: 'reusable_access_key',
+    recipientProviderUserId: Constants.slack.memberUserId,
+  })
+  expect(confirmResponse.status).toBe(200)
+  await expect(confirmResponse.json()).resolves.toMatchObject({ ok: true })
+  expect(tipDetails).toMatchObject({
+    amount: 1000,
+    confirmed_at: expect.any(String),
+    recipient_member_id: connected.hostRecipientMember.id,
+    sender_member_id: connected.senderMember.id,
+    workspace_id: connected.senderWorkspace.id,
+  })
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slackConnect.userId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+    { channelId, wait: true },
+  )
+  fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
 test('@Tipbot mention fails closed when Slack Connect recipient workspace is not installed', async () => {
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
   await connectTipAccounts({ recipient: false })
-  const connectWorkspace = await db
-    .selectFrom('workspace')
-    .select('id')
-    .where('provider', '=', 'slack')
-    .where('provider_id', '=', Constants.slackConnect.teamId)
-    .executeTakeFirst()
-  if (connectWorkspace) {
-    const connectMembers = await db
-      .selectFrom('member')
-      .select(['id', 'provider_identity_id'])
-      .where('workspace_id', '=', connectWorkspace.id)
-      .execute()
-    if (connectMembers.length > 0) {
-      await db
-        .deleteFrom('tip')
-        .where(
-          'recipient_member_id',
-          'in',
-          connectMembers.map((member) => member.id),
-        )
-        .execute()
-      await db
-        .deleteFrom('member')
-        .where(
-          'id',
-          'in',
-          connectMembers.map((member) => member.id),
-        )
-        .execute()
-      const providerIdentityIds = connectMembers
-        .map((member) => member.provider_identity_id)
-        .filter((providerIdentityId) => providerIdentityId !== null)
-      if (providerIdentityIds.length > 0)
-        await db.deleteFrom('provider_identity').where('id', 'in', providerIdentityIds).execute()
-    }
-    await db.deleteFrom('workspace').where('id', '=', connectWorkspace.id).execute()
-  }
+  await deleteSlackConnectWorkspace()
   const channelId = await getSlackConnectChannelId()
   const messageTs = `1700000000.${Nanoid.generate().slice(0, 6)}`
 
@@ -4484,7 +4516,7 @@ async function connectSlackConnectSender() {
     expires_at: accessKeyExpiresAt,
     token_address: Tempo.addressLookup.pathUsd,
   })
-  return { hostRecipientMember, hostWorkspace, senderMember, senderWorkspace }
+  return { hostRecipientMember, hostWorkspace, senderAccount, senderMember, senderWorkspace }
 }
 
 async function findOrCreateAccount(address: string) {
@@ -5168,37 +5200,43 @@ async function createSlashCommandRequestInit(
 }
 
 async function deleteSlackConnectWorkspace() {
-  const workspace = await db
+  const workspaces = await db
     .selectFrom('workspace')
     .select('id')
     .where('provider', '=', 'slack')
     .where('provider_id', '=', Constants.slackConnect.teamId)
-    .executeTakeFirst()
-  if (!workspace) return
-
-  const members = await db
-    .selectFrom('member')
-    .select(['id', 'provider_identity_id'])
-    .where('workspace_id', '=', workspace.id)
     .execute()
-  if (members.length > 0) {
-    const memberIds = members.map((member) => member.id)
-    await db.deleteFrom('reaction_tip').where('sender_member_id', 'in', memberIds).execute()
-    await db.deleteFrom('reaction_tip').where('recipient_member_id', 'in', memberIds).execute()
-    await db.deleteFrom('tip').where('sender_member_id', 'in', memberIds).execute()
-    await db.deleteFrom('tip').where('recipient_member_id', 'in', memberIds).execute()
-    await db.deleteFrom('tip_batch').where('sender_member_id', 'in', memberIds).execute()
-    await db.deleteFrom('member').where('id', 'in', memberIds).execute()
-    await db
-      .deleteFrom('provider_identity')
-      .where(
-        'id',
-        'in',
-        members.map((member) => member.provider_identity_id),
-      )
+
+  for (const workspace of workspaces) {
+    const members = await db
+      .selectFrom('member')
+      .select(['id', 'provider_identity_id'])
+      .where('workspace_id', '=', workspace.id)
       .execute()
+    const memberIds = members.map((member) => member.id)
+    await db.deleteFrom('reaction_tip_thread').where('workspace_id', '=', workspace.id).execute()
+    if (memberIds.length > 0) {
+      await db.deleteFrom('reaction_tip').where('sender_member_id', 'in', memberIds).execute()
+      await db.deleteFrom('reaction_tip').where('recipient_member_id', 'in', memberIds).execute()
+    }
+    await db.deleteFrom('tip').where('workspace_id', '=', workspace.id).execute()
+    if (memberIds.length > 0) {
+      await db.deleteFrom('tip').where('sender_member_id', 'in', memberIds).execute()
+      await db.deleteFrom('tip').where('recipient_member_id', 'in', memberIds).execute()
+    }
+    await db.deleteFrom('tip_batch').where('workspace_id', '=', workspace.id).execute()
+    if (memberIds.length > 0) {
+      await db.deleteFrom('tip_batch').where('sender_member_id', 'in', memberIds).execute()
+      await db.deleteFrom('account_link_token').where('member_id', 'in', memberIds).execute()
+      await db.deleteFrom('member').where('id', 'in', memberIds).execute()
+    }
+    const providerIdentityIds = members
+      .map((member) => member.provider_identity_id)
+      .filter((providerIdentityId) => providerIdentityId !== null)
+    if (providerIdentityIds.length > 0)
+      await db.deleteFrom('provider_identity').where('id', 'in', providerIdentityIds).execute()
+    await db.deleteFrom('workspace').where('id', '=', workspace.id).execute()
   }
-  await db.deleteFrom('workspace').where('id', '=', workspace.id).execute()
 }
 
 async function insertMember(

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1921,6 +1921,44 @@ test('@Tipbot mention sends Slack Connect external sender tip from sender worksp
   })
 }, 20_000) // 20 seconds
 
+test('@Tipbot mention shows add funds action for Slack Connect external sender with host installation', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  const handleTipRequest = vi.spyOn(Tip, 'handleTipRequest').mockResolvedValue({
+    code: 'insufficient_funds',
+    ok: false,
+  })
+  await deleteSlackConnectWorkspace()
+  const channelId = await getSlackConnectChannelId()
+  const connected = await connectSlackConnectSender()
+  const messageTs = `1700000032.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    userId: Constants.slackConnect.userId,
+  })
+  const call = await getSlackPostEphemeralCall(
+    fetchSpy,
+    'Payment not sent. Your wallet has insufficient funds.',
+  )
+
+  expect(response.status).toBe(200)
+  expect(handleTipRequest).toHaveBeenCalledWith(
+    env,
+    expect.objectContaining({
+      providerId,
+      settingsProviderId: providerId,
+      workspaceProviderId: connected.senderWorkspace.provider_id,
+    }),
+  )
+  expect(getSlackFetchAuthorization(call)).toBe(`Bearer ${Constants.slack.botToken}`)
+  expect(getSlackFetchAuthorization(call)).not.toBe(`Bearer ${Constants.slackConnect.teamBotToken}`)
+  await expectSlackPostEphemeralCall(fetchSpy, 'Add funds on https://wallet.tempo.xyz')
+  handleTipRequest.mockRestore()
+  fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
 test('@Tipbot mention blocks Slack Connect external sender after sender workspace installs', async () => {
   await deleteSlackConnectWorkspace()
   const channelId = await getSlackConnectChannelId()

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1167,7 +1167,7 @@ test.each([
     expect(tips).toEqual([])
     const expectedMessage =
       input.name === 'tip text'
-        ? 'Payment not sent. Use your workspace’s Tipbot app to send payments here.'
+        ? 'Payment not sent. Connect with `<@Tipbot> connect` first.'
         : 'Tipbot is not installed in your Slack workspace yet.'
     await expectSlackMessage(expectedMessage, { channelId })
     await expectSlackThreadMessageNotContaining(messageTs, expectedMessage, { channelId })
@@ -1215,6 +1215,14 @@ test('@Tipbot mention supports connect command for Slack Connect external actors
   await deleteSlackConnectWorkspace()
   const channelId = await getSlackConnectChannelId()
   const messageTs = `1700000016.${Nanoid.generate().slice(0, 6)}`
+  await db
+    .updateTable('workspace')
+    .set({
+      chain_id: Tempo.chainLookup.testnet,
+      default_token_address: Tempo.addressLookup.betaUsd,
+    })
+    .where('provider_id', '=', providerId)
+    .execute()
 
   const response = await postSlackAppMention({
     channelId,
@@ -1228,6 +1236,8 @@ test('@Tipbot mention supports connect command for Slack Connect external actors
     .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
     .select([
       'account_link_token.id',
+      'workspace.chain_id',
+      'workspace.default_token_address',
       'member.provider_user_id',
       'workspace.installed_at',
       'workspace.provider_id',
@@ -1247,6 +1257,8 @@ test('@Tipbot mention supports connect command for Slack Connect external actors
   expect(response.status).toBe(200)
   expect(hostMembers).toEqual([])
   expect(token).toMatchObject({
+    chain_id: Tempo.chainLookup.testnet,
+    default_token_address: Tempo.addressLookup.betaUsd,
     installed_at: null,
     provider_id: Constants.slackConnect.teamId,
     provider_user_id: Constants.slackConnect.userId,
@@ -1486,6 +1498,95 @@ test('@Tipbot mention sends Slack Connect tip to recipient home workspace member
     sender_member_id: connected.senderMember.id,
     workspace_id: connected.workspace.id,
   })
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention sends Slack Connect external sender tip from sender workspace with host defaults', async () => {
+  await deleteSlackConnectWorkspace()
+  const channelId = await getSlackConnectChannelId()
+  await db
+    .updateTable('workspace')
+    .set({ default_amount: 2000 })
+    .where('provider_id', '=', providerId)
+    .execute()
+  const connected = await connectSlackConnectSender()
+  const messageTs = `1700000027.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    userId: Constants.slackConnect.userId,
+  })
+  const tip = await waitForTipByIdempotencyKey(`mention:${providerId}:${channelId}:${messageTs}`)
+  const batch = await db
+    .selectFrom('tip_batch')
+    .select('provider_id')
+    .where(
+      'id',
+      '=',
+      (
+        await db
+          .selectFrom('tip')
+          .select('batch_id')
+          .where('id', '=', tip.id)
+          .executeTakeFirstOrThrow()
+      ).batch_id,
+    )
+    .executeTakeFirstOrThrow()
+  const tipDetails = await db
+    .selectFrom('tip')
+    .select([
+      'tip.amount',
+      'tip.confirmed_at',
+      'tip.recipient_member_id',
+      'tip.sender_member_id',
+      'tip.workspace_id',
+    ])
+    .where('tip.id', '=', tip.id)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slackConnect.userId}> tipped <@${Constants.slack.memberUserId}> $0.002 · Receipt`,
+    { channelId },
+  )
+  expect({ ...tipDetails, provider_id: batch.provider_id }).toMatchObject({
+    amount: 2000,
+    confirmed_at: expect.any(String),
+    provider_id: providerId,
+    recipient_member_id: connected.hostRecipientMember.id,
+    sender_member_id: connected.senderMember.id,
+    workspace_id: connected.senderWorkspace.id,
+  })
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention blocks Slack Connect external sender after sender workspace installs', async () => {
+  await deleteSlackConnectWorkspace()
+  const channelId = await getSlackConnectChannelId()
+  const connected = await connectSlackConnectSender()
+  await db
+    .updateTable('workspace')
+    .set({ installed_at: new Date().toISOString() })
+    .where('id', '=', connected.senderWorkspace.id)
+    .execute()
+  const messageTs = `1700000028.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    userId: Constants.slackConnect.userId,
+  })
+  const tips = await db
+    .selectFrom('tip')
+    .select('id')
+    .where('sender_member_id', '=', connected.senderMember.id)
+    .execute()
+
+  expect(response.status).toBe(200)
+  expect(tips).toEqual([])
+  await expectSlackMessage('Use your workspace’s Tipbot app', { channelId })
 }, 20_000) // 20 seconds
 
 test('@Tipbot mention posts Slack Connect confirmation with host workspace installation', async () => {
@@ -2595,13 +2696,13 @@ test('reaction tipping sends Slack Connect tip to recipient home workspace membe
   await expectSlackThreadMessage(message.ts, 'tipped', { channelId, wait: true })
 }, 20_000) // 20 seconds
 
-test('reaction tipping blocks Slack Connect external sender', async () => {
+test('reaction tipping silently ignores unconnected Slack Connect external sender', async () => {
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
-  await connectTipAccounts()
+  await deleteSlackConnectWorkspace()
   const channelId = await getSlackConnectChannelId()
   const message = await memberSlack.chat.postMessage({
     channel: channelId,
-    text: 'external sender should not reaction tip',
+    text: 'unconnected external sender should not reaction tip',
   })
   if (!message.ts) throw new Error('Expected Slack message timestamp.')
 
@@ -2611,22 +2712,67 @@ test('reaction tipping blocks Slack Connect external sender', async () => {
     reaction: 'money_with_wings',
     userId: Constants.slackConnect.userId,
   })
-  const reactionTips = await db
-    .selectFrom('reaction_tip')
-    .innerJoin('workspace', 'workspace.id', 'reaction_tip.workspace_id')
-    .selectAll('reaction_tip')
-    .where('workspace.provider_id', '=', providerId)
-    .execute()
+  const workspace = await db
+    .selectFrom('workspace')
+    .select('id')
+    .where('provider', '=', 'slack')
+    .where('provider_id', '=', Constants.slackConnect.teamId)
+    .executeTakeFirst()
 
   expect(response.status).toBe(200)
-  expect(reactionTips).toHaveLength(0)
-  await expectSlackPostEphemeralCall(
-    fetchSpy,
-    'payments in Slack Connect channels aren’t supported yet unless you install the Tipbot app to your workspace.',
-  )
+  expect(workspace).toBeUndefined()
+  expect(
+    await Promise.all(
+      fetchSpy.mock.calls.map(async (call) => {
+        const input = call[0]
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+        const params = await slackFetchCallBodyParams(...call)
+        return (
+          url.endsWith('/chat.postEphemeral') &&
+          `${params.get('text') ?? ''} ${params.get('blocks') ?? ''}`.includes('Connect')
+        )
+      }),
+    ).then((calls) => calls.some(Boolean)),
+  ).toBe(false)
   await expectSlackThreadMessageNotContaining(message.ts, 'tipped', { channelId })
   fetchSpy.mockRestore()
 })
+
+test('reaction tipping sends Slack Connect external sender tip from sender workspace with host defaults', async () => {
+  await deleteSlackConnectWorkspace()
+  const channelId = await getSlackConnectChannelId()
+  await db
+    .updateTable('workspace')
+    .set({ default_amount: 3000 })
+    .where('provider_id', '=', providerId)
+    .execute()
+  const connected = await connectSlackConnectSender()
+  const message = await memberSlack.chat.postMessage({
+    channel: channelId,
+    text: 'external sender should reaction tip host member',
+  })
+  if (!message.ts) throw new Error('Expected Slack message timestamp.')
+
+  const response = await postSlackReaction({
+    channelId,
+    itemUserId: Constants.slack.memberUserId,
+    messageTs: message.ts,
+    reaction: 'money_with_wings',
+    userId: Constants.slackConnect.userId,
+  })
+  const tip = await waitForTipByIdempotencyKey(
+    `${Chat.reactionTipIdempotencyPrefix}:${connected.senderWorkspace.id}:${channelId}:${message.ts}:money_with_wings:${connected.senderMember.id}:${message.ts}-reaction`,
+  )
+
+  expect(response.status).toBe(200)
+  expect(tip).toMatchObject({
+    recipient_member_id: connected.hostRecipientMember.id,
+    sender_member_id: connected.senderMember.id,
+    workspace_id: connected.senderWorkspace.id,
+  })
+  await expectSlackThreadMessage(message.ts, '$0.003', { channelId, wait: true })
+}, 20_000) // 20 seconds
 
 test('reaction tipping reports unconnected recipient', async () => {
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
@@ -3893,6 +4039,54 @@ async function connectTipAccounts(
     senderMember,
     workspace,
   }
+}
+
+async function connectSlackConnectSender() {
+  const hostWorkspace = await db
+    .selectFrom('workspace')
+    .selectAll()
+    .where('provider_id', '=', providerId)
+    .executeTakeFirstOrThrow()
+  const senderRoot = Account.fromSecp256k1(Constants.tip.senderRootPrivateKey)
+  const recipientRoot = Account.fromSecp256k1(Constants.tip.recipientRootPrivateKey)
+  const accessKey = AccessKey.generate()
+  const accessKeyExpiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days
+  const senderAccount = await findOrCreateAccount(senderRoot.address)
+  const recipientAccount = await findOrCreateAccount(recipientRoot.address)
+  const senderWorkspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    installed_at: null,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  const senderMember = await insertMember({
+    account_id: senderAccount.id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: senderWorkspace.id,
+  })
+  const hostRecipientMember = await insertMember({
+    account_id: recipientAccount.id,
+    provider_user_id: Constants.slack.memberUserId,
+    workspace_id: hostWorkspace.id,
+  })
+  await db.deleteFrom('access_key').where('account_id', '=', senderAccount.id).execute()
+  await factory.access_key.insert({
+    account_id: senderAccount.id,
+    address: accessKey.address,
+    authorization: JSON.stringify(
+      await AccountLink.signKeyAuthorization(senderRoot, {
+        accessKeyAddress: accessKey.address,
+        chainId: Tempo.chainLookup.localnet,
+        expiresAt: accessKeyExpiresAt,
+        tokenAddress: Tempo.addressLookup.pathUsd,
+      }),
+    ),
+    chain_id: Tempo.chainLookup.localnet,
+    ciphertext: await AccessKey.encrypt(env, accessKey.privateKey),
+    expires_at: accessKeyExpiresAt,
+    token_address: Tempo.addressLookup.pathUsd,
+  })
+  return { hostRecipientMember, hostWorkspace, senderMember, senderWorkspace }
 }
 
 async function findOrCreateAccount(address: string) {

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -101,7 +101,9 @@ export async function handleTipRequest(
     recipientProviderUserId: string
     recipientProviderWorkspaceId?: string
     senderProviderUserId: string
+    settingsProviderId?: string
     tokenAddress?: string
+    workspaceProviderId?: string
   },
 ): Promise<TipResult> {
   const db = DB.create(env.DB)
@@ -110,7 +112,7 @@ export async function handleTipRequest(
       .selectFrom('workspace')
       .selectAll()
       .where('provider', '=', input.provider)
-      .where('provider_id', '=', input.providerId)
+      .where('provider_id', '=', input.workspaceProviderId ?? input.providerId)
       .executeTakeFirst()) ??
     (await (async () => {
       const id = Nanoid.generate()
@@ -124,7 +126,7 @@ export async function handleTipRequest(
           id,
           installed_at: now,
           provider: input.provider,
-          provider_id: input.providerId,
+          provider_id: input.workspaceProviderId ?? input.providerId,
           uninstalled_at: null,
           updated_at: now,
         })
@@ -135,17 +137,32 @@ export async function handleTipRequest(
         .where('id', '=', id)
         .executeTakeFirstOrThrow()
     })())
+  const settingsWorkspace = input.settingsProviderId
+    ? await db
+        .selectFrom('workspace')
+        .selectAll()
+        .where('provider', '=', input.provider)
+        .where('provider_id', '=', input.settingsProviderId)
+        .executeTakeFirstOrThrow()
+    : workspace
+  const executionWorkspace = {
+    ...workspace,
+    chain_id: settingsWorkspace.chain_id,
+    default_amount: settingsWorkspace.default_amount,
+    default_token_address: settingsWorkspace.default_token_address,
+  }
   if (
     input.senderProviderUserId === input.recipientProviderUserId &&
-    (!input.recipientProviderWorkspaceId || input.recipientProviderWorkspaceId === input.providerId)
+    (!input.recipientProviderWorkspaceId ||
+      input.recipientProviderWorkspaceId === (input.workspaceProviderId ?? input.providerId))
   )
     return { code: 'self_tip', ok: false }
 
-  const amount = input.amount ?? workspace.default_amount
+  const amount = input.amount ?? executionWorkspace.default_amount
   const tokenAddress = Address.checksum(
-    input.tokenAddress ?? workspace.default_token_address ?? Tempo.addressLookup.pathUsd,
+    input.tokenAddress ?? executionWorkspace.default_token_address ?? Tempo.addressLookup.pathUsd,
   )
-  if (!Tempo.isAllowedToken(workspace.chain_id, tokenAddress))
+  if (!Tempo.isAllowedToken(executionWorkspace.chain_id, tokenAddress))
     return {
       code: 'failed',
       message: 'Workspace token is not supported on this network.',
@@ -174,7 +191,7 @@ export async function handleTipRequest(
     .selectFrom('access_key')
     .selectAll()
     .where('account_id', '=', sender.account.id)
-    .where('chain_id', '=', workspace.chain_id)
+    .where('chain_id', '=', executionWorkspace.chain_id)
     .where('revoked_at', 'is', null)
     .where('expires_at', '>', new Date().toISOString())
     .orderBy('created_at', 'desc')
@@ -191,7 +208,7 @@ export async function handleTipRequest(
         amount,
         authorization,
         authorizationUsedAt: row.authorization_used_at,
-        chainId: workspace.chain_id,
+        chainId: executionWorkspace.chain_id,
         tokenAddress,
       }))
     ) {
@@ -202,7 +219,7 @@ export async function handleTipRequest(
     break
   }
   if (!accessKey)
-    return await createConfirmationRequired(env, input, workspace, amount, tokenAddress, {
+    return await createConfirmationRequired(env, input, executionWorkspace, amount, tokenAddress, {
       kind: trackedAccessKeyLimitExceeded ? 'onetime_payment' : undefined,
     })
 
@@ -214,12 +231,15 @@ export async function handleTipRequest(
     idempotencyKey: input.idempotencyKey,
     keyAuthorization: KeyAuthorization.fromRpc(JSON.parse(accessKey.authorization) as never),
     memo: input.memo,
+    providerChannelId: input.providerChannelId,
+    providerId: input.providerId,
+    providerThreadId: input.providerThreadId,
     recipient,
     recipientProviderUserId: input.recipientProviderUserId,
     sender,
     senderProviderUserId: input.senderProviderUserId,
     tokenAddress,
-    workspace,
+    workspace: executionWorkspace,
   })
 }
 
@@ -235,11 +255,13 @@ export async function handleTipBatchRequest(
     providerThreadId?: string
     recipients: TipRecipientInput[]
     senderProviderUserId: string
+    settingsProviderId?: string
     skippedRecipients?: TipSkippedRecipient[]
     source: 'command' | 'mention' | 'reaction'
     tokenAddress?: string
     usergroupId?: string
     usergroupLabel?: string
+    workspaceProviderId?: string
   },
 ): Promise<TipBatchResult> {
   const db = DB.create(env.DB)
@@ -248,7 +270,7 @@ export async function handleTipBatchRequest(
       .selectFrom('workspace')
       .selectAll()
       .where('provider', '=', input.provider)
-      .where('provider_id', '=', input.providerId)
+      .where('provider_id', '=', input.workspaceProviderId ?? input.providerId)
       .executeTakeFirst()) ??
     (await (async () => {
       const id = Nanoid.generate()
@@ -262,7 +284,7 @@ export async function handleTipBatchRequest(
           id,
           installed_at: now,
           provider: input.provider,
-          provider_id: input.providerId,
+          provider_id: input.workspaceProviderId ?? input.providerId,
           uninstalled_at: null,
           updated_at: now,
         })
@@ -273,6 +295,20 @@ export async function handleTipBatchRequest(
         .where('id', '=', id)
         .executeTakeFirstOrThrow()
     })())
+  const settingsWorkspace = input.settingsProviderId
+    ? await db
+        .selectFrom('workspace')
+        .selectAll()
+        .where('provider', '=', input.provider)
+        .where('provider_id', '=', input.settingsProviderId)
+        .executeTakeFirstOrThrow()
+    : workspace
+  const executionWorkspace = {
+    ...workspace,
+    chain_id: settingsWorkspace.chain_id,
+    default_amount: settingsWorkspace.default_amount,
+    default_token_address: settingsWorkspace.default_token_address,
+  }
   const recipients = input.recipients.slice(0, maxTipBatchRecipients)
   if (input.recipients.length === 0)
     return { code: 'failed', message: 'Payment must have at least one recipient.', ok: false }
@@ -287,19 +323,20 @@ export async function handleTipBatchRequest(
       (recipient) =>
         recipient.recipientProviderUserId === input.senderProviderUserId &&
         (!recipient.recipientProviderWorkspaceId ||
-          recipient.recipientProviderWorkspaceId === input.providerId),
+          recipient.recipientProviderWorkspaceId ===
+            (input.workspaceProviderId ?? input.providerId)),
     )
   )
     return { code: 'self_tip', ok: false }
 
-  const amount = input.amount ?? workspace.default_amount
+  const amount = input.amount ?? executionWorkspace.default_amount
   const totalAmount = amount * recipients.length
   if (!Number.isSafeInteger(totalAmount) || totalAmount <= 0)
     return { code: 'failed', message: 'Payment amount is too large.', ok: false }
   const tokenAddress = Address.checksum(
-    input.tokenAddress ?? workspace.default_token_address ?? Tempo.addressLookup.pathUsd,
+    input.tokenAddress ?? executionWorkspace.default_token_address ?? Tempo.addressLookup.pathUsd,
   )
-  if (!Tempo.isAllowedToken(workspace.chain_id, tokenAddress))
+  if (!Tempo.isAllowedToken(executionWorkspace.chain_id, tokenAddress))
     return {
       code: 'failed',
       message: 'Workspace token is not supported on this network.',
@@ -329,7 +366,7 @@ export async function handleTipBatchRequest(
     .selectFrom('access_key')
     .selectAll()
     .where('account_id', '=', sender.account.id)
-    .where('chain_id', '=', workspace.chain_id)
+    .where('chain_id', '=', executionWorkspace.chain_id)
     .where('revoked_at', 'is', null)
     .where('expires_at', '>', new Date().toISOString())
     .orderBy('created_at', 'desc')
@@ -346,7 +383,7 @@ export async function handleTipBatchRequest(
         amount: totalAmount,
         authorization,
         authorizationUsedAt: row.authorization_used_at,
-        chainId: workspace.chain_id,
+        chainId: executionWorkspace.chain_id,
         tokenAddress,
       }))
     )
@@ -374,7 +411,7 @@ export async function handleTipBatchRequest(
         usergroupId: input.usergroupId,
         usergroupLabel: input.usergroupLabel,
       },
-      workspace,
+      executionWorkspace,
       amount,
       tokenAddress,
       {
@@ -404,7 +441,7 @@ export async function handleTipBatchRequest(
     tokenAddress,
     usergroupId: input.usergroupId,
     usergroupLabel: input.usergroupLabel,
-    workspace,
+    workspace: executionWorkspace,
   })
 }
 
@@ -758,6 +795,9 @@ export async function confirmTipRequest(
     idempotencyKey: payload.idempotencyKey,
     keyAuthorization: verified.authorization,
     memo: payload.memo,
+    providerChannelId: payload.providerChannelId,
+    providerId: payload.providerId,
+    providerThreadId: payload.providerThreadId,
     recipient,
     recipientProviderUserId: payload.recipientProviderUserId,
     sender,
@@ -1300,6 +1340,9 @@ async function submitTip(
     idempotencyKey: string
     keyAuthorization: KeyAuthorization.Signed
     memo: string | null
+    providerChannelId: string
+    providerId: string
+    providerThreadId?: string
     recipient: ConnectedMember
     recipientProviderUserId: string
     sender: ConnectedMember
@@ -1318,8 +1361,9 @@ async function submitTip(
     keyAuthorization: input.keyAuthorization,
     memo: input.memo,
     provider: input.workspace.provider,
-    providerChannelId: '',
-    providerId: input.workspace.provider_id,
+    providerChannelId: input.providerChannelId,
+    providerId: input.providerId,
+    providerThreadId: input.providerThreadId,
     recipients: [
       {
         recipientProviderUserId: input.recipientProviderUserId,


### PR DESCRIPTION
Support Slack Connect external senders by storing tips under the sender workspace while using the host workspace defaults.