### PR TITLE
feat: add pending tip hardening tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev": "PORTLESS_HTTPS=1 portless run vp dev",
     "dev:app": "vp dev",
     "gen:types": "cp -n .env.example .env 2>/dev/null; wrangler types src/worker-configuration.d.ts",
+    "pending_tip:requeue": "node --experimental-strip-types scripts/pending_tip.ts requeue",
     "prepare": "vp config && pnpm gen:types",
     "preview": "vp build && vp preview",
     "slack:app": "node --experimental-strip-types scripts/slack.ts",

--- a/scripts/pending_tip.ts
+++ b/scripts/pending_tip.ts
@@ -1,0 +1,57 @@
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const command = args[0]
+
+if (command !== 'requeue') usage()
+
+const queueName = args[2] ? args[1] : (process.env.PENDING_TIP_QUEUE_NAME ?? 'tipbot-pending-tip')
+const pendingTipId = args[2] ?? args[1]
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+const token = process.env.CLOUDFLARE_API_TOKEN
+
+if (!queueName) usage('Expected queue name')
+if (!pendingTipId) usage('Expected pending tip id')
+if (!accountId) usage('Expected CLOUDFLARE_ACCOUNT_ID')
+if (!token) usage('Expected CLOUDFLARE_API_TOKEN with Queues Edit')
+
+const queueListResponse = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${accountId}/queues?name=${encodeURIComponent(queueName)}`,
+  { headers: { authorization: `Bearer ${token}` } },
+)
+const queueListText = await queueListResponse.text()
+if (!queueListResponse.ok) fail(queueListText)
+
+const queueId = (
+  JSON.parse(queueListText) as {
+    result?: { id: string; queue_name: string }[]
+  }
+).result?.find((queue) => queue.queue_name === queueName)?.id
+if (!queueId) fail(`Queue not found: ${queueName}`)
+
+const response = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${accountId}/queues/${queueId}/messages`,
+  {
+    body: JSON.stringify({ body: { pendingTipId } }),
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  },
+)
+const text = await response.text()
+if (!response.ok) fail(text)
+if (!(JSON.parse(text) as { success?: boolean }).success) fail(text)
+console.log(JSON.stringify({ ok: true, pendingTipId, queueName }))
+
+function fail(message: string): never {
+  console.error(message)
+  process.exit(1)
+}
+
+function usage(message?: string): never {
+  if (message) console.error(message)
+  console.error(
+    'Usage: CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... pnpm pending_tip:requeue [queue_name] <pending_tip_id>',
+  )
+  process.exit(1)
+}

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2342,6 +2342,52 @@ test('@Tipbot mention queues Slack Connect tip for unconnected recipient workspa
   await expectSlackThreadMessage(messageTs, 'Run `/tip connect` to receive it', { channelId })
 }, 20_000) // 20 seconds
 
+test('@Tipbot mention fails closed for ambiguous Slack Connect recipient', async () => {
+  const connected = await connectTipAccounts({ recipient: false })
+  await deleteSlackConnectWorkspace()
+  await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
+    botToken: Constants.slackConnect.teamBotToken,
+    botUserId: Constants.slackConnect.teamBotUserId,
+    teamName: Constants.slackConnect.teamName,
+  })
+  const connectWorkspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  await insertMember({
+    account_id: (await factory.account.insert({})).id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: connected.workspace.id,
+  })
+  await insertMember({
+    account_id: (await factory.account.insert({})).id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: connectWorkspace.id,
+  })
+  const channelId = await getSlackConnectChannelId()
+  const messageTs = `1700000005.${Nanoid.generate().slice(0, 6)}`
+  await expectSlackConnectEmulator(channelId)
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slackConnect.userId}>`,
+  })
+  const pendingTips = await db
+    .selectFrom('pending_tip')
+    .selectAll()
+    .where('sender_member_id', '=', connected.senderMember.id)
+    .execute()
+
+  expect(response.status).toBe(200)
+  expect(pendingTips).toEqual([])
+  await expectSlackMessage(
+    `Payment not sent. <@${Constants.slackConnect.userId}> could not be resolved safely across Slack workspaces.`,
+    { channelId },
+  )
+}, 20_000) // 20 seconds
+
 test('@Tipbot mention queued Slack Connect tip uses mention connect when recipient workspace is uninstalled', async () => {
   const connected = await connectTipAccounts({ recipient: false })
   await deleteSlackConnectWorkspace()

--- a/src/entry-server.ts
+++ b/src/entry-server.ts
@@ -28,6 +28,8 @@ export default {
         await handler(message as never)
         message.ack()
       } catch (error) {
+        if (queue === processPendingTipMessage.queueName && message.attempts >= 3)
+          console.error('Pending tip queue message reached DLQ threshold:', message.body)
         console.error(`Queue message ${message.id} failed:`, error)
         message.retry()
       }


### PR DESCRIPTION
Adds pending tip DLQ logging, a standalone Cloudflare Queue requeue script, and a Slack Connect ambiguity regression test.