### PR TITLE
feat: aggregate threaded receipt boosts

### DIFF
--- a/db/migrations/0015_receipt_boost_thread.sql
+++ b/db/migrations/0015_receipt_boost_thread.sql
@@ -1,0 +1,16 @@
+-- Track Slack receipt boost aggregate replies so threaded boosts update one summary message.
+CREATE TABLE "receipt_boost_thread" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "workspace_id" TEXT NOT NULL REFERENCES "workspace" ("id") ON DELETE CASCADE,
+  "channel_id" TEXT NOT NULL,
+  "thread_ts" TEXT NOT NULL,
+  "reply_ts" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "receipt_boost_thread_thread_idx" ON "receipt_boost_thread" (
+  "workspace_id",
+  "channel_id",
+  "thread_ts"
+);

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -100,6 +100,16 @@ export const reaction_tip_thread = z.object({
   workspace_id: z.string(),
 })
 
+export const receipt_boost_thread = z.object({
+  channel_id: z.string(),
+  created_at: z.string(),
+  id: z.string(),
+  reply_ts: z.string(),
+  thread_ts: z.string(),
+  updated_at: z.string(),
+  workspace_id: z.string(),
+})
+
 export const tip = z.object({
   access_key_id: z.string().nullable(),
   amount: z.number(),
@@ -186,6 +196,7 @@ export const db = {
   reaction_tip: reaction_tip,
   reaction_tip_config: reaction_tip_config,
   reaction_tip_thread: reaction_tip_thread,
+  receipt_boost_thread: receipt_boost_thread,
   tip: tip,
   tip_batch: tip_batch,
   tip_receipt_message: tip_receipt_message,

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -11,6 +11,7 @@ export interface DB {
   reaction_tip: reaction_tip
   reaction_tip_config: reaction_tip_config
   reaction_tip_thread: reaction_tip_thread
+  receipt_boost_thread: receipt_boost_thread
   tip: tip
   tip_batch: tip_batch
   tip_receipt_message: tip_receipt_message
@@ -115,6 +116,16 @@ type reaction_tip_thread = {
   workspace_id: string
 }
 
+type receipt_boost_thread = {
+  channel_id: string
+  created_at: k.Generated<string>
+  id: string
+  reply_ts: string
+  thread_ts: string
+  updated_at: k.Generated<string>
+  workspace_id: string
+}
+
 type tip = {
   access_key_id: string | null
   amount: number
@@ -194,6 +205,7 @@ export declare namespace DB {
   type reaction_tip = k.Selectable<DB['reaction_tip']>
   type reaction_tip_config = k.Selectable<DB['reaction_tip_config']>
   type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
+  type receipt_boost_thread = k.Selectable<DB['receipt_boost_thread']>
   type tip = k.Selectable<DB['tip']>
   type tip_batch = k.Selectable<DB['tip_batch']>
   type tip_receipt_message = k.Selectable<DB['tip_receipt_message']>
@@ -208,6 +220,7 @@ export declare namespace DB {
     type reaction_tip = k.Insertable<DB['reaction_tip']>
     type reaction_tip_config = k.Insertable<DB['reaction_tip_config']>
     type reaction_tip_thread = k.Insertable<DB['reaction_tip_thread']>
+    type receipt_boost_thread = k.Insertable<DB['receipt_boost_thread']>
     type tip = k.Insertable<DB['tip']>
     type tip_batch = k.Insertable<DB['tip_batch']>
     type tip_receipt_message = k.Insertable<DB['tip_receipt_message']>
@@ -223,6 +236,7 @@ export declare namespace DB {
     type reaction_tip = k.Selectable<DB['reaction_tip']>
     type reaction_tip_config = k.Selectable<DB['reaction_tip_config']>
     type reaction_tip_thread = k.Selectable<DB['reaction_tip_thread']>
+    type receipt_boost_thread = k.Selectable<DB['receipt_boost_thread']>
     type tip = k.Selectable<DB['tip']>
     type tip_batch = k.Selectable<DB['tip_batch']>
     type tip_receipt_message = k.Selectable<DB['tip_receipt_message']>
@@ -238,6 +252,7 @@ export declare namespace DB {
     type reaction_tip = k.Updateable<DB['reaction_tip']>
     type reaction_tip_config = k.Updateable<DB['reaction_tip_config']>
     type reaction_tip_thread = k.Updateable<DB['reaction_tip_thread']>
+    type receipt_boost_thread = k.Updateable<DB['receipt_boost_thread']>
     type tip = k.Updateable<DB['tip']>
     type tip_batch = k.Updateable<DB['tip_batch']>
     type tip_receipt_message = k.Updateable<DB['tip_receipt_message']>

--- a/src/api.ts
+++ b/src/api.ts
@@ -535,6 +535,34 @@ export const api = new Hono<{
                 .executeTakeFirst()
               if (!receipt) return
 
+              if (receipt.thread_ts !== receipt.message_ts) {
+                await Chat.updateReceiptBoostAggregate(data.payload.providerId, {
+                  channelId,
+                  threadTs: receipt.thread_ts,
+                  workspaceId,
+                })
+                if (data.payload.skippedRecipients?.length) {
+                  const skippedBody = new URLSearchParams()
+                  const recipientCount = data.payload.recipients?.length ?? 1
+                  const skippedCount = data.payload.skippedRecipients.length
+                  skippedBody.set('channel', channelId)
+                  skippedBody.set(
+                    'text',
+                    `Boost sent to ${recipientCount} ${recipientCount === 1 ? 'account' : 'accounts'}. Skipped ${skippedCount} ${skippedCount === 1 ? 'account' : 'accounts'} that can no longer receive payments.`,
+                  )
+                  skippedBody.set('thread_ts', receipt.thread_ts)
+                  skippedBody.set('user', data.payload.senderProviderUserId)
+                  await Chat.getSlack().withBotToken(installation.botToken, () =>
+                    fetch(`${c.env.SLACK_API_URL}/chat.postEphemeral`, {
+                      body: skippedBody,
+                      headers: { authorization: `Bearer ${installation.botToken}` },
+                      method: 'POST',
+                    }),
+                  )
+                }
+                return
+              }
+
               const originalReceiptLink = (() => {
                 if (receipt.thread_ts === receipt.message_ts) return ''
                 const url = new URL('slack://channel')

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -2238,17 +2238,36 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
         .where('channel_id', '=', event.item.channel)
         .where('message_ts', '=', event.item.ts)
         .executeTakeFirst()
-      if (existing)
+      if (existing) {
+        let threadTs = message?.thread_ts ?? existing.thread_ts
+        if (threadTs === existing.message_ts) {
+          const batch = await db
+            .selectFrom('tip_batch')
+            .select('provider_thread_id')
+            .where('id', '=', existing.tip_batch_id)
+            .executeTakeFirst()
+          threadTs = batch?.provider_thread_id ?? threadTs
+        }
+        if (threadTs !== existing.thread_ts)
+          await recordSlackReceiptMessage(db, {
+            channelId: existing.channel_id,
+            messageTs: existing.message_ts,
+            threadTs,
+            tipBatchId: existing.tip_batch_id,
+            workspaceId: existing.workspace_id,
+          })
         return {
           channelId: existing.channel_id,
           messageTs: existing.message_ts,
-          threadTs: existing.thread_ts,
+          threadTs,
           tipBatchId: existing.tip_batch_id,
           workspaceId: existing.workspace_id,
         }
+      }
 
       // Backfill older receipts by parsing the receipt link from the Slack message.
-      if (message?.text?.startsWith('Reaction tips')) return null
+      if (message?.text?.startsWith('Reaction tips') || message?.text?.startsWith('Boosts'))
+        return null
       const transactionHash = JSON.stringify(message ?? {}).match(
         /\/receipt\/(0x[0-9a-fA-F]{64})/,
       )?.[1]
@@ -2424,24 +2443,27 @@ async function handleSlackReactionTip(event: SlackReactionEvent, context: Reacti
 
     if (result.ok) {
       if (result.status === 'sent') {
-        await postSlackReceiptMessage(
-          {
-            channel: getChat().channel(`slack:${event.item.channel}`),
+        if (receipt.threadTs === receipt.messageTs)
+          await postSlackReceiptMessage(
+            {
+              channel: getChat().channel(`slack:${event.item.channel}`),
+              threadTs: receipt.threadTs,
+              user: { userId: event.user } as chat.Author,
+            },
+            { db, provider, text: '', threadTs: receipt.threadTs },
+            `<@${sender.provider_user_id}> boosted`,
+            result.chainId,
+            result.transactionHash,
+            undefined,
+            undefined,
+            receipt.threadTs,
+          )
+        else
+          await updateReceiptBoostAggregate(provider.id, {
+            channelId: event.item.channel,
             threadTs: receipt.threadTs,
-            user: { userId: event.user } as chat.Author,
-          },
-          { db, provider, text: '', threadTs: receipt.threadTs },
-          `<@${sender.provider_user_id}> boosted${
-            receipt.threadTs === receipt.messageTs
-              ? ''
-              : ` ${Slack.formatMessageLink(provider.id, event.item.channel, receipt.messageTs)}`
-          }`,
-          result.chainId,
-          result.transactionHash,
-          undefined,
-          undefined,
-          receipt.threadTs,
-        )
+            workspaceId: receipt.workspaceId,
+          })
         if (skippedRecipients.length)
           await postSlackEphemeral(
             provider.id,
@@ -3107,6 +3129,175 @@ export async function updateReactionTipAggregate(
         id: Nanoid.generate(),
         message_ts: options.threadTs,
         reply_ts: json.ts,
+        updated_at: now,
+        workspace_id: options.workspaceId,
+      })
+      .execute()
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error
+  }
+}
+
+export async function updateReceiptBoostAggregate(
+  providerId: string,
+  options: {
+    channelId: string
+    threadTs: string
+    workspaceId: string
+  },
+) {
+  const db = DB.create(env.DB)
+  const rows = await db
+    .selectFrom('tip_batch')
+    .innerJoin('member as sender', 'sender.id', 'tip_batch.sender_member_id')
+    .innerJoin('workspace', 'workspace.id', 'tip_batch.workspace_id')
+    .select([
+      'sender.provider_user_id as sender_provider_user_id',
+      'tip_batch.amount_each',
+      'tip_batch.idempotency_key',
+      'tip_batch.token_address',
+      'tip_batch.transaction_hash',
+      'workspace.chain_id',
+      'workspace.default_token_address',
+    ])
+    .where('tip_batch.workspace_id', '=', options.workspaceId)
+    .where((eb) =>
+      eb.or([
+        eb('tip_batch.provider_channel_id', '=', options.channelId),
+        eb('tip_batch.provider_channel_id', '=', `slack:${options.channelId}`),
+      ]),
+    )
+    .where('tip_batch.provider_thread_id', '=', options.threadTs)
+    .where('tip_batch.idempotency_key', 'like', `${receiptBoostIdempotencyPrefix}%`)
+    .where('tip_batch.status', '=', 'confirmed')
+    .where('tip_batch.transaction_hash', 'is not', null)
+    .orderBy('tip_batch.created_at', 'asc')
+    .execute()
+  if (rows.length === 0) return
+
+  const installation = await getSlack().getInstallation(providerId)
+  if (!installation) return
+
+  const groups = rows.reduce(
+    (groups, row) => {
+      const [, workspaceId, channelId, messageTs] = row.idempotency_key.split(':')
+      if (
+        workspaceId !== options.workspaceId ||
+        channelId !== options.channelId ||
+        !messageTs ||
+        !row.transaction_hash
+      )
+        return groups
+      const group = groups.find((group) => group.messageTs === messageTs)
+      const line = `• <@${row.sender_provider_user_id}> boosted · <${Tempo.formatTxLink(row.chain_id, row.transaction_hash)}|Receipt>`
+      if (group) {
+        group.lines.push(line)
+        return groups
+      }
+      groups.push({
+        amount: row.amount_each,
+        chainId: row.chain_id,
+        defaultTokenAddress: row.default_token_address,
+        lines: [line],
+        messageTs,
+        tokenAddress: row.token_address,
+      })
+      return groups
+    },
+    [] as Array<{
+      amount: number
+      chainId: number
+      defaultTokenAddress: string | null
+      lines: string[]
+      messageTs: string
+      tokenAddress: string
+    }>,
+  )
+  if (groups.length === 0) return
+
+  const groupTexts = await Promise.all(
+    groups.map(async (group) => {
+      const token = await Tempo.getTokenMetadata(env, group.chainId, group.tokenAddress)
+      const amount = formatAmount(group.amount)
+      const displayAmount = Address.isEqual(
+        Address.checksum(group.tokenAddress),
+        Address.checksum(group.defaultTokenAddress ?? Tempo.addressLookup.pathUsd),
+      )
+        ? formatCurrencyAmount(amount, token.currency)
+        : formatTipAmount(amount, token.currency, token.symbol)
+      return `Boosted ${Slack.formatMessageLink(providerId, options.channelId, group.messageTs)} ${displayAmount}:\n${group.lines.join('\n')}`
+    }),
+  )
+  const text = `Boosts\n\n${groupTexts.join('\n\n')}`
+  const existing = await db
+    .selectFrom('receipt_boost_thread')
+    .selectAll()
+    .where('workspace_id', '=', options.workspaceId)
+    .where('channel_id', '=', options.channelId)
+    .where('thread_ts', '=', options.threadTs)
+    .executeTakeFirst()
+
+  if (existing) {
+    const body = new URLSearchParams()
+    body.set('channel', options.channelId)
+    body.set('text', text)
+    body.set('ts', existing.reply_ts)
+    const response = await getSlack().withBotToken(installation.botToken, () =>
+      fetch(`${env.SLACK_API_URL}/chat.update`, {
+        body,
+        headers: { authorization: `Bearer ${installation.botToken}` },
+        method: 'POST',
+      }),
+    )
+    const json = z.parse(
+      z.object({
+        error: z.string().optional(),
+        ok: z.boolean().optional(),
+      }),
+      await response.json(),
+    )
+    if (!json.ok) throw Slack.slackApiError('chat.update', json.error)
+    await db
+      .updateTable('receipt_boost_thread')
+      .set({ updated_at: new Date().toISOString() })
+      .where('id', '=', existing.id)
+      .execute()
+    return
+  }
+
+  const body = new URLSearchParams()
+  body.set('channel', options.channelId)
+  body.set('text', text)
+  body.set('thread_ts', options.threadTs)
+  body.set('unfurl_links', 'false')
+  body.set('unfurl_media', 'false')
+  const response = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
+      body,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      error: z.string().optional(),
+      ok: z.boolean().optional(),
+      ts: z.string().optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok || !json.ts) throw Slack.slackApiError('chat.postMessage', json.error)
+
+  const now = new Date().toISOString()
+  try {
+    await db
+      .insertInto('receipt_boost_thread')
+      .values({
+        channel_id: options.channelId,
+        created_at: now,
+        id: Nanoid.generate(),
+        reply_ts: json.ts,
+        thread_ts: options.threadTs,
         updated_at: now,
         workspace_id: options.workspaceId,
       })

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -3624,6 +3624,126 @@ test('plus reaction boosts a receipt', async () => {
   })
 }, 20_000) // 20 seconds
 
+test('receipt boost aggregates threaded receipt boosts', async () => {
+  const connected = await connectTipAccounts()
+  const boosterMember = await insertMember({
+    account_id: connected.senderAccount.id,
+    provider_user_id: unconnectedProviderUserId,
+    workspace_id: connected.workspace.id,
+  })
+  const parent = await memberSlack.chat.postMessage({
+    channel: Constants.slack.channelId,
+    text: 'threaded boost aggregate parent',
+  })
+  if (!parent.ts) throw new Error('Expected Slack parent message timestamp.')
+  const parentTs = parent.ts
+  const tipResponse = await postSlackAppMention({
+    messageTs: `1700000041.${Nanoid.generate().slice(0, 6)}`,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    threadTs: parentTs,
+  })
+  await expectSlackThreadMessage(
+    parentTs,
+    `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+    { wait: true },
+  )
+  const replies = await slack.conversations.replies({
+    channel: Constants.slack.channelId,
+    ts: parentTs,
+  })
+  const receiptTs = replies.messages?.find((message) =>
+    message.text?.includes(
+      `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+    ),
+  )?.ts
+  if (!receiptTs) throw new Error('Expected Slack receipt message timestamp.')
+  await factory.tip_batch.insert({
+    amount_each: 1000,
+    idempotency_key: `${Chat.receiptBoostIdempotencyPrefix.replace(/:$/, '')}:${connected.workspace.id}:${Constants.slack.channelId}:${receiptTs}:${connected.senderMember.id}`,
+    provider: 'slack',
+    provider_channel_id: Constants.slack.channelId,
+    provider_id: providerId,
+    provider_thread_id: parentTs,
+    recipient_count: 1,
+    sender_member_id: connected.senderMember.id,
+    source: 'reaction',
+    status: 'confirmed',
+    token_address: Tempo.addressLookup.pathUsd,
+    total_amount: 1000,
+    transaction_hash: `0x${'1'.repeat(64)}`,
+    workspace_id: connected.workspace.id,
+  })
+  await factory.tip_batch.insert({
+    amount_each: 1000,
+    idempotency_key: `${Chat.receiptBoostIdempotencyPrefix.replace(/:$/, '')}:${connected.workspace.id}:${Constants.slack.channelId}:${receiptTs}:${boosterMember.id}`,
+    provider: 'slack',
+    provider_channel_id: Constants.slack.channelId,
+    provider_id: providerId,
+    provider_thread_id: parentTs,
+    recipient_count: 1,
+    sender_member_id: boosterMember.id,
+    source: 'reaction',
+    status: 'confirmed',
+    token_address: Tempo.addressLookup.pathUsd,
+    total_amount: 1000,
+    transaction_hash: `0x${'2'.repeat(64)}`,
+    workspace_id: connected.workspace.id,
+  })
+  await Chat.updateReceiptBoostAggregate(providerId, {
+    channelId: Constants.slack.channelId,
+    threadTs: parentTs,
+    workspaceId: connected.workspace.id,
+  })
+  expect(tipResponse.status).toBe(200)
+  await expect
+    .poll(
+      async () => {
+        const replies = await slack.conversations.replies({
+          channel: Constants.slack.channelId,
+          ts: parentTs,
+        })
+        return replies.messages?.find((message) => message.text?.startsWith('Boosts'))?.text ?? ''
+      },
+      { timeout: 5_000 }, // 5 seconds
+    )
+    .toContain(`• <@${unconnectedProviderUserId}> boosted · <`)
+  const aggregateReplies = await slack.conversations.replies({
+    channel: Constants.slack.channelId,
+    ts: parentTs,
+  })
+  const aggregate = aggregateReplies.messages?.find((message) => message.text?.startsWith('Boosts'))
+  if (!aggregate?.ts || !aggregate.text) throw new Error('Expected boost aggregate reply.')
+  const ignoredResponse = await postSlackReaction({
+    eventTs: `${aggregate.ts}-boost-ignored`,
+    messageTs: aggregate.ts,
+    reaction: '+',
+    userId: Constants.slack.adminUserId,
+  })
+  const boostCount = await db
+    .selectFrom('tip_batch')
+    .innerJoin('workspace', 'workspace.id', 'tip_batch.workspace_id')
+    .select(({ fn }) => fn.count<number>('tip_batch.id').as('count'))
+    .where('workspace.provider_id', '=', providerId)
+    .where('tip_batch.idempotency_key', 'like', `${Chat.receiptBoostIdempotencyPrefix}%`)
+    .executeTakeFirstOrThrow()
+
+  expect(ignoredResponse.status).toBe(200)
+  expect(aggregate.text).toContain(
+    `Boosted <slack://channel?team=${providerId}&id=${Constants.slack.channelId}&message=${receiptTs}|this message> $0.001:`,
+  )
+  expect(aggregate.text).toContain(`• <@${Constants.slack.adminUserId}> boosted · <`)
+  expect(aggregate.text).toContain(`• <@${unconnectedProviderUserId}> boosted · <`)
+  expect(
+    aggregateReplies.messages?.filter((message) => message.text?.startsWith('Boosts')),
+  ).toHaveLength(1)
+  expect(
+    aggregateReplies.messages?.some((message) =>
+      message.text?.startsWith(`<@${Constants.slack.adminUserId}> boosted`),
+    ),
+  ).toBe(false)
+  expect(boostCount.count).toBe(2)
+}, 20_000) // 20 seconds
+
 test('receipt boost uses backfilled missing receipt row', async () => {
   const originalFetch = globalThis.fetch
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
@@ -3969,6 +4089,96 @@ test('receipt boost confirms after approval', async () => {
   await expectSlackThreadMessage(receiptTs, `<@${Constants.slack.adminUserId}> boosted`, {
     wait: true,
   })
+  fetchSpy.mockRestore()
+}, 20_000) // 20 seconds
+
+test('threaded receipt boost confirms into aggregate after approval', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  const connected = await connectTipAccounts()
+  const parent = await memberSlack.chat.postMessage({
+    channel: Constants.slack.channelId,
+    text: 'threaded approval boost parent',
+  })
+  if (!parent.ts) throw new Error('Expected Slack parent message timestamp.')
+  const parentTs = parent.ts
+  const tipResponse = await postSlackAppMention({
+    messageTs: `1700000042.${Nanoid.generate().slice(0, 6)}`,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}>`,
+    threadTs: parentTs,
+  })
+  await expectSlackThreadMessage(
+    parentTs,
+    `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+    { wait: true },
+  )
+  const replies = await slack.conversations.replies({
+    channel: Constants.slack.channelId,
+    ts: parentTs,
+  })
+  const receiptTs = replies.messages?.find((message) =>
+    message.text?.includes(
+      `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt`,
+    ),
+  )?.ts
+  if (!receiptTs) throw new Error('Expected Slack receipt message timestamp.')
+  await db.deleteFrom('access_key').where('account_id', '=', connected.senderAccount.id).execute()
+
+  const boostResponse = await postSlackReaction({
+    messageTs: receiptTs,
+    reaction: '+',
+    userId: Constants.slack.adminUserId,
+  })
+  const confirmParams = await getSlackPostEphemeralParams(fetchSpy, '/confirm/')
+  const token = confirmParams.get('text')?.match(/\/confirm\/(0x[0-9a-f]+\.0x[0-9a-f]+)/i)?.[1]
+  if (!token) throw new Error('Expected confirmation token in Slack ephemeral message.')
+  const confirmation = await client.api.confirm[':token'].$get({ param: { token } })
+  const confirmationJson = await confirmation.json()
+  if (!confirmationJson.ok) throw new Error('Expected confirmation metadata.')
+  if (!confirmationJson.transactionRequest) throw new Error('Expected transaction request.')
+  await expectSlackThreadMessageNotContaining(parentTs, 'Boosts')
+
+  const provider = Provider.create({
+    adapter: dangerous_secp256k1({ privateKey: Constants.tip.senderRootPrivateKey }),
+    chains: [
+      {
+        ...Tempo.getChain(confirmationJson.chainId),
+        rpcUrls: { default: { http: [env.RPC_URL_TESTNET!] } },
+      },
+    ],
+    transports: { [confirmationJson.chainId]: http(env.RPC_URL_TESTNET) },
+  })
+  await provider.request({
+    method: 'wallet_connect',
+    params: [{ capabilities: { method: 'register' } }],
+  })
+  const signedTransaction = await provider.request({
+    method: 'eth_signTransaction',
+    params: [
+      { ...confirmationJson.transactionRequest, chainId: toHex(confirmationJson.chainId) } as never,
+    ],
+  })
+  const confirmResponse = await client.api.confirm[':token'].$post({
+    json: { address: connected.senderAccount.address, signedTransaction },
+    param: { token },
+  })
+  await drainWaitUntil()
+
+  expect(tipResponse.status).toBe(200)
+  expect(boostResponse.status).toBe(200)
+  expect(confirmation.status).toBe(200)
+  expect(confirmationJson).toMatchObject({ kind: 'onetime_payment' })
+  expect(confirmResponse.status).toBe(200)
+  await expect(confirmResponse.json()).resolves.toMatchObject({ ok: true })
+  await expectSlackThreadMessage(parentTs, 'Boosts', { wait: true })
+  await expectSlackThreadMessage(
+    parentTs,
+    `Boosted <slack://channel?team=${providerId}&id=${Constants.slack.channelId}&message=${receiptTs}|this message> $0.001:`,
+  )
+  await expectSlackThreadMessage(parentTs, `• <@${Constants.slack.adminUserId}> boosted · <`)
+  await expectSlackThreadMessageNotContaining(
+    parentTs,
+    `<@${Constants.slack.adminUserId}> boosted · Receipt`,
+  )
   fetchSpy.mockRestore()
 }, 20_000) // 20 seconds
 


### PR DESCRIPTION
Aggregate confirmed receipt boosts in threads into one updated Boosts reply instead of posting one receipt message per boost.