### PR TITLE
test: cover alternate sender id in Slack group tips

### DIFF
--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -311,6 +311,45 @@ describe('/tip @account', () => {
     fetchSpy.mockRestore()
   })
 
+  test('skips sender account when channel membership uses alternate Slack account id', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.endsWith('/conversations.members'))
+        return Response.json({
+          members: ['WALTERNATESELF', Constants.slack.memberUserId],
+          ok: true,
+          response_metadata: { next_cursor: '' },
+        })
+      if (url.endsWith('/users.info')) {
+        const params = slackFetchBodyParams(init?.body)
+        if (params.get('user') === 'WALTERNATESELF')
+          return Response.json({
+            ok: true,
+            user: { deleted: false, id: 'WALTERNATESELF', is_app_user: false, is_bot: false },
+          })
+      }
+      return originalFetch(input, init)
+    }) satisfies typeof fetch)
+    const accounts = await connectTipAccounts()
+    await insertMember({
+      account_id: accounts.senderAccount.id,
+      provider_user_id: 'WALTERNATESELF',
+      workspace_id: accounts.workspace.id,
+    })
+
+    const response = await postSlashCommand('<!channel> 0.001 for coffee')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      `<@${Constants.slack.adminUserId}> sent <!channel> 1 accounts $0.001 each for coffee · Receipt`,
+    )
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessageNotContaining('WALTERNATESELF')
+    await expectSlackMessageNotContaining('Payment not sent. Cannot send a payment to yourself.')
+    fetchSpy.mockRestore()
+  }, 20_000) // 20 seconds
+
   test('previews here tip through active channel membership', async () => {
     const originalFetch = globalThis.fetch
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {


### PR DESCRIPTION
Adds regression coverage for Slack group tips when channel membership returns an alternate Slack user ID that maps to the sender’s connected account.