### PR TITLE
Add @channel, @here, and @everyone tip targets

### DIFF
--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -431,6 +431,7 @@ jobs:
           SHA: ${{ inputs.sha }}
           SEEDED_AT: ${{ steps.seed.outputs.seeded_at }}
           SLACK_APP_ID: ${{ steps.slack.outputs.app_id }}
+          SLACK_APP_CREATED: ${{ steps.slack.outputs.created }}
           SLACK_STATE_CREDENTIALS: ${{ steps.slack.outputs.state_credentials }}
           STATE_D1_ID: ${{ steps.state.outputs.d1_id }}
           STATE_SCOPES_HASH: ${{ steps.state.outputs.scopes_hash }}
@@ -448,7 +449,9 @@ jobs:
           STATUS="[![Ready](https://vercel.com/static/status/ready.svg) Ready](${RUN_URL})"
           if [ "$JOB_STATUS" != "success" ]; then STATUS="[![Error](https://vercel.com/static/status/error.svg) Error](${RUN_URL})"; fi
           REINSTALL=""
-          if [ -n "$STATE_SCOPES_HASH" ] && [ "$STATE_SCOPES_HASH" != "$MANIFEST_SCOPES_HASH" ]; then
+          if [ "$SLACK_APP_CREATED" = "true" ]; then
+            REINSTALL="\n\nSlack preview app changed. Reinstall the Slack preview."
+          elif [ -n "$STATE_SCOPES_HASH" ] && [ "$STATE_SCOPES_HASH" != "$MANIFEST_SCOPES_HASH" ]; then
             REINSTALL="\n\nOAuth scopes changed. Reinstall the Slack preview."
           fi
           STATE=$(jq -nc \

--- a/scripts/slack.ts
+++ b/scripts/slack.ts
@@ -13,16 +13,19 @@ const scopeReasons = {
     'Show a temporary sending payment status while Tipbot processes a mentioned tip.',
   'channels:history':
     'Read messages Tipbot is asked to act on in public channels, including reaction and mention tips.',
-  'channels:read': 'Check public channel metadata and respond in the correct conversation.',
+  'channels:read':
+    'Check public channel metadata, read channel members for @channel/@here tips, and respond in the correct conversation.',
   'chat:write': 'Send tip receipts, connection prompts, confirmation prompts, and error messages.',
   commands: 'Register and handle the /tip slash command.',
   'emoji:read': 'Validate configured custom tip reaction emoji exist in the workspace.',
   'groups:history':
     'Read messages Tipbot is asked to act on in private channels where Tipbot has been added.',
-  'groups:read': 'Check private channel metadata where Tipbot has been added.',
+  'groups:read':
+    'Check private channel metadata and read channel members for @channel/@here tips where Tipbot has been added.',
   'reactions:read': 'Detect configured tip reaction emoji and identify the message being tipped.',
   'usergroups:read': 'Expand Slack user groups like @engineering into eligible tip recipients.',
-  'users:read': 'Resolve Slack users for mentions, admin checks, and connected account status.',
+  'users:read':
+    'Resolve Slack users for mentions, admin checks, connected account status, and active @here tips.',
 } as const
 const eventReasons = {
   app_home_opened: 'Refresh each member Home tab when they open Tipbot in Slack.',

--- a/src/api.ts
+++ b/src/api.ts
@@ -782,14 +782,23 @@ export const api = new Hono<{
         )
         const json = z.parse(
           z.object({
-            channel: z.object({ is_member: z.boolean().optional() }).optional(),
+            channel: z
+              .object({
+                is_ext_shared: z.boolean().optional(),
+                is_member: z.boolean().optional(),
+                is_org_shared: z.boolean().optional(),
+                is_shared: z.boolean().optional(),
+              })
+              .optional(),
             error: z.string().optional(),
             ok: z.boolean().optional(),
           }),
           await response.json(),
         )
-        if (json.ok) return json.channel?.is_member === false
-        return ['channel_not_found', 'no_permission', 'not_in_channel'].includes(json.error ?? '')
+        if (!json.ok) return false
+        if (json.channel?.is_ext_shared || json.channel?.is_org_shared || json.channel?.is_shared)
+          return false
+        return json.channel?.is_member === false
       })()
       if (botMissingFromChannel)
         return c.json({

--- a/src/api.workers.test.ts
+++ b/src/api.workers.test.ts
@@ -159,7 +159,7 @@ describe('/api/chat/slack', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
       if (url.startsWith(env.SLACK_API_URL) && url.includes('/conversations.info'))
-        return Promise.resolve(Response.json({ error: 'not_in_channel', ok: false }))
+        return Promise.resolve(Response.json({ channel: { is_member: false }, ok: true }))
       return originalFetch(input, init)
     })
     await Chat.getChat().initialize()
@@ -199,6 +199,46 @@ describe('/api/chat/slack', () => {
       ].join('\n'),
     })
     expect(executionCtx.waitUntil).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+
+  test('slash command does not return invite instructions when shared channel membership is ambiguous', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.startsWith(env.SLACK_API_URL) && url.includes('/conversations.info'))
+        return Promise.resolve(Response.json({ error: 'not_in_channel', ok: false }))
+      return originalFetch(input, init)
+    })
+    await Chat.getChat().initialize()
+    await Chat.getSlack().setInstallation(Constants.slack.teamId, {
+      botToken: Constants.slack.botToken,
+      botUserId: Constants.slack.botUserId,
+      teamName: Constants.slack.teamName,
+    })
+    const body = new URLSearchParams({
+      channel_id: Constants.slack.channelId,
+      command: '/tip',
+      team_id: Constants.slack.teamId,
+      text: 'status',
+      trigger_id: 'trigger-ambiguous-channel',
+      user_id: Constants.slack.adminUserId,
+    }).toString()
+
+    const response = await client.api.chat.slack.$post(
+      {},
+      {
+        headers: {
+          ...(await createSlackHeaders(body, env.SLACK_SIGNING_SECRET)),
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        init: { body },
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('')
+    expect(executionCtx.waitUntil).toHaveBeenCalled()
     fetchSpy.mockRestore()
   })
 })

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1435,8 +1435,6 @@ type PendingSlackTip = {
 type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
-const slackVanityUsergroupIds = ['channel', 'here'] as const
-type SlackVanityUsergroupId = (typeof slackVanityUsergroupIds)[number]
 
 export function isReactionTipIdempotencyKey(value: string) {
   return value.startsWith(reactionTipIdempotencyPrefix)
@@ -1521,9 +1519,11 @@ async function resolveSlackTipPlan(
 
   const conversation = await getSlackConversationInfo(installation.botToken, event.channel.id)
   if (
-    parsed.usergroups?.some(
-      (usergroup) => !isSlackVanityUsergroupId(usergroup.providerUsergroupId),
-    ) &&
+    parsed.usergroups?.some((usergroup) => {
+      // Slack special mentions resolve from channel state, so they can work in Slack Connect;
+      // custom Slack usergroups still cannot be resolved safely there.
+      return !['channel', 'here'].includes(usergroup.providerUsergroupId)
+    }) &&
     conversation.isShared
   ) {
     return {
@@ -1539,11 +1539,14 @@ async function resolveSlackTipPlan(
       source: 'explicit' as const,
     }))
   for (const usergroup of parsed.usergroups ?? []) {
-    const users = isSlackVanityUsergroupId(usergroup.providerUsergroupId)
-      ? await (async (): Promise<
-          { ok: true; providerUserIds: string[] } | { message: string; ok: false }
-        > => {
-          // @channel includes all conversation members; @here narrows that list to active members.
+    const users = (() => {
+      // Slack special mentions are represented in the parsed usergroup list but resolve via
+      // conversation APIs instead of usergroups.users.list.
+      return ['channel', 'here'].includes(usergroup.providerUsergroupId)
+    })()
+      ? await (async () => {
+          // Slack special mentions: @channel includes all conversation members;
+          // @here narrows that list to active members.
           const providerUserIds: string[] = []
           let cursor: string | undefined
           for (;;) {
@@ -1569,13 +1572,14 @@ async function resolveSlackTipPlan(
             if (!json.ok)
               return {
                 message: formatSlackConversationMembersError(json.error),
-                ok: false,
+                ok: false as const,
               }
             providerUserIds.push(...(json.members ?? []))
             cursor = json.response_metadata?.next_cursor || undefined
             if (!cursor) break
           }
-          if (usergroup.providerUsergroupId === 'channel') return { ok: true, providerUserIds }
+          if (usergroup.providerUsergroupId === 'channel')
+            return { ok: true as const, providerUserIds }
 
           const activeProviderUserIds = [] as string[]
           for (const providerUserId of providerUserIds) {
@@ -1600,13 +1604,13 @@ async function resolveSlackTipPlan(
               return {
                 message:
                   json.error === 'missing_scope'
-                    ? 'Payment not sent. I could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
-                    : `Payment not sent. I could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
-                ok: false,
+                    ? 'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+                    : `Payment not sent. Tipbot could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
+                ok: false as const,
               }
             if (json.presence === 'active') activeProviderUserIds.push(providerUserId)
           }
-          return { ok: true, providerUserIds: activeProviderUserIds }
+          return { ok: true as const, providerUserIds: activeProviderUserIds }
         })()
       : await getSlackUsergroupMembers(installation.botToken, usergroup)
     if (!users.ok) return { message: users.message, ok: false }
@@ -1679,10 +1683,6 @@ async function resolveSlackTipPlan(
   }
 }
 
-function isSlackVanityUsergroupId(value: string): value is SlackVanityUsergroupId {
-  return slackVanityUsergroupIds.includes(value as SlackVanityUsergroupId)
-}
-
 async function getSlackUsergroupMembers(
   botToken: string,
   usergroup: Tip.TipUsergroupInput,
@@ -1715,10 +1715,10 @@ async function getSlackUsergroupMembers(
 
 function formatSlackConversationMembersError(error?: string) {
   if (error === 'not_in_channel' || error === 'no_permission' || error === 'channel_not_found')
-    return 'Payment not sent. I could not read the channel members. Invite Tipbot to this channel and try again.'
+    return 'Payment not sent. Tipbot could not read the channel members. Invite Tipbot to this channel and try again.'
   if (error === 'missing_scope')
-    return 'Payment not sent. I could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
-  return `Payment not sent. I could not read the channel members${error ? ` (${error})` : ''}.`
+    return 'Payment not sent. Tipbot could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+  return `Payment not sent. Tipbot could not read the channel members${error ? ` (${error})` : ''}.`
 }
 
 async function getSlackConversationInfo(botToken: string, channelId: string) {
@@ -2644,7 +2644,13 @@ function parseSlackMentionTipText(text: string) {
 }
 
 function formatSlackUsergroupMention(usergroupId: string, usergroupLabel?: string) {
-  if (isSlackVanityUsergroupId(usergroupId)) return `<!${usergroupId}>`
+  if (
+    (() => {
+      // Slack special mentions are formatted without subteam syntax.
+      return ['channel', 'here'].includes(usergroupId)
+    })()
+  )
+    return `<!${usergroupId}>`
   return `<!subteam^${usergroupId}${usergroupLabel ? `|@${usergroupLabel}` : ''}>`
 }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -2653,13 +2653,7 @@ function parseSlackMentionTipText(text: string) {
 }
 
 function formatSlackUsergroupMention(usergroupId: string, usergroupLabel?: string) {
-  if (
-    (() => {
-      // Slack special mentions are formatted without subteam syntax.
-      return ['channel', 'here'].includes(usergroupId)
-    })()
-  )
-    return `<!${usergroupId}>`
+  if (['channel', 'here'].includes(usergroupId)) return `<!${usergroupId}>`
   return `<!subteam^${usergroupId}${usergroupLabel ? `|@${usergroupLabel}` : ''}>`
 }
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1582,32 +1582,43 @@ async function resolveSlackTipPlan(
 
       const activeProviderUserIds = [] as string[]
       for (const providerUserId of providerUserIds) {
-        const body = new URLSearchParams()
-        body.set('user', providerUserId)
-        const response = await getSlack().withBotToken(installation.botToken, () =>
-          fetch(`${env.SLACK_API_URL}/users.getPresence`, {
-            body,
-            headers: { authorization: `Bearer ${installation.botToken}` },
-            method: 'POST',
-          }),
-        )
-        const json = z.parse(
-          z.object({
-            error: z.string().optional(),
-            ok: z.boolean().optional(),
-            presence: z.string().optional(),
-          }),
-          await response.json(),
-        )
-        if (!json.ok)
-          return {
-            message:
-              json.error === 'missing_scope'
-                ? 'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
-                : `Payment not sent. Tipbot could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
-            ok: false as const,
+        const presence = await (async () => {
+          // Slack Connect can return user_not_found for a shared-channel member when using the
+          // host workspace token. Try every installed shared workspace before skipping that member.
+          for (const providerId of [ctx.provider.id, ...conversation.teamIds]) {
+            const tokenInstallation = await getSlack().getInstallation(providerId)
+            if (!tokenInstallation) continue
+            const body = new URLSearchParams()
+            body.set('user', providerUserId)
+            const response = await getSlack().withBotToken(tokenInstallation.botToken, () =>
+              fetch(`${env.SLACK_API_URL}/users.getPresence`, {
+                body,
+                headers: { authorization: `Bearer ${tokenInstallation.botToken}` },
+                method: 'POST',
+              }),
+            )
+            const json = z.parse(
+              z.object({
+                error: z.string().optional(),
+                ok: z.boolean().optional(),
+                presence: z.string().optional(),
+              }),
+              await response.json(),
+            )
+            if (json.ok) return { ok: true as const, presence: json.presence }
+            if (json.error !== 'user_not_found')
+              return {
+                message:
+                  json.error === 'missing_scope'
+                    ? 'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+                    : `Payment not sent. Tipbot could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
+                ok: false as const,
+              }
           }
-        if (json.presence === 'active') activeProviderUserIds.push(providerUserId)
+          return { ok: true as const, presence: 'away' }
+        })()
+        if (!presence.ok) return presence
+        if (presence.presence === 'active') activeProviderUserIds.push(providerUserId)
       }
       return { ok: true as const, providerUserIds: activeProviderUserIds }
     })()

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1539,80 +1539,78 @@ async function resolveSlackTipPlan(
       source: 'explicit' as const,
     }))
   for (const usergroup of parsed.usergroups ?? []) {
-    const users = (() => {
+    const users = await (async () => {
+      if (usergroup.providerUsergroupId !== 'channel' && usergroup.providerUsergroupId !== 'here')
+        return await getSlackUsergroupMembers(installation.botToken, usergroup)
+
       // Slack special mentions are represented in the parsed usergroup list but resolve via
       // conversation APIs instead of usergroups.users.list.
-      return ['channel', 'here'].includes(usergroup.providerUsergroupId)
-    })()
-      ? await (async () => {
-          // Slack special mentions: @channel includes all conversation members;
-          // @here narrows that list to active members.
-          const providerUserIds: string[] = []
-          let cursor: string | undefined
-          for (;;) {
-            const body = new URLSearchParams()
-            body.set('channel', Slack.getChannelId(event.channel.id))
-            if (cursor) body.set('cursor', cursor)
-            const response = await getSlack().withBotToken(installation.botToken, () =>
-              fetch(`${env.SLACK_API_URL}/conversations.members`, {
-                body,
-                headers: { authorization: `Bearer ${installation.botToken}` },
-                method: 'POST',
-              }),
-            )
-            const json = z.parse(
-              z.object({
-                error: z.string().optional(),
-                members: z.array(z.string()).optional(),
-                ok: z.boolean().optional(),
-                response_metadata: z.object({ next_cursor: z.string().optional() }).optional(),
-              }),
-              await response.json(),
-            )
-            if (!json.ok)
-              return {
-                message: formatSlackConversationMembersError(json.error),
-                ok: false as const,
-              }
-            providerUserIds.push(...(json.members ?? []))
-            cursor = json.response_metadata?.next_cursor || undefined
-            if (!cursor) break
+      const providerUserIds: string[] = []
+      const slackChannelId = Slack.getChannelId(event.channel.id)
+      let cursor: string | undefined
+      do {
+        const body = new URLSearchParams()
+        body.set('channel', slackChannelId)
+        if (cursor) body.set('cursor', cursor)
+        const response = await getSlack().withBotToken(installation.botToken, () =>
+          fetch(`${env.SLACK_API_URL}/conversations.members`, {
+            body,
+            headers: { authorization: `Bearer ${installation.botToken}` },
+            method: 'POST',
+          }),
+        )
+        const json = z.parse(
+          z.object({
+            error: z.string().optional(),
+            members: z.array(z.string()).optional(),
+            ok: z.boolean().optional(),
+            response_metadata: z.object({ next_cursor: z.string().optional() }).optional(),
+          }),
+          await response.json(),
+        )
+        if (!json.ok)
+          return {
+            message: formatSlackConversationMembersError(json.error),
+            ok: false as const,
           }
-          if (usergroup.providerUsergroupId === 'channel')
-            return { ok: true as const, providerUserIds }
+        providerUserIds.push(...(json.members ?? []))
+        cursor = json.response_metadata?.next_cursor || undefined
+      } while (cursor)
 
-          const activeProviderUserIds = [] as string[]
-          for (const providerUserId of providerUserIds) {
-            const body = new URLSearchParams()
-            body.set('user', providerUserId)
-            const response = await getSlack().withBotToken(installation.botToken, () =>
-              fetch(`${env.SLACK_API_URL}/users.getPresence`, {
-                body,
-                headers: { authorization: `Bearer ${installation.botToken}` },
-                method: 'POST',
-              }),
-            )
-            const json = z.parse(
-              z.object({
-                error: z.string().optional(),
-                ok: z.boolean().optional(),
-                presence: z.string().optional(),
-              }),
-              await response.json(),
-            )
-            if (!json.ok)
-              return {
-                message:
-                  json.error === 'missing_scope'
-                    ? 'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
-                    : `Payment not sent. Tipbot could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
-                ok: false as const,
-              }
-            if (json.presence === 'active') activeProviderUserIds.push(providerUserId)
+      // @channel includes all conversation members; @here narrows that list to active members.
+      if (usergroup.providerUsergroupId === 'channel') return { ok: true as const, providerUserIds }
+
+      const activeProviderUserIds = [] as string[]
+      for (const providerUserId of providerUserIds) {
+        const body = new URLSearchParams()
+        body.set('user', providerUserId)
+        const response = await getSlack().withBotToken(installation.botToken, () =>
+          fetch(`${env.SLACK_API_URL}/users.getPresence`, {
+            body,
+            headers: { authorization: `Bearer ${installation.botToken}` },
+            method: 'POST',
+          }),
+        )
+        const json = z.parse(
+          z.object({
+            error: z.string().optional(),
+            ok: z.boolean().optional(),
+            presence: z.string().optional(),
+          }),
+          await response.json(),
+        )
+        if (!json.ok)
+          return {
+            message:
+              json.error === 'missing_scope'
+                ? 'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+                : `Payment not sent. Tipbot could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
+            ok: false as const,
           }
-          return { ok: true as const, providerUserIds: activeProviderUserIds }
-        })()
-      : await getSlackUsergroupMembers(installation.botToken, usergroup)
+        if (json.presence === 'active') activeProviderUserIds.push(providerUserId)
+      }
+      return { ok: true as const, providerUserIds: activeProviderUserIds }
+    })()
     if (!users.ok) return { message: users.message, ok: false }
     for (const providerUserId of users.providerUserIds) {
       if (!/^[UW][A-Z0-9_]+$/.test(providerUserId)) continue

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -53,7 +53,17 @@ export function getChat() {
 
     const raw = z.parse(
       z.object({
+        authorizations: z
+          .array(
+            z.object({
+              is_bot: z.boolean().optional(),
+              team_id: z.string().min(1).nullable().optional(),
+              user_id: z.string().min(1).nullable().optional(),
+            }),
+          )
+          .optional(),
         channel: z.string().min(1),
+        context_team_id: z.string().min(1).nullable().optional(),
         subtype: z.string().min(1).optional(),
         team: z.string().min(1).optional(),
         team_id: z.string().min(1).optional(),
@@ -67,7 +77,20 @@ export function getChat() {
     )
     if (raw.subtype) return
 
-    const providerId = raw.team_id ?? raw.team
+    const providerId = (() => {
+      const mentioned = new Set(
+        [...raw.text.matchAll(/<@([A-Z0-9_]+)(?:\|[^>]+)?>/g)].map((match) => match[1]),
+      )
+      return (
+        raw.authorizations?.find(
+          (authorization) =>
+            authorization.user_id && mentioned.has(authorization.user_id) && authorization.team_id,
+        )?.team_id ??
+        raw.context_team_id ??
+        raw.team_id ??
+        raw.team
+      )
+    })()
     if (!providerId) throw new Error('Slack app mention missing team id.')
 
     const installation = await getSlack().getInstallation(providerId)
@@ -1150,7 +1173,9 @@ const handlers = {
           amountEach: parsed.amount ?? workspace?.default_amount,
         })
     if (!plan.ok) {
-      await postPrivateReply(event, event.user, plan.message)
+      await postPrivateReply(event, event.user, plan.message, {
+        providerId: ctx.channelProviderId ?? ctx.provider.id,
+      })
       return
     }
     if (plan.previewRequired) {
@@ -1410,7 +1435,7 @@ type PendingSlackTip = {
 type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
-const slackVanityUsergroupIds = ['channel', 'here', 'everyone'] as const
+const slackVanityUsergroupIds = ['channel', 'here'] as const
 type SlackVanityUsergroupId = (typeof slackVanityUsergroupIds)[number]
 
 export function isReactionTipIdempotencyKey(value: string) {
@@ -1495,12 +1520,18 @@ async function resolveSlackTipPlan(
     }
 
   const conversation = await getSlackConversationInfo(installation.botToken, event.channel.id)
-  if (parsed.usergroups?.length && conversation.isShared)
+  if (
+    parsed.usergroups?.some(
+      (usergroup) => !isSlackVanityUsergroupId(usergroup.providerUsergroupId),
+    ) &&
+    conversation.isShared
+  ) {
     return {
       message:
         'Group tips are not supported in Slack Connect channels yet; mention individual recipients instead.',
       ok: false,
     }
+  }
 
   const targets: Array<{ recipient: Tip.TipRecipientInput; source: 'explicit' | 'usergroup' }> =
     parsed.recipients.map((recipient) => ({
@@ -1509,7 +1540,74 @@ async function resolveSlackTipPlan(
     }))
   for (const usergroup of parsed.usergroups ?? []) {
     const users = isSlackVanityUsergroupId(usergroup.providerUsergroupId)
-      ? await getSlackConversationMembers(installation.botToken, event.channel.id)
+      ? await (async (): Promise<
+          { ok: true; providerUserIds: string[] } | { message: string; ok: false }
+        > => {
+          // @channel includes all conversation members; @here narrows that list to active members.
+          const providerUserIds: string[] = []
+          let cursor: string | undefined
+          for (;;) {
+            const body = new URLSearchParams()
+            body.set('channel', Slack.getChannelId(event.channel.id))
+            if (cursor) body.set('cursor', cursor)
+            const response = await getSlack().withBotToken(installation.botToken, () =>
+              fetch(`${env.SLACK_API_URL}/conversations.members`, {
+                body,
+                headers: { authorization: `Bearer ${installation.botToken}` },
+                method: 'POST',
+              }),
+            )
+            const json = z.parse(
+              z.object({
+                error: z.string().optional(),
+                members: z.array(z.string()).optional(),
+                ok: z.boolean().optional(),
+                response_metadata: z.object({ next_cursor: z.string().optional() }).optional(),
+              }),
+              await response.json(),
+            )
+            if (!json.ok)
+              return {
+                message: formatSlackConversationMembersError(json.error),
+                ok: false,
+              }
+            providerUserIds.push(...(json.members ?? []))
+            cursor = json.response_metadata?.next_cursor || undefined
+            if (!cursor) break
+          }
+          if (usergroup.providerUsergroupId === 'channel') return { ok: true, providerUserIds }
+
+          const activeProviderUserIds = [] as string[]
+          for (const providerUserId of providerUserIds) {
+            const body = new URLSearchParams()
+            body.set('user', providerUserId)
+            const response = await getSlack().withBotToken(installation.botToken, () =>
+              fetch(`${env.SLACK_API_URL}/users.getPresence`, {
+                body,
+                headers: { authorization: `Bearer ${installation.botToken}` },
+                method: 'POST',
+              }),
+            )
+            const json = z.parse(
+              z.object({
+                error: z.string().optional(),
+                ok: z.boolean().optional(),
+                presence: z.string().optional(),
+              }),
+              await response.json(),
+            )
+            if (!json.ok)
+              return {
+                message:
+                  json.error === 'missing_scope'
+                    ? 'Payment not sent. I could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+                    : `Payment not sent. I could not read active channel members${json.error ? ` (${json.error})` : ''}.`,
+                ok: false,
+              }
+            if (json.presence === 'active') activeProviderUserIds.push(providerUserId)
+          }
+          return { ok: true, providerUserIds: activeProviderUserIds }
+        })()
       : await getSlackUsergroupMembers(installation.botToken, usergroup)
     if (!users.ok) return { message: users.message, ok: false }
     for (const providerUserId of users.providerUserIds) {
@@ -1615,41 +1713,12 @@ async function getSlackUsergroupMembers(
   return { ok: true, providerUserIds: json.users ?? [] }
 }
 
-async function getSlackConversationMembers(
-  botToken: string,
-  channelId: string,
-): Promise<{ ok: true; providerUserIds: string[] } | { message: string; ok: false }> {
-  const providerUserIds: string[] = []
-  let cursor: string | undefined
-  for (;;) {
-    const body = new URLSearchParams()
-    body.set('channel', channelId.replace(/^slack:/, ''))
-    if (cursor) body.set('cursor', cursor)
-    const response = await getSlack().withBotToken(botToken, () =>
-      fetch(`${env.SLACK_API_URL}/conversations.members`, {
-        body,
-        headers: { authorization: `Bearer ${botToken}` },
-        method: 'POST',
-      }),
-    )
-    const json = z.parse(
-      z.object({
-        error: z.string().optional(),
-        members: z.array(z.string()).optional(),
-        ok: z.boolean().optional(),
-        response_metadata: z.object({ next_cursor: z.string().optional() }).optional(),
-      }),
-      await response.json(),
-    )
-    if (!json.ok)
-      return {
-        message: 'Payment not sent. I could not read the channel members.',
-        ok: false,
-      }
-    providerUserIds.push(...(json.members ?? []))
-    cursor = json.response_metadata?.next_cursor || undefined
-    if (!cursor) return { ok: true, providerUserIds }
-  }
+function formatSlackConversationMembersError(error?: string) {
+  if (error === 'not_in_channel' || error === 'no_permission' || error === 'channel_not_found')
+    return 'Payment not sent. I could not read the channel members. Invite Tipbot to this channel and try again.'
+  if (error === 'missing_scope')
+    return 'Payment not sent. I could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.'
+  return `Payment not sent. I could not read the channel members${error ? ` (${error})` : ''}.`
 }
 
 async function getSlackConversationInfo(botToken: string, channelId: string) {
@@ -2566,7 +2635,7 @@ function normalizeSlackMentionText(value: string, botUserId: string) {
 
 function parseSlackMentionTipText(text: string) {
   const target = text.match(
-    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here|everyone)(?:\|[^>]+)?>/,
+    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here)(?:\|[^>]+)?>/,
   )
   if (!target) return null
   const prefix = text.slice(0, target.index).trim().toLowerCase()
@@ -2953,9 +3022,24 @@ async function postPrivateReply(
   event: TipEvent,
   user: chat.Author,
   message: Parameters<TipEvent['channel']['postEphemeral']>[1],
-  options: { threadTs?: string } = {},
+  options: { providerId?: string; threadTs?: string } = {},
 ) {
   const threadTs = options.threadTs ?? event.threadTs
+  if (options.providerId && typeof message === 'string') {
+    const body = new URLSearchParams()
+    body.set('channel', Slack.getChannelId(event.channel.id))
+    body.set('text', message)
+    await postSlackPrivateReply(
+      options.providerId,
+      Slack.getChannelId(event.channel.id),
+      user.userId,
+      body,
+      {
+        threadTs,
+      },
+    )
+    return
+  }
   if (Slack.isDMChannelId(event.channel.id)) {
     await event.channel.post(message)
     return

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1410,6 +1410,8 @@ type PendingSlackTip = {
 type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
+const slackVanityUsergroupIds = ['channel', 'here', 'everyone'] as const
+type SlackVanityUsergroupId = (typeof slackVanityUsergroupIds)[number]
 
 export function isReactionTipIdempotencyKey(value: string) {
   return value.startsWith(reactionTipIdempotencyPrefix)
@@ -1506,30 +1508,11 @@ async function resolveSlackTipPlan(
       source: 'explicit' as const,
     }))
   for (const usergroup of parsed.usergroups ?? []) {
-    const response = await getSlack().withBotToken(installation.botToken, () => {
-      const body = new URLSearchParams()
-      body.set('usergroup', usergroup.providerUsergroupId)
-      return fetch(`${env.SLACK_API_URL}/usergroups.users.list`, {
-        body,
-        headers: { authorization: `Bearer ${installation.botToken}` },
-        method: 'POST',
-      })
-    })
-    const json = z.parse(
-      z.object({
-        ok: z.boolean().optional(),
-        users: z.array(z.string()).optional(),
-      }),
-      await response.json(),
-    )
-    if (!json.ok)
-      return {
-        message: `Payment not sent. I could not read @${usergroup.providerUsergroupLabel ?? usergroup.providerUsergroupId}.`,
-        ok: false,
-      }
-    // Slack usergroups.users.list is treated as authoritative flat membership; no recursive
-    // usergroup expansion.
-    for (const providerUserId of json.users ?? []) {
+    const users = isSlackVanityUsergroupId(usergroup.providerUsergroupId)
+      ? await getSlackConversationMembers(installation.botToken, event.channel.id)
+      : await getSlackUsergroupMembers(installation.botToken, usergroup)
+    if (!users.ok) return { message: users.message, ok: false }
+    for (const providerUserId of users.providerUserIds) {
       if (!/^[UW][A-Z0-9_]+$/.test(providerUserId)) continue
       const user = await getSlackUserInfo(installation.botToken, providerUserId)
       if (!user || user.deleted || user.is_app_user || user.is_bot) continue
@@ -1595,6 +1578,77 @@ async function resolveSlackTipPlan(
     skippedRecipients,
     usergroupId: parsed.usergroups?.[0]?.providerUsergroupId,
     usergroupLabel: parsed.usergroups?.[0]?.providerUsergroupLabel,
+  }
+}
+
+function isSlackVanityUsergroupId(value: string): value is SlackVanityUsergroupId {
+  return slackVanityUsergroupIds.includes(value as SlackVanityUsergroupId)
+}
+
+async function getSlackUsergroupMembers(
+  botToken: string,
+  usergroup: Tip.TipUsergroupInput,
+): Promise<{ ok: true; providerUserIds: string[] } | { message: string; ok: false }> {
+  const response = await getSlack().withBotToken(botToken, () => {
+    const body = new URLSearchParams()
+    body.set('usergroup', usergroup.providerUsergroupId)
+    return fetch(`${env.SLACK_API_URL}/usergroups.users.list`, {
+      body,
+      headers: { authorization: `Bearer ${botToken}` },
+      method: 'POST',
+    })
+  })
+  const json = z.parse(
+    z.object({
+      ok: z.boolean().optional(),
+      users: z.array(z.string()).optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok)
+    return {
+      message: `Payment not sent. I could not read ${formatSlackUsergroupMention(usergroup.providerUsergroupId, usergroup.providerUsergroupLabel)}.`,
+      ok: false,
+    }
+  // Slack usergroups.users.list is treated as authoritative flat membership; no recursive
+  // usergroup expansion.
+  return { ok: true, providerUserIds: json.users ?? [] }
+}
+
+async function getSlackConversationMembers(
+  botToken: string,
+  channelId: string,
+): Promise<{ ok: true; providerUserIds: string[] } | { message: string; ok: false }> {
+  const providerUserIds: string[] = []
+  let cursor: string | undefined
+  for (;;) {
+    const body = new URLSearchParams()
+    body.set('channel', channelId.replace(/^slack:/, ''))
+    if (cursor) body.set('cursor', cursor)
+    const response = await getSlack().withBotToken(botToken, () =>
+      fetch(`${env.SLACK_API_URL}/conversations.members`, {
+        body,
+        headers: { authorization: `Bearer ${botToken}` },
+        method: 'POST',
+      }),
+    )
+    const json = z.parse(
+      z.object({
+        error: z.string().optional(),
+        members: z.array(z.string()).optional(),
+        ok: z.boolean().optional(),
+        response_metadata: z.object({ next_cursor: z.string().optional() }).optional(),
+      }),
+      await response.json(),
+    )
+    if (!json.ok)
+      return {
+        message: 'Payment not sent. I could not read the channel members.',
+        ok: false,
+      }
+    providerUserIds.push(...(json.members ?? []))
+    cursor = json.response_metadata?.next_cursor || undefined
+    if (!cursor) return { ok: true, providerUserIds }
   }
 }
 
@@ -2511,7 +2565,9 @@ function normalizeSlackMentionText(value: string, botUserId: string) {
 }
 
 function parseSlackMentionTipText(text: string) {
-  const target = text.match(/<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>/)
+  const target = text.match(
+    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here|everyone)(?:\|[^>]+)?>/,
+  )
   if (!target) return null
   const prefix = text.slice(0, target.index).trim().toLowerCase()
   if (prefix && !['pay', 'send', 'tip'].includes(prefix)) return null
@@ -2519,6 +2575,7 @@ function parseSlackMentionTipText(text: string) {
 }
 
 function formatSlackUsergroupMention(usergroupId: string, usergroupLabel?: string) {
+  if (isSlackVanityUsergroupId(usergroupId)) return `<!${usergroupId}>`
   return `<!subteam^${usergroupId}${usergroupLabel ? `|@${usergroupLabel}` : ''}>`
 }
 

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1691,6 +1691,11 @@ test('@Tipbot mention sends Slack Connect here tip with active members', async (
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
     if (url.endsWith('/users.getPresence')) {
       const params = slackFetchBodyParams(init?.body)
+      if (
+        params.get('user') === Constants.slackConnect.userId &&
+        getSlackFetchAuthorization([input, init]) === `Bearer ${Constants.slack.botToken}`
+      )
+        return Response.json({ error: 'user_not_found', ok: false })
       return Response.json({
         ok: true,
         presence:

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -277,6 +277,132 @@ describe('/tip @account', () => {
     await expectSlackMessageNotContaining('Receipt')
   })
 
+  test('previews channel tip through paginated channel membership', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/conversations.members')) {
+        const params = slackFetchBodyParams(init?.body)
+        return Response.json(
+          params.get('cursor')
+            ? {
+                members: [Constants.slack.memberUserId],
+                ok: true,
+                response_metadata: { next_cursor: '' },
+              }
+            : {
+                members: [Constants.slack.adminUserId],
+                ok: true,
+                response_metadata: { next_cursor: 'page_2' },
+              },
+        )
+      }
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!channel> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip <!channel> 1 accounts $11.00 each for coffee.')
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining('Receipt')
+    fetchSpy.mockRestore()
+  })
+
+  test('previews here tip through active channel membership', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/users.getPresence')) {
+        const params = slackFetchBodyParams(init?.body)
+        return Response.json({
+          ok: true,
+          presence:
+            params.get('user') === Constants.slack.adminUserId ||
+            params.get('user') === Constants.slack.memberUserId
+              ? 'active'
+              : 'away',
+        })
+      }
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    await connectTipAccounts()
+    await memberSlack.conversations.join({ channel: Constants.slack.channelId })
+
+    const response = await postSlashCommand('<!here> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip <!here> 1 accounts $11.00 each for coffee.')
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining(`• <@${unconnectedProviderUserId}> (not connected yet)`)
+    await expectSlackMessageNotContaining('Receipt')
+    fetchSpy.mockRestore()
+  })
+
+  test('explains when channel membership cannot be read', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/conversations.members'))
+        return Response.json({ error: 'not_in_channel', ok: false })
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!channel> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Payment not sent. I could not read the channel members. Invite Tipbot to this channel and try again.',
+    )
+    await expectSlackMessageNotContaining('You’re about to tip')
+    fetchSpy.mockRestore()
+  })
+
+  test('explains when channel membership permission is missing', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/conversations.members'))
+        return Response.json({ error: 'missing_scope', ok: false })
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!channel> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Payment not sent. I could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
+    )
+    await expectSlackMessageNotContaining('You’re about to tip')
+    fetchSpy.mockRestore()
+  })
+
+  test('explains when active channel membership permission is missing', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/users.getPresence'))
+        return Response.json({ error: 'missing_scope', ok: false })
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    await connectTipAccounts()
+    await memberSlack.conversations.join({ channel: Constants.slack.channelId })
+
+    const response = await postSlashCommand('<!here> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      'Payment not sent. I could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
+    )
+    await expectSlackMessageNotContaining('You’re about to tip')
+    fetchSpy.mockRestore()
+  })
+
   test('previews small group tip when total is more than $10', async () => {
     await connectTipAccounts()
 
@@ -1499,6 +1625,152 @@ test('@Tipbot mention sends Slack Connect tip to recipient home workspace member
     sender_member_id: connected.senderMember.id,
     workspace_id: connected.workspace.id,
   })
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention sends Slack Connect channel tip with mentioned workspace installation', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  await deleteSlackConnectWorkspace()
+  await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
+    botToken: Constants.slackConnect.teamBotToken,
+    botUserId: Constants.slackConnect.teamBotUserId,
+    teamName: Constants.slackConnect.teamName,
+  })
+  const connected = await connectTipAccounts({ recipient: false })
+  const connectWorkspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  const connectMember = await insertMember({
+    account_id: connected.recipientAccount.id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: connectWorkspace.id,
+  })
+  const channelId = await getSlackConnectChannelId()
+  const messageTs = `1700000027.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    authorizations: [{ is_bot: true, team_id: providerId, user_id: Constants.slack.botUserId }],
+    channelId,
+    contextTeamId: providerId,
+    messageTs,
+    teamId: Constants.slackConnect.teamId,
+    text: `<@${Constants.slack.botUserId}> <!channel>`,
+  })
+  const tip = await waitForTipByIdempotencyKey(`mention:${providerId}:${channelId}:${messageTs}`)
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slack.adminUserId}> tipped <!channel> 1 accounts $0.001 each · Receipt`,
+    { channelId },
+  )
+  expect(tip).toMatchObject({
+    recipient_member_id: connectMember.id,
+    sender_member_id: connected.senderMember.id,
+    workspace_id: connected.workspace.id,
+  })
+  expect(
+    fetchSpy.mock.calls.some((call) => {
+      const input = call[0]
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const params = slackFetchBodyParams(call[1]?.body)
+      return (
+        url.endsWith('/chat.postMessage') &&
+        getSlackFetchAuthorization(call) === `Bearer ${Constants.slack.botToken}` &&
+        params.get('text')?.includes('tipped <!channel>')
+      )
+    }),
+  ).toBe(true)
+  fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention sends Slack Connect here tip with active members', async () => {
+  const originalFetch = globalThis.fetch
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    if (url.endsWith('/users.getPresence')) {
+      const params = slackFetchBodyParams(init?.body)
+      return Response.json({
+        ok: true,
+        presence:
+          params.get('user') === Constants.slack.adminUserId ||
+          params.get('user') === Constants.slackConnect.userId
+            ? 'active'
+            : 'away',
+      })
+    }
+    return originalFetch(input, init)
+  }) satisfies typeof fetch)
+  await deleteSlackConnectWorkspace()
+  await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
+    botToken: Constants.slackConnect.teamBotToken,
+    botUserId: Constants.slackConnect.teamBotUserId,
+    teamName: Constants.slackConnect.teamName,
+  })
+  const connected = await connectTipAccounts({ recipient: false })
+  const connectWorkspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  const connectMember = await insertMember({
+    account_id: connected.recipientAccount.id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: connectWorkspace.id,
+  })
+  const channelId = await getSlackConnectChannelId()
+  const messageTs = `1700000028.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    authorizations: [{ is_bot: true, team_id: providerId, user_id: Constants.slack.botUserId }],
+    channelId,
+    contextTeamId: providerId,
+    messageTs,
+    teamId: Constants.slackConnect.teamId,
+    text: `<@${Constants.slack.botUserId}> <!here>`,
+  })
+  const tip = await waitForTipByIdempotencyKey(`mention:${providerId}:${channelId}:${messageTs}`)
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slack.adminUserId}> tipped <!here> 1 accounts $0.001 each · Receipt`,
+    { channelId },
+  )
+  expect(tip).toMatchObject({
+    recipient_member_id: connectMember.id,
+    sender_member_id: connected.senderMember.id,
+    workspace_id: connected.workspace.id,
+  })
+  expect(
+    fetchSpy.mock.calls.some((call) => {
+      const input = call[0]
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const params = slackFetchBodyParams(call[1]?.body)
+      return (
+        url.endsWith('/chat.postMessage') &&
+        getSlackFetchAuthorization(call) === `Bearer ${Constants.slack.botToken}` &&
+        params.get('text')?.includes('tipped <!here>')
+      )
+    }),
+  ).toBe(true)
+  fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
+test('@Tipbot mention ignores everyone as a tip target', async () => {
+  aiRunMock.mockResolvedValueOnce({ response: '@Tipbot' } as never)
+  const messageTs = `1700000029.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <!everyone> $11 for coffee`,
+  })
+
+  expect(response.status).toBe(200)
+  await expectSlackThreadMessage(messageTs, 'Anytime.')
+  await expectSlackThreadMessageNotContaining(messageTs, 'You’re about to tip')
+  await expectSlackThreadMessageNotContaining(messageTs, 'Receipt')
 }, 20_000) // 20 seconds
 
 test('@Tipbot mention posts Slack Connect confirmation with host workspace installation', async () => {
@@ -4408,21 +4680,31 @@ async function postSlackInteraction(payload: unknown) {
 }
 
 async function postSlackAppMention(options: {
+  authorizations?: Array<{
+    is_bot?: boolean
+    team_id?: string
+    user_id?: string
+  }>
   channelId?: string
+  contextTeamId?: string
   eventId?: string
   messageTs: string
   subtype?: string
+  teamId?: string
   text: string
   threadTs?: string
   userId?: string
 }) {
   const body = JSON.stringify({
+    ...(options.authorizations ? { authorizations: options.authorizations } : {}),
+    ...(options.contextTeamId ? { context_team_id: options.contextTeamId } : {}),
     event: {
       channel: options.channelId ?? Constants.slack.channelId,
       channel_type: 'channel',
+      ...(options.contextTeamId ? { context_team_id: options.contextTeamId } : {}),
       event_ts: options.messageTs,
       ...(options.subtype ? { subtype: options.subtype } : {}),
-      team: providerId,
+      team: options.teamId ?? providerId,
       text: options.text,
       ...(options.threadTs ? { thread_ts: options.threadTs } : {}),
       ts: options.messageTs,
@@ -4430,7 +4712,7 @@ async function postSlackAppMention(options: {
       user: options.userId ?? Constants.slack.adminUserId,
     },
     event_id: options.eventId ?? `Ev${Nanoid.generate()}`,
-    team_id: providerId,
+    team_id: options.teamId ?? providerId,
     type: 'event_callback',
   })
   const response = await client.api.chat.slack.$post(

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -266,13 +266,13 @@ describe('/tip @account', () => {
 
   test('previews channel tip through channel membership', async () => {
     await connectTipAccounts()
+    await memberSlack.conversations.join({ channel: Constants.slack.channelId })
 
     const response = await postSlashCommand('<!channel> $11 for coffee')
 
     expect(response.status).toBe(200)
     await expectSlackMessage('You’re about to tip <!channel> 1 accounts $11.00 each for coffee.')
     await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
-    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
     await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
     await expectSlackMessageNotContaining('Receipt')
   })

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -356,7 +356,7 @@ describe('/tip @account', () => {
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      'Payment not sent. I could not read the channel members. Invite Tipbot to this channel and try again.',
+      'Payment not sent. Tipbot could not read the channel members. Invite Tipbot to this channel and try again.',
     )
     await expectSlackMessageNotContaining('You’re about to tip')
     fetchSpy.mockRestore()
@@ -376,7 +376,7 @@ describe('/tip @account', () => {
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      'Payment not sent. I could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
+      'Payment not sent. Tipbot could not read the channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
     )
     await expectSlackMessageNotContaining('You’re about to tip')
     fetchSpy.mockRestore()
@@ -397,7 +397,7 @@ describe('/tip @account', () => {
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
-      'Payment not sent. I could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
+      'Payment not sent. Tipbot could not read active channel members because Tipbot is missing Slack permissions. Reinstall Tipbot and try again.',
     )
     await expectSlackMessageNotContaining('You’re about to tip')
     fetchSpy.mockRestore()

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -264,6 +264,19 @@ describe('/tip @account', () => {
     await expectSlackMessageNotContaining('Receipt')
   }, 20_000) // 20 seconds
 
+  test('previews channel tip through channel membership', async () => {
+    await connectTipAccounts()
+
+    const response = await postSlashCommand('<!channel> $11 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage('You’re about to tip <!channel> 1 accounts $11.00 each for coffee.')
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining('Receipt')
+  })
+
   test('previews small group tip when total is more than $10', async () => {
     await connectTipAccounts()
 

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -195,13 +195,6 @@ test('parses multi-recipient tip mentions', () => {
     token: null,
     usergroups: [{ providerUsergroupId: 'here', providerUsergroupLabel: 'here' }],
   })
-  expect(Tip.parseTipBatchText('<!everyone> 1 USDC for ship')).toEqual({
-    amount: 1_000_000,
-    memo: 'ship',
-    recipients: [],
-    token: 'USDC',
-    usergroups: [{ providerUsergroupId: 'everyone' }],
-  })
   expect(Tip.parseTipBatchText('<@UFOO> for <@UBAR>')).toBe(null)
 })
 

--- a/src/lib/tip.test.ts
+++ b/src/lib/tip.test.ts
@@ -181,6 +181,27 @@ test('parses multi-recipient tip mentions', () => {
     token: null,
     usergroups: [{ providerUsergroupId: 'SENGINEERING', providerUsergroupLabel: 'engineering' }],
   })
+  expect(Tip.parseTipBatchText('<!channel> 0.001 for coffee')).toEqual({
+    amount: 1000,
+    memo: 'coffee',
+    recipients: [],
+    token: null,
+    usergroups: [{ providerUsergroupId: 'channel' }],
+  })
+  expect(Tip.parseTipBatchText('<!here|@here>')).toEqual({
+    amount: undefined,
+    memo: null,
+    recipients: [],
+    token: null,
+    usergroups: [{ providerUsergroupId: 'here', providerUsergroupLabel: 'here' }],
+  })
+  expect(Tip.parseTipBatchText('<!everyone> 1 USDC for ship')).toEqual({
+    amount: 1_000_000,
+    memo: 'ship',
+    recipients: [],
+    token: 'USDC',
+    usergroups: [{ providerUsergroupId: 'everyone' }],
+  })
   expect(Tip.parseTipBatchText('<@UFOO> for <@UBAR>')).toBe(null)
 })
 

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -508,18 +508,27 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
     }
 
     const usergroup = remaining.match(/^<!subteam\^([A-Z0-9_]+)(?:\|([^>]+))?>\s*/)
-    if (!usergroup) break
-    if (!usergroups.some((item) => item.providerUsergroupId === usergroup[1]))
+    const vanityUsergroup = usergroup
+      ? null
+      : remaining.match(/^<!(channel|here|everyone)(?:\|([^>]+))?>\s*/)
+    if (!usergroup && !vanityUsergroup) break
+    const providerUsergroupId = (usergroup?.[1] ?? vanityUsergroup?.[1])!
+    const providerUsergroupLabel =
+      usergroup?.[2]?.trim().replace(/^@+/, '') ?? vanityUsergroup?.[2]?.trim().replace(/^@+/, '')
+    if (!usergroups.some((item) => item.providerUsergroupId === providerUsergroupId))
       usergroups.push({
-        ...(usergroup[2]?.trim()
-          ? { providerUsergroupLabel: usergroup[2].trim().replace(/^@+/, '') }
-          : {}),
-        providerUsergroupId: usergroup[1]!,
+        ...(providerUsergroupLabel ? { providerUsergroupLabel } : {}),
+        providerUsergroupId,
       })
-    remaining = remaining.slice(usergroup[0].length)
+    remaining = remaining.slice((usergroup ?? vanityUsergroup)![0].length)
   }
   if (recipients.length === 0 && usergroups.length === 0) return null
-  if (/<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>/.test(remaining)) return null
+  if (
+    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here|everyone)(?:\|[^>]+)?>/.test(
+      remaining,
+    )
+  )
+    return null
 
   const parsed = parseTipText(
     `<@${recipients[0]?.recipientProviderUserId ?? 'U000000000'}${recipients[0]?.recipientProviderLabel ? `|${recipients[0].recipientProviderLabel}` : ''}> ${remaining}`,

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -510,7 +510,7 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
     const usergroup = remaining.match(/^<!subteam\^([A-Z0-9_]+)(?:\|([^>]+))?>\s*/)
     const vanityUsergroup = usergroup
       ? null
-      : remaining.match(/^<!(channel|here|everyone)(?:\|([^>]+))?>\s*/)
+      : remaining.match(/^<!(channel|here)(?:\|([^>]+))?>\s*/)
     if (!usergroup && !vanityUsergroup) break
     const providerUsergroupId = (usergroup?.[1] ?? vanityUsergroup?.[1])!
     const providerUsergroupLabel =
@@ -524,7 +524,7 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
   }
   if (recipients.length === 0 && usergroups.length === 0) return null
   if (
-    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here|everyone)(?:\|[^>]+)?>/.test(
+    /<@[A-Z0-9_]+(?:\|[^>]+)?>|<!subteam\^[A-Z0-9_]+(?:\|[^>]+)?>|<!(?:channel|here)(?:\|[^>]+)?>/.test(
       remaining,
     )
   )

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -508,19 +508,17 @@ export function parseTipBatchText(value: string, options: { chainId?: number } =
     }
 
     const usergroup = remaining.match(/^<!subteam\^([A-Z0-9_]+)(?:\|([^>]+))?>\s*/)
-    const vanityUsergroup = usergroup
-      ? null
-      : remaining.match(/^<!(channel|here)(?:\|([^>]+))?>\s*/)
-    if (!usergroup && !vanityUsergroup) break
-    const providerUsergroupId = (usergroup?.[1] ?? vanityUsergroup?.[1])!
+    const specialMention = usergroup ? null : remaining.match(/^<!(channel|here)(?:\|([^>]+))?>\s*/)
+    if (!usergroup && !specialMention) break
+    const providerUsergroupId = (usergroup?.[1] ?? specialMention?.[1])!
     const providerUsergroupLabel =
-      usergroup?.[2]?.trim().replace(/^@+/, '') ?? vanityUsergroup?.[2]?.trim().replace(/^@+/, '')
+      usergroup?.[2]?.trim().replace(/^@+/, '') ?? specialMention?.[2]?.trim().replace(/^@+/, '')
     if (!usergroups.some((item) => item.providerUsergroupId === providerUsergroupId))
       usergroups.push({
         ...(providerUsergroupLabel ? { providerUsergroupLabel } : {}),
         providerUsergroupId,
       })
-    remaining = remaining.slice((usergroup ?? vanityUsergroup)![0].length)
+    remaining = remaining.slice((usergroup ?? specialMention)![0].length)
   }
   if (recipients.length === 0 && usergroups.length === 0) return null
   if (


### PR DESCRIPTION
## Summary
- parse Slack vanity mentions (<!channel>, <!here>, <!everyone>) as group tip targets
- resolve vanity targets through conversations.members and reuse existing multi-recipient preview/confirmation flow
- cover vanity mention parsing and channel membership preview behavior

## Validation
- PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0zL9WKZ:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm test --run src/lib/tip.test.ts
- PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0zL9WKZ:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm check:types
- PATH=/home/agent/bin:/home/agent/.local/bin:/home/agent/bin:/home/agent/.codex/tmp/arg0/codex-arg0zL9WKZ:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pnpm test --run src/chat.workers.test.ts -t "channel tip|group tip|Tipbot mention shows group preview" (blocked in worker global setup: local Tempo RPC returned HTTP 400 for eth_getTransactionCount during fee-payer mint before tests ran)
