### PR TITLE
feat: support explicit multi-recipient pending tips

### DIFF
--- a/.github/TODO.md
+++ b/.github/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 
 - Use Workers AI to parse more flexible natural-language tip commands after explicit amount/token syntax is stable.
+- Support queued tips for group/usergroup recipients after explicit multi-recipient pending tips roll out.
 - Production setup guide (see below)
 
 ## Production

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1309,6 +1309,7 @@ const handlers = {
     const plan = !shouldResolvePlan
       ? {
           ok: true as const,
+          pendingRecipients: [],
           previewRequired: false,
           recipients: parsed.recipients,
           skippedRecipients: [],
@@ -1356,7 +1357,7 @@ const handlers = {
       })
     try {
       const result = await (
-        plan.recipients.length === 1 && !plan.usergroupId
+        plan.recipients.length === 1 && plan.pendingRecipients.length === 0 && !plan.usergroupId
           ? Tip.handleTipRequest(env, {
               amount: parsed.amount,
               idempotencyKey: options.idempotencyKey,
@@ -1382,6 +1383,7 @@ const handlers = {
               providerChannelId: event.channel.id,
               providerId: ctx.channelProviderId ?? ctx.provider.id,
               providerThreadId: options.threadTs,
+              pendingRecipients: plan.pendingRecipients,
               recipients: plan.recipients,
               senderProviderUserId: event.user.userId,
               settingsProviderId: ctx.settingsProviderId,
@@ -1401,14 +1403,33 @@ const handlers = {
           }) satisfies Tip.TipResult,
       )
 
-      if (result.ok && result.status === 'sent' && 'recipients' in result) {
+      if (result.ok && 'queuedRecipients' in result && result.queuedRecipients?.length) {
+        const messageTs = await postSlackQueuedTipBatchMessage(
+          ctx,
+          {
+            ...result,
+            queuedRecipients: result.queuedRecipients,
+          },
+          {
+            channelId: event.channel.id,
+            mentionUser: (providerUserId) => event.channel.mentionUser(providerUserId),
+            threadTs: options.threadTs,
+          },
+        )
+        for (const recipient of result.queuedRecipients) {
+          await Tip.recordPendingTipMessage(env, {
+            pendingTipId: recipient.pendingTipId,
+            providerMessageTs: messageTs,
+          })
+        }
+      } else if (result.ok && result.status === 'sent' && 'recipients' in result) {
         await postTipResult(event, ctx, result, {
           skippedRecipients: plan.skippedRecipients,
           threadTs: options.threadTs,
           usergroupId: plan.usergroupId,
           usergroupLabel: plan.usergroupLabel,
         })
-      } else if (result.ok && result.status === 'queued') {
+      } else if (result.ok && result.status === 'queued' && 'pendingTipId' in result) {
         const messageTs = await postSlackQueuedTipMessage(ctx, result, {
           channelId: event.channel.id,
           mentionUser: (providerUserId) => event.channel.mentionUser(providerUserId),
@@ -1434,7 +1455,7 @@ const handlers = {
         )
         if (result.memo && options.threadTs)
           await postSlackMemoReply(event, ctx, result.memo, options.threadTs)
-      } else if (result.ok)
+      } else if (result.ok && 'transactionHash' in result)
         await postSlackReceiptMessage(
           event,
           ctx,
@@ -1447,6 +1468,7 @@ const handlers = {
             : undefined,
           options.threadTs,
         )
+      else if (result.ok) await postPrivateReply(event, event.user, 'Payment already sent.')
       else {
         if (result.code === 'confirmation_required' && result.confirmUrl) {
           await postSlackPaymentConfirmation(event, ctx, result.confirmUrl, {
@@ -1671,6 +1693,7 @@ async function resolveSlackTipPlan(
 ): Promise<
   | {
       ok: true
+      pendingRecipients: Tip.TipRecipientInput[]
       previewRequired: boolean
       recipients: Tip.TipRecipientInput[]
       skippedRecipients: Tip.TipSkippedRecipient[]
@@ -1682,6 +1705,7 @@ async function resolveSlackTipPlan(
   if (ctx.provider.type !== 'slack')
     return {
       ok: true,
+      pendingRecipients: [],
       previewRequired: false,
       recipients: parsed.recipients,
       skippedRecipients: [],
@@ -1695,6 +1719,7 @@ async function resolveSlackTipPlan(
   if (!installation)
     return {
       ok: true,
+      pendingRecipients: [],
       previewRequired: false,
       recipients: parsed.recipients,
       skippedRecipients: [],
@@ -1818,7 +1843,9 @@ async function resolveSlackTipPlan(
   }
 
   const recipients = [] as Tip.TipRecipientInput[]
+  const pendingRecipients = [] as Tip.TipRecipientInput[]
   const skippedRecipients = [] as Tip.TipSkippedRecipient[]
+  const explicitRecipientCount = parsed.recipients.length
   const senderAccount = await ctx.db
     .selectFrom('workspace')
     .innerJoin('member', 'member.workspace_id', 'workspace.id')
@@ -1839,7 +1866,7 @@ async function resolveSlackTipPlan(
     }
 
     const allowUnconnectedSingleRecipient = Boolean(
-      conversation.isShared && target.source === 'explicit' && targets.length === 1,
+      conversation.isShared && target.source === 'explicit',
     )
     const recipient = conversation.isShared
       ? await resolveSlackConnectRecipient(ctx, conversation.teamIds, target.recipient, {
@@ -1848,11 +1875,15 @@ async function resolveSlackTipPlan(
       : await resolveLocalSlackRecipient(ctx, target.recipient)
     if ('message' in recipient) return { message: recipient.message, ok: false }
     if (!recipient.value) {
-      skippedRecipients.push({
-        reason: 'not_connected',
-        recipientProviderLabel: target.recipient.recipientProviderLabel,
-        recipientProviderUserId: target.recipient.recipientProviderUserId,
-      })
+      if (target.source === 'explicit') pendingRecipients.push(target.recipient)
+      else {
+        // TODO: support queued tips for group/usergroup recipients after explicit multi-recipient rollout.
+        skippedRecipients.push({
+          reason: 'not_connected',
+          recipientProviderLabel: target.recipient.recipientProviderLabel,
+          recipientProviderUserId: target.recipient.recipientProviderUserId,
+        })
+      }
       continue
     }
     if (recipient.accountId && recipient.accountId === senderAccount?.account_id) {
@@ -1860,10 +1891,14 @@ async function resolveSlackTipPlan(
         return { message: 'Payment not sent. Cannot send a payment to yourself.', ok: false }
       continue
     }
+    if (target.source === 'explicit' && !recipient.accountId && explicitRecipientCount > 1) {
+      pendingRecipients.push(recipient.value)
+      continue
+    }
     recipients.push(recipient.value)
   }
 
-  if (recipients.length === 0) {
+  if (recipients.length === 0 && pendingRecipients.length === 0) {
     const usergroup = parsed.usergroups?.[0]
     return {
       message: usergroup
@@ -1887,8 +1922,8 @@ async function resolveSlackTipPlan(
   )
   return {
     ok: true,
-    previewRequired:
-      groupPreviewRequired || (!parsed.usergroups?.length && skippedRecipients.length > 0),
+    pendingRecipients,
+    previewRequired: groupPreviewRequired,
     recipients,
     skippedRecipients,
     usergroupId: parsed.usergroups?.[0]?.providerUsergroupId,
@@ -4141,6 +4176,90 @@ async function postSlackQueuedTipMessage(
   return json.ts
 }
 
+async function postSlackQueuedTipBatchMessage(
+  ctx: HandlerContext,
+  result: Extract<Tip.TipBatchResult, { ok: true }> & {
+    queuedRecipients: NonNullable<Extract<Tip.TipBatchResult, { ok: true }>['queuedRecipients']>
+  },
+  options: {
+    channelId: string
+    mentionUser: (providerUserId: string) => string
+    threadTs?: string
+  },
+) {
+  const installation = await getSlack().getInstallation(ctx.channelProviderId ?? ctx.provider.id)
+  if (!installation) throw new Error('Tibot app not installed for this workspace.')
+
+  const amount = result.isDefaultToken
+    ? formatCurrencyAmount(result.amount, result.tokenCurrency)
+    : formatTipAmount(result.amount, result.tokenCurrency, result.tokenSymbol)
+  const queued = formatSlackMentionList(
+    result.queuedRecipients.map((recipient) => recipient.recipientProviderUserId),
+    options.mentionUser,
+  )
+  const queuedAmount = `${amount}${result.queuedRecipients.length === 1 ? '' : ' each'}`
+  const queuedText = `queued ${queued} ${queuedAmount}`
+  const baseText =
+    result.status === 'sent'
+      ? `${options.mentionUser(result.senderProviderUserId)} ${result.memo ? 'sent' : 'tipped'} ${formatSlackMentionList(
+          result.recipients.map((recipient) => recipient.recipientProviderUserId),
+          options.mentionUser,
+        )} ${amount}${result.memo ? ` for ${result.memo}` : ''}`
+      : `${options.mentionUser(result.senderProviderUserId)} ${queuedText}${result.memo ? ` for ${result.memo}` : ''}`
+  const context = `Run \`${getSlackCommand(env.HOST)} connect\` to receive it`
+  const receiptLink =
+    result.status === 'sent'
+      ? `<${Tempo.formatTxLink(result.chainId, result.transactionHash)}|Receipt>`
+      : undefined
+  const blocks = [
+    {
+      text: {
+        text: `${receiptLink ? formatReceiptText(baseText, receiptLink) : baseText}${result.status === 'sent' ? ` (${queuedText})` : ''}`,
+        type: 'mrkdwn',
+      },
+      type: 'section',
+    },
+    {
+      elements: [{ text: context, type: 'mrkdwn' }],
+      type: 'context',
+    },
+  ]
+  const body = new URLSearchParams()
+  body.set('blocks', JSON.stringify(blocks))
+  body.set('channel', options.channelId.replace(/^slack:/, ''))
+  body.set(
+    'text',
+    `${receiptLink ? formatReceiptText(baseText, 'Receipt') : baseText}${result.status === 'sent' ? ` (${queuedText})` : ''}. ${context}`,
+  )
+  if (options.threadTs) body.set('thread_ts', options.threadTs)
+  body.set('unfurl_links', 'false')
+  body.set('unfurl_media', 'false')
+  const response = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
+      body,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      error: z.string().optional(),
+      ok: z.boolean().optional(),
+      ts: z.string().optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok || !json.ts) throw Slack.slackApiError('chat.postMessage', json.error)
+  if (result.status === 'sent')
+    await recordSlackReceiptMessageForTransaction(ctx.db, {
+      channelId: options.channelId.replace(/^slack:/, ''),
+      messageTs: json.ts,
+      threadTs: options.threadTs ?? json.ts,
+      transactionHash: result.transactionHash,
+    })
+  return json.ts
+}
+
 async function postSlackReceiptMessage(
   event: TipEvent,
   ctx: HandlerContext,
@@ -4245,6 +4364,12 @@ export async function recordSlackReceiptMessageForTransaction(
 export async function updateSlackPendingTipMessage(db: DB.Type, result: Tip.PendingTipClaimResult) {
   const installation = await getSlack().getInstallation(result.pendingTip.provider_id)
   if (!installation || !result.pendingTip.provider_message_ts) return
+
+  const aggregate = await getSlackPendingTipAggregate(db, result.pendingTip)
+  if (aggregate) {
+    await updateSlackPendingTipAggregateMessage(db, result, aggregate, installation.botToken)
+    return
+  }
 
   const channelId = result.pendingTip.provider_channel_id.replace(/^slack:/, '')
   const tokenMetadata = await Tempo.getTokenMetadata(
@@ -4371,6 +4496,182 @@ export async function updateSlackPendingTipMessage(db: DB.Type, result: Tip.Pend
   })
 }
 
+async function getSlackPendingTipAggregate(db: DB.Type, pendingTip: DB_gen.Selectable.pending_tip) {
+  if (!pendingTip.provider_message_ts) return null
+
+  const pendingTips = await db
+    .selectFrom('pending_tip')
+    .selectAll()
+    .where('workspace_id', '=', pendingTip.workspace_id)
+    .where('provider_channel_id', '=', pendingTip.provider_channel_id)
+    .where('provider_message_ts', '=', pendingTip.provider_message_ts)
+    .orderBy('created_at', 'asc')
+    .execute()
+  const batchIdempotencyKey = pendingTip.idempotency_key.endsWith(
+    `:${pendingTip.recipient_provider_user_id}`,
+  )
+    ? pendingTip.idempotency_key.slice(0, -1 * (pendingTip.recipient_provider_user_id.length + 1))
+    : null
+  const batch = batchIdempotencyKey
+    ? await db
+        .selectFrom('tip_batch')
+        .selectAll()
+        .where('workspace_id', '=', pendingTip.workspace_id)
+        .where('idempotency_key', '=', batchIdempotencyKey)
+        .executeTakeFirst()
+    : null
+  if (pendingTips.length <= 1 && !batch) return null
+
+  const batchRecipients = batch
+    ? await db
+        .selectFrom('tip')
+        .innerJoin('member', 'member.id', 'tip.recipient_member_id')
+        .select('member.provider_user_id')
+        .where('tip.batch_id', '=', batch.id)
+        .where('tip.confirmed_at', 'is not', null)
+        .orderBy('tip.created_at', 'asc')
+        .execute()
+    : []
+  const sentPendingTips = await db
+    .selectFrom('pending_tip')
+    .leftJoin('tip', 'tip.id', 'pending_tip.tip_id')
+    .leftJoin('tip_batch', 'tip_batch.id', 'tip.batch_id')
+    .select([
+      'pending_tip.id',
+      'pending_tip.recipient_provider_user_id',
+      'tip_batch.transaction_hash',
+    ])
+    .where('pending_tip.workspace_id', '=', pendingTip.workspace_id)
+    .where('pending_tip.provider_channel_id', '=', pendingTip.provider_channel_id)
+    .where('pending_tip.provider_message_ts', '=', pendingTip.provider_message_ts)
+    .where('pending_tip.status', '=', 'sent')
+    .orderBy('pending_tip.created_at', 'asc')
+    .execute()
+  return { batch, batchRecipients, pendingTips, sentPendingTips }
+}
+
+async function updateSlackPendingTipAggregateMessage(
+  db: DB.Type,
+  result: Tip.PendingTipClaimResult,
+  aggregate: NonNullable<Awaited<ReturnType<typeof getSlackPendingTipAggregate>>>,
+  botToken: string,
+) {
+  if (!result.pendingTip.provider_message_ts) return
+  const channelId = result.pendingTip.provider_channel_id.replace(/^slack:/, '')
+  const tokenMetadata = await Tempo.getTokenMetadata(
+    env,
+    result.pendingTip.chain_id,
+    result.pendingTip.token_address,
+  )
+  const workspace = await db
+    .selectFrom('workspace')
+    .select('default_token_address')
+    .where('id', '=', result.pendingTip.workspace_id)
+    .executeTakeFirst()
+  const amount = Address.isEqual(
+    Address.checksum(result.pendingTip.token_address),
+    Address.checksum(workspace?.default_token_address ?? Tempo.addressLookup.pathUsd),
+  )
+    ? formatCurrencyAmount(formatAmount(result.pendingTip.amount), tokenMetadata.currency)
+    : formatTipAmount(
+        formatAmount(result.pendingTip.amount),
+        tokenMetadata.currency,
+        tokenMetadata.symbol,
+      )
+  const completedProviderUserIds = [
+    ...(aggregate.batch?.status === 'confirmed' && aggregate.batch.transaction_hash
+      ? aggregate.batchRecipients.map((recipient) => recipient.provider_user_id)
+      : []),
+    ...aggregate.sentPendingTips.map((pending) => pending.recipient_provider_user_id),
+  ]
+  const queuedProviderUserIds = aggregate.pendingTips
+    .filter((pending) => pending.status === 'pending' || pending.status === 'sending')
+    .map((pending) => pending.recipient_provider_user_id)
+  const expiredProviderUserIds = aggregate.pendingTips
+    .filter((pending) => pending.status === 'expired')
+    .map((pending) => pending.recipient_provider_user_id)
+  const failedProviderUserIds = aggregate.pendingTips
+    .filter((pending) => pending.status === 'failed')
+    .map((pending) => pending.recipient_provider_user_id)
+  const mentionUser = (providerUserId: string) => `<@${providerUserId}>`
+  const statusSegments = [
+    ...(queuedProviderUserIds.length
+      ? [
+          `queued ${formatSlackMentionList(queuedProviderUserIds, mentionUser)} ${amount}${queuedProviderUserIds.length === 1 ? '' : ' each'}`,
+        ]
+      : []),
+    ...(expiredProviderUserIds.length
+      ? [`expired ${formatSlackMentionList(expiredProviderUserIds, mentionUser)}`]
+      : []),
+    ...(failedProviderUserIds.length
+      ? [`failed ${formatSlackMentionList(failedProviderUserIds, mentionUser)}`]
+      : []),
+  ]
+  const text = completedProviderUserIds.length
+    ? `<@${result.pendingTip.sender_provider_user_id}> ${result.pendingTip.memo ? 'sent' : 'tipped'} ${formatSlackMentionList(completedProviderUserIds, mentionUser)} ${amount}${result.pendingTip.memo ? ` for ${result.pendingTip.memo}` : ''}${statusSegments.length ? ` (${statusSegments.join('; ')})` : ''}`
+    : `<@${result.pendingTip.sender_provider_user_id}> queued ${formatSlackMentionList(queuedProviderUserIds, mentionUser)} ${amount}${queuedProviderUserIds.length === 1 ? '' : ' each'}${result.pendingTip.memo ? ` for ${result.pendingTip.memo}` : ''}${statusSegments.length && !queuedProviderUserIds.length ? ` (${statusSegments.join('; ')})` : ''}`
+  const receiptLinks = [
+    ...(aggregate.batch?.status === 'confirmed' && aggregate.batch.transaction_hash
+      ? [
+          `<${Tempo.formatTxLink(result.pendingTip.chain_id, aggregate.batch.transaction_hash)}|Receipt>`,
+        ]
+      : []),
+    ...aggregate.sentPendingTips
+      .filter((pending) => pending.transaction_hash)
+      .map(
+        (pending) =>
+          `<${Tempo.formatTxLink(result.pendingTip.chain_id, pending.transaction_hash!)}|Receipt>`,
+      ),
+  ]
+  const context = queuedProviderUserIds.length
+    ? `Run \`${getSlackCommand(env.HOST)} connect\` to receive it`
+    : undefined
+  const blocks = [
+    {
+      text: {
+        text: receiptLinks.length ? formatReceiptText(text, receiptLinks.join(' ')) : text,
+        type: 'mrkdwn',
+      },
+      type: 'section',
+    },
+    ...(context
+      ? [
+          {
+            elements: [{ text: context, type: 'mrkdwn' }],
+            type: 'context',
+          },
+        ]
+      : []),
+  ]
+  const body = new URLSearchParams()
+  body.set('blocks', JSON.stringify(blocks))
+  body.set('channel', channelId)
+  body.set(
+    'text',
+    receiptLinks.length
+      ? formatReceiptText(text, receiptLinks.map(() => 'Receipt').join(' '))
+      : `${text}${context ? `. ${context}` : ''}`,
+  )
+  body.set('ts', result.pendingTip.provider_message_ts)
+  body.set('unfurl_links', 'false')
+  body.set('unfurl_media', 'false')
+  const response = await getSlack().withBotToken(botToken, () =>
+    fetch(`${env.SLACK_API_URL}/chat.update`, {
+      body,
+      headers: { authorization: `Bearer ${botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      error: z.string().optional(),
+      ok: z.boolean().optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok) console.error('Failed to update queued tip message:', json.error)
+}
+
 async function recordSlackReceiptMessage(
   db: DB.Type,
   options: {
@@ -4477,6 +4778,13 @@ function formatReceiptText(text: string, receipt: string) {
   const lineBreakIndex = text.indexOf('\n')
   if (lineBreakIndex === -1) return `${text} · ${receipt}`
   return `${text.slice(0, lineBreakIndex).replace(/\.$/, '')} · ${receipt}${text.slice(lineBreakIndex)}`
+}
+
+function formatSlackMentionList(
+  providerUserIds: string[],
+  mentionUser: (providerUserId: string) => string,
+) {
+  return providerUserIds.map((providerUserId) => mentionUser(providerUserId)).join(', ')
 }
 
 async function isSlackAdmin(providerId: string, providerUserId: string) {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -4365,7 +4365,62 @@ export async function updateSlackPendingTipMessage(db: DB.Type, result: Tip.Pend
   const installation = await getSlack().getInstallation(result.pendingTip.provider_id)
   if (!installation || !result.pendingTip.provider_message_ts) return
 
-  const aggregate = await getSlackPendingTipAggregate(db, result.pendingTip)
+  const aggregate = await (async () => {
+    // Multi-recipient pending tips share one Slack summary message, so update the
+    // whole logical operation instead of rendering only the claimed row.
+    const pendingTips = await db
+      .selectFrom('pending_tip')
+      .selectAll()
+      .where('workspace_id', '=', result.pendingTip.workspace_id)
+      .where('provider_channel_id', '=', result.pendingTip.provider_channel_id)
+      .where('provider_message_ts', '=', result.pendingTip.provider_message_ts)
+      .orderBy('created_at', 'asc')
+      .execute()
+    const batchIdempotencyKey = result.pendingTip.idempotency_key.endsWith(
+      `:${result.pendingTip.recipient_provider_user_id}`,
+    )
+      ? result.pendingTip.idempotency_key.slice(
+          0,
+          -1 * (result.pendingTip.recipient_provider_user_id.length + 1),
+        )
+      : null
+    const batch = batchIdempotencyKey
+      ? await db
+          .selectFrom('tip_batch')
+          .selectAll()
+          .where('workspace_id', '=', result.pendingTip.workspace_id)
+          .where('idempotency_key', '=', batchIdempotencyKey)
+          .executeTakeFirst()
+      : null
+    if (pendingTips.length <= 1 && !batch) return null
+
+    const batchRecipients = batch
+      ? await db
+          .selectFrom('tip')
+          .innerJoin('member', 'member.id', 'tip.recipient_member_id')
+          .select('member.provider_user_id')
+          .where('tip.batch_id', '=', batch.id)
+          .where('tip.confirmed_at', 'is not', null)
+          .orderBy('tip.created_at', 'asc')
+          .execute()
+      : []
+    const sentPendingTips = await db
+      .selectFrom('pending_tip')
+      .leftJoin('tip', 'tip.id', 'pending_tip.tip_id')
+      .leftJoin('tip_batch', 'tip_batch.id', 'tip.batch_id')
+      .select([
+        'pending_tip.id',
+        'pending_tip.recipient_provider_user_id',
+        'tip_batch.transaction_hash',
+      ])
+      .where('pending_tip.workspace_id', '=', result.pendingTip.workspace_id)
+      .where('pending_tip.provider_channel_id', '=', result.pendingTip.provider_channel_id)
+      .where('pending_tip.provider_message_ts', '=', result.pendingTip.provider_message_ts)
+      .where('pending_tip.status', '=', 'sent')
+      .orderBy('pending_tip.created_at', 'asc')
+      .execute()
+    return { batch, batchRecipients, pendingTips, sentPendingTips }
+  })()
   if (aggregate) {
     await updateSlackPendingTipAggregateMessage(db, result, aggregate, installation.botToken)
     return
@@ -4496,64 +4551,19 @@ export async function updateSlackPendingTipMessage(db: DB.Type, result: Tip.Pend
   })
 }
 
-async function getSlackPendingTipAggregate(db: DB.Type, pendingTip: DB_gen.Selectable.pending_tip) {
-  if (!pendingTip.provider_message_ts) return null
-
-  const pendingTips = await db
-    .selectFrom('pending_tip')
-    .selectAll()
-    .where('workspace_id', '=', pendingTip.workspace_id)
-    .where('provider_channel_id', '=', pendingTip.provider_channel_id)
-    .where('provider_message_ts', '=', pendingTip.provider_message_ts)
-    .orderBy('created_at', 'asc')
-    .execute()
-  const batchIdempotencyKey = pendingTip.idempotency_key.endsWith(
-    `:${pendingTip.recipient_provider_user_id}`,
-  )
-    ? pendingTip.idempotency_key.slice(0, -1 * (pendingTip.recipient_provider_user_id.length + 1))
-    : null
-  const batch = batchIdempotencyKey
-    ? await db
-        .selectFrom('tip_batch')
-        .selectAll()
-        .where('workspace_id', '=', pendingTip.workspace_id)
-        .where('idempotency_key', '=', batchIdempotencyKey)
-        .executeTakeFirst()
-    : null
-  if (pendingTips.length <= 1 && !batch) return null
-
-  const batchRecipients = batch
-    ? await db
-        .selectFrom('tip')
-        .innerJoin('member', 'member.id', 'tip.recipient_member_id')
-        .select('member.provider_user_id')
-        .where('tip.batch_id', '=', batch.id)
-        .where('tip.confirmed_at', 'is not', null)
-        .orderBy('tip.created_at', 'asc')
-        .execute()
-    : []
-  const sentPendingTips = await db
-    .selectFrom('pending_tip')
-    .leftJoin('tip', 'tip.id', 'pending_tip.tip_id')
-    .leftJoin('tip_batch', 'tip_batch.id', 'tip.batch_id')
-    .select([
-      'pending_tip.id',
-      'pending_tip.recipient_provider_user_id',
-      'tip_batch.transaction_hash',
-    ])
-    .where('pending_tip.workspace_id', '=', pendingTip.workspace_id)
-    .where('pending_tip.provider_channel_id', '=', pendingTip.provider_channel_id)
-    .where('pending_tip.provider_message_ts', '=', pendingTip.provider_message_ts)
-    .where('pending_tip.status', '=', 'sent')
-    .orderBy('pending_tip.created_at', 'asc')
-    .execute()
-  return { batch, batchRecipients, pendingTips, sentPendingTips }
-}
-
 async function updateSlackPendingTipAggregateMessage(
   db: DB.Type,
   result: Tip.PendingTipClaimResult,
-  aggregate: NonNullable<Awaited<ReturnType<typeof getSlackPendingTipAggregate>>>,
+  aggregate: {
+    batch: DB_gen.Selectable.tip_batch | null | undefined
+    batchRecipients: Array<{ provider_user_id: string }>
+    pendingTips: DB_gen.Selectable.pending_tip[]
+    sentPendingTips: Array<{
+      id: string
+      recipient_provider_user_id: string
+      transaction_hash: string | null
+    }>
+  },
   botToken: string,
 ) {
   if (!result.pendingTip.provider_message_ts) return

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -200,6 +200,40 @@ describe('/tip @account', () => {
     ])
   }, 20_000) // 20 seconds
 
+  test('queues explicit multi-recipient slash tip when all recipients are unconnected', async () => {
+    const connected = await connectTipAccounts({ recipient: false })
+    const secondUnconnectedProviderUserId = 'U000000099'
+
+    const response = await postSlashCommand(
+      `<@${unconnectedProviderUserId}> <@${secondUnconnectedProviderUserId}>`,
+    )
+    const pendingTips = await db
+      .selectFrom('pending_tip')
+      .selectAll()
+      .where('sender_member_id', '=', connected.senderMember.id)
+      .orderBy('recipient_provider_user_id', 'asc')
+      .execute()
+    const tips = await db
+      .selectFrom('tip')
+      .selectAll()
+      .where('sender_member_id', '=', connected.senderMember.id)
+      .execute()
+
+    expect(response.status).toBe(200)
+    expect(tips).toEqual([])
+    expect(pendingTips).toHaveLength(2)
+    expect(pendingTips.map((tip) => tip.recipient_provider_user_id)).toEqual([
+      unconnectedProviderUserId,
+      secondUnconnectedProviderUserId,
+    ])
+    expect(pendingTips.every((tip) => tip.provider_message_ts)).toBe(true)
+    expect(new Set(pendingTips.map((tip) => tip.provider_message_ts)).size).toBe(1)
+    await expectSlackMessage(
+      `<@${Constants.slack.adminUserId}> queued <@${unconnectedProviderUserId}>, <@${secondUnconnectedProviderUserId}> $0.001 each`,
+    )
+    await expectSlackMessage('Run `/tip connect` to receive it')
+  }, 20_000) // 20 seconds
+
   test('sends small group tip immediately with skipped recipients', async () => {
     await connectTipAccounts()
 
@@ -209,6 +243,11 @@ describe('/tip @account', () => {
       .selectAll()
       .where('idempotency_key', 'like', `command:${providerId}:%`)
       .executeTakeFirstOrThrow()
+    const pendingTips = await db
+      .selectFrom('pending_tip')
+      .selectAll()
+      .where('provider_id', '=', providerId)
+      .execute()
 
     expect(response.status).toBe(200)
     await expectSlackMessage(
@@ -219,6 +258,7 @@ describe('/tip @account', () => {
     await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
     await expectSlackMessageNotContaining('You’re about to tip')
     expect(batch).toMatchObject({ recipient_count: 1, status: 'confirmed' })
+    expect(pendingTips).toEqual([])
   }, 20_000) // 20 seconds
 
   test('sends fifteen-recipient group tip immediately', async () => {
@@ -508,18 +548,28 @@ describe('/tip @account', () => {
     handleTipBatchRequest.mockRestore()
   })
 
-  test('previews explicit batch tip with skipped unconnected recipient', async () => {
+  test('sends explicit batch tip with queued unconnected recipient', async () => {
     await connectTipAccounts()
 
     const response = await postSlashCommand(
       `<@${Constants.slack.memberUserId}> <@${unconnectedProviderUserId}> for coffee`,
     )
+    const pendingTip = await db
+      .selectFrom('pending_tip')
+      .selectAll()
+      .where('provider_id', '=', providerId)
+      .executeTakeFirstOrThrow()
 
     expect(response.status).toBe(200)
-    await expectSlackMessage('You’re about to tip 1 accounts $0.001 each for coffee.')
-    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
-    await expectSlackMessage(`• <@${unconnectedProviderUserId}> (not connected yet)`)
-    await expectSlackMessageNotContaining('Receipt')
+    expect(pendingTip).toMatchObject({
+      provider_message_ts: expect.any(String),
+      recipient_provider_user_id: unconnectedProviderUserId,
+      status: 'pending',
+    })
+    await expectSlackMessage(
+      `<@${Constants.slack.adminUserId}> sent <@${Constants.slack.memberUserId}> $0.001 for coffee · Receipt (queued <@${unconnectedProviderUserId}> $0.001)`,
+    )
+    await expectSlackMessage('Run `/tip connect` to receive it')
   })
 
   test('rejects group tips in Slack Connect channels', async () => {
@@ -753,8 +803,26 @@ describe('/tip @account', () => {
       token_address: Tempo.addressLookup.thetaUsd,
       workspace_id: connected.workspace.id,
     })
+    await factory.pending_tip.insert({
+      access_key_id: connected.accessKey.id,
+      amount: 500_000,
+      chain_id: connected.workspace.chain_id,
+      expires_at: connected.accessKey.expires_at,
+      idempotency_key: `existing-pending-${Nanoid.generate()}`,
+      provider_channel_id: Constants.slack.channelId,
+      provider_id: providerId,
+      recipient_member_id: connected.recipientMember.id,
+      recipient_provider_user_id: Constants.slack.memberUserId,
+      sender_id: connected.senderAccount.id,
+      sender_member_id: connected.senderMember.id,
+      sender_provider_user_id: Constants.slack.adminUserId,
+      source: 'command',
+      status: 'pending',
+      token_address: Tempo.addressLookup.thetaUsd,
+      workspace_id: connected.workspace.id,
+    })
 
-    const response = await postSlashCommand(`<@${Constants.slack.memberUserId}> 9.50 ThetaUSD`)
+    const response = await postSlashCommand(`<@${Constants.slack.memberUserId}> 8.75 ThetaUSD`)
 
     expect(response.status).toBe(200)
     await expectSlackMessage('Tipbot needs your approval to send this payment.')
@@ -2527,7 +2595,7 @@ test('@Tipbot mention claims Slack Connect pending tip when recipient connects',
   )
 }, 20_000) // 20 seconds
 
-test('@Tipbot mention does not queue Slack Connect multi-recipient tip', async () => {
+test('@Tipbot mention sends connected Slack Connect multi-recipient tip and queues unconnected recipient', async () => {
   const connected = await connectTipAccounts()
   await deleteSlackConnectWorkspace()
   await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
@@ -2561,14 +2629,19 @@ test('@Tipbot mention does not queue Slack Connect multi-recipient tip', async (
     .execute()
 
   expect(response.status).toBe(200)
-  expect(pendingTips).toEqual([])
-  expect(tips).toEqual([])
-  await expectSlackMessage('You’re about to tip 1 accounts $0.001 each.', { channelId })
-  await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`, { channelId })
-  await expectSlackMessage(`• <@${Constants.slackConnect.userId}> (not connected yet)`, {
-    channelId,
+  expect(pendingTips).toHaveLength(1)
+  expect(pendingTips[0]).toMatchObject({
+    provider_message_ts: expect.any(String),
+    recipient_provider_user_id: Constants.slackConnect.userId,
+    status: 'pending',
   })
-  await expectSlackMessageNotContaining('queued', { channelId })
+  expect(tips).toHaveLength(1)
+  await expectSlackThreadMessage(
+    messageTs,
+    `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}> $0.001 · Receipt (queued <@${Constants.slackConnect.userId}> $0.001)`,
+    { channelId },
+  )
+  await expectSlackThreadMessage(messageTs, 'Run `/tip connect` to receive it', { channelId })
 }, 20_000) // 20 seconds
 
 test.each([

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2644,6 +2644,104 @@ test('@Tipbot mention sends connected Slack Connect multi-recipient tip and queu
   await expectSlackThreadMessage(messageTs, 'Run `/tip connect` to receive it', { channelId })
 }, 20_000) // 20 seconds
 
+test('@Tipbot mention updates mixed multi-recipient summary when queued recipient connects', async () => {
+  const connected = await connectTipAccounts()
+  await deleteSlackConnectWorkspace()
+  await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
+    botToken: Constants.slackConnect.teamBotToken,
+    botUserId: Constants.slackConnect.teamBotUserId,
+    teamName: Constants.slackConnect.teamName,
+  })
+  await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  const channelId = await getSlackConnectChannelId()
+  const tipMessageTs = `1700000006.${Nanoid.generate().slice(0, 6)}`
+  const connectMessageTs = `1700000007.${Nanoid.generate().slice(0, 6)}`
+  await expectSlackConnectEmulator(channelId)
+
+  await postSlackAppMention({
+    channelId,
+    messageTs: tipMessageTs,
+    text: `<@${Constants.slack.botUserId}> <@${Constants.slack.memberUserId}> <@${Constants.slackConnect.userId}>`,
+  })
+  const pendingTip = await db
+    .selectFrom('pending_tip')
+    .selectAll()
+    .where('sender_member_id', '=', connected.senderMember.id)
+    .where('recipient_provider_user_id', '=', Constants.slackConnect.userId)
+    .executeTakeFirstOrThrow()
+  const connectResponse = await postSlackAppMention({
+    channelId,
+    messageTs: connectMessageTs,
+    text: `<@${Constants.slack.botUserId}> connect`,
+    userId: Constants.slackConnect.userId,
+  })
+  const token = await getLatestConnectToken({ channelId })
+  const link = await db
+    .selectFrom('account_link_token')
+    .innerJoin('member', 'member.id', 'account_link_token.member_id')
+    .innerJoin('workspace', 'workspace.id', 'member.workspace_id')
+    .select([
+      'account_link_token.access_key_address',
+      'account_link_token.access_key_expires_at',
+      'workspace.chain_id',
+      'workspace.default_token_address',
+    ])
+    .where('member.provider_user_id', '=', Constants.slackConnect.userId)
+    .where('workspace.provider_id', '=', Constants.slackConnect.teamId)
+    .executeTakeFirstOrThrow()
+  const root = Account.fromSecp256k1(
+    '0x5555555555555555555555555555555555555555555555555555555555555555',
+  )
+  vi.spyOn(env.PENDING_TIP_QUEUE, 'send').mockResolvedValue({
+    metadata: { metrics: { backlogBytes: 0, backlogCount: 0 } },
+  })
+  const completeResponse = await client.api.account.link[':token'].$post({
+    json: {
+      address: root.address,
+      keyAuthorization: await AccountLink.signKeyAuthorization(root, {
+        accessKeyAddress: link.access_key_address,
+        chainId: link.chain_id,
+        expiresAt: link.access_key_expires_at,
+        tokenAddress: Address.checksum(link.default_token_address ?? Tempo.addressLookup.pathUsd),
+      }),
+    },
+    param: { token },
+  })
+  await drainWaitUntil()
+  const batch = createMessageBatch<processPendingTipMessage.Body>(
+    processPendingTipMessage.queueName,
+    [
+      {
+        attempts: 1,
+        body: { pendingTipId: pendingTip.id },
+        id: crypto.randomUUID(),
+        timestamp: new Date(),
+      },
+    ],
+  )
+
+  await processPendingTipMessage(batch.messages[0]!)
+  const updatedPendingTip = await db
+    .selectFrom('pending_tip')
+    .selectAll()
+    .where('id', '=', pendingTip.id)
+    .executeTakeFirstOrThrow()
+
+  expect(connectResponse.status).toBe(200)
+  expect(completeResponse.status).toBe(200)
+  expect(updatedPendingTip.status).toBe('sent')
+  await expectSlackThreadMessage(
+    tipMessageTs,
+    `<@${Constants.slack.adminUserId}> tipped <@${Constants.slack.memberUserId}>, <@${Constants.slackConnect.userId}> $0.001 · Receipt Receipt`,
+    { channelId, wait: true },
+  )
+  await expectSlackThreadMessageNotContaining(tipMessageTs, 'queued', { channelId })
+}, 20_000) // 20 seconds
+
 test.each([
   {
     amount: 2000,

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -81,6 +81,28 @@ export type TipBatchResult =
       tokenCurrency: string
       tokenSymbol: string
       transactionHash: string
+      queuedRecipients?: Array<{
+        pendingTipId: string
+        recipientProviderLabel?: string
+        recipientProviderUserId: string
+      }>
+    }
+  | {
+      amount: string
+      chainId: number
+      isDefaultToken: boolean
+      memo: string | null
+      ok: true
+      queuedRecipients: Array<{
+        pendingTipId: string
+        recipientProviderLabel?: string
+        recipientProviderUserId: string
+      }>
+      senderProviderUserId: string
+      skippedRecipients?: TipSkippedRecipient[]
+      status: 'queued'
+      tokenCurrency: string
+      tokenSymbol: string
     }
   | Extract<TipResult, { ok: false }>
 
@@ -312,6 +334,7 @@ export async function handleTipBatchRequest(
     providerChannelId: string
     providerId: string
     providerThreadId?: string
+    pendingRecipients?: TipRecipientInput[]
     recipients: TipRecipientInput[]
     senderProviderUserId: string
     settingsProviderId?: string
@@ -368,17 +391,20 @@ export async function handleTipBatchRequest(
     default_amount: settingsWorkspace.default_amount,
     default_token_address: settingsWorkspace.default_token_address,
   }
+  const recipientCount = input.recipients.length + (input.pendingRecipients?.length ?? 0)
   const recipients = input.recipients.slice(0, maxTipBatchRecipients)
-  if (input.recipients.length === 0)
+  const pendingRecipients = (input.pendingRecipients ?? []).slice(0, maxTipBatchRecipients)
+  const allRecipients = [...recipients, ...pendingRecipients]
+  if (recipientCount === 0)
     return { code: 'failed', message: 'Payment must have at least one recipient.', ok: false }
-  if (input.recipients.length > maxTipBatchRecipients)
+  if (recipientCount > maxTipBatchRecipients)
     return {
       code: 'failed',
       message: `Multi-tip supports up to ${maxTipBatchRecipients} recipients.`,
       ok: false,
     }
   if (
-    recipients.some(
+    allRecipients.some(
       (recipient) =>
         recipient.recipientProviderUserId === input.senderProviderUserId &&
         (!recipient.recipientProviderWorkspaceId ||
@@ -389,7 +415,7 @@ export async function handleTipBatchRequest(
     return { code: 'self_tip', ok: false }
 
   const amount = input.amount ?? executionWorkspace.default_amount
-  const totalAmount = amount * recipients.length
+  const totalAmount = amount * allRecipients.length
   if (!Number.isSafeInteger(totalAmount) || totalAmount <= 0)
     return { code: 'failed', message: 'Payment amount is too large.', ok: false }
   const tokenAddress = Address.checksum(
@@ -408,6 +434,8 @@ export async function handleTipBatchRequest(
   const sender = await getConnectedMember(db, workspace.id, input.senderProviderUserId)
   if (!sender) return { code: 'sender_unconnected', ok: false }
   const connectedRecipients = [] as ConnectedMember[]
+  const connectedRecipientInputs = [] as TipRecipientInput[]
+  const actuallyPendingRecipients = [] as TipRecipientInput[]
   for (const recipient of recipients) {
     const connected = await getConnectedRecipient(db, workspace, input.provider, recipient)
     if (connected?.account.id === sender.account.id) return { code: 'self_tip', ok: false }
@@ -419,6 +447,15 @@ export async function handleTipBatchRequest(
         senderProviderUserId: input.senderProviderUserId,
       }
     connectedRecipients.push(connected)
+    connectedRecipientInputs.push(recipient)
+  }
+  for (const recipient of pendingRecipients) {
+    const connected = await getConnectedRecipient(db, workspace, input.provider, recipient)
+    if (connected?.account.id === sender.account.id) return { code: 'self_tip', ok: false }
+    if (connected) {
+      connectedRecipients.push(connected)
+      connectedRecipientInputs.push(recipient)
+    } else actuallyPendingRecipients.push(recipient)
   }
 
   const accessKeys = await db
@@ -480,29 +517,83 @@ export async function handleTipBatchRequest(
       },
     )) as Extract<TipBatchResult, { ok: false }>
 
-  return await submitTipBatch(env, db, {
-    accessKeyId: accessKey.id,
-    accessKeyPrivateKey: await AccessKey.decrypt(env, accessKey.ciphertext),
-    amount,
-    authorizationUsedAt: accessKey.authorization_used_at,
-    connectedRecipients,
-    idempotencyKey: input.idempotencyKey,
-    keyAuthorization: KeyAuthorization.fromRpc(JSON.parse(accessKey.authorization) as never),
+  const sentResult = connectedRecipients.length
+    ? await submitTipBatch(env, db, {
+        accessKeyId: accessKey.id,
+        accessKeyPrivateKey: await AccessKey.decrypt(env, accessKey.ciphertext),
+        amount,
+        authorizationUsedAt: accessKey.authorization_used_at,
+        connectedRecipients,
+        idempotencyKey: input.idempotencyKey,
+        keyAuthorization: KeyAuthorization.fromRpc(JSON.parse(accessKey.authorization) as never),
+        memo: input.memo,
+        provider: input.provider,
+        providerChannelId: input.providerChannelId,
+        providerId: input.providerId,
+        providerThreadId: input.providerThreadId,
+        recipients: connectedRecipientInputs,
+        sender,
+        senderProviderUserId: input.senderProviderUserId,
+        skippedRecipients: input.skippedRecipients,
+        source: input.source,
+        tokenAddress,
+        usergroupId: input.usergroupId,
+        usergroupLabel: input.usergroupLabel,
+        workspace: executionWorkspace,
+      })
+    : null
+  if (sentResult && !sentResult.ok) return sentResult
+
+  const queuedRecipients = [] as Array<{
+    pendingTipId: string
+    recipientProviderLabel?: string
+    recipientProviderUserId: string
+  }>
+  for (const recipient of actuallyPendingRecipients) {
+    const result = await createPendingTip(env, db, {
+      accessKey,
+      amount,
+      idempotencyKey: `${input.idempotencyKey}:${recipient.recipientProviderUserId}`,
+      memo: input.memo,
+      provider: input.provider,
+      providerChannelId: input.providerChannelId,
+      providerId: input.providerId,
+      providerThreadId: input.providerThreadId,
+      recipientProviderUserId: recipient.recipientProviderUserId,
+      recipientProviderWorkspaceId: recipient.recipientProviderWorkspaceId,
+      sender,
+      senderProviderUserId: input.senderProviderUserId,
+      source: input.source,
+      tokenAddress,
+      workspace: executionWorkspace,
+    })
+    if (!result.ok) return result
+    if (result.status !== 'queued') continue
+    queuedRecipients.push({
+      pendingTipId: result.pendingTipId,
+      recipientProviderLabel: recipient.recipientProviderLabel,
+      recipientProviderUserId: recipient.recipientProviderUserId,
+    })
+  }
+  if (sentResult?.ok) return { ...sentResult, queuedRecipients }
+
+  const tokenMetadata = await Tempo.getTokenMetadata(env, executionWorkspace.chain_id, tokenAddress)
+  return {
+    amount: formatAmount(amount),
+    chainId: executionWorkspace.chain_id,
+    isDefaultToken: Address.isEqual(
+      Address.checksum(tokenAddress),
+      Address.checksum(executionWorkspace.default_token_address ?? Tempo.addressLookup.pathUsd),
+    ),
     memo: input.memo,
-    provider: input.provider,
-    providerChannelId: input.providerChannelId,
-    providerId: input.providerId,
-    providerThreadId: input.providerThreadId,
-    recipients,
-    sender,
+    ok: true,
+    queuedRecipients,
     senderProviderUserId: input.senderProviderUserId,
     skippedRecipients: input.skippedRecipients,
-    source: input.source,
-    tokenAddress,
-    usergroupId: input.usergroupId,
-    usergroupLabel: input.usergroupLabel,
-    workspace: executionWorkspace,
-  })
+    status: 'queued',
+    tokenCurrency: tokenMetadata.currency,
+    tokenSymbol: tokenMetadata.symbol,
+  }
 }
 
 export function parseAmount(value: string) {
@@ -1029,6 +1120,7 @@ export async function claimPendingTip(
       authorization,
       authorizationUsedAt: accessKey.authorization_used_at,
       chainId: pending.chain_id,
+      excludePendingTipId: pending.id,
       tokenAddress: pending.token_address,
     }))
   )
@@ -1895,6 +1987,8 @@ async function submitTip(
     workspace: input.workspace,
   })
   if (!result.ok) return result
+  if (result.status === 'queued')
+    return { code: 'failed', message: 'Payment could not be sent.', ok: false }
   return {
     amount: result.amount,
     chainId: result.chainId,
@@ -2375,6 +2469,7 @@ async function hasTrackedAccessKeyLimitRemaining(
     authorization: KeyAuthorization.KeyAuthorization
     authorizationUsedAt: string | null
     chainId: number
+    excludePendingTipId?: string
     tokenAddress: string
   },
 ) {
@@ -2401,7 +2496,20 @@ async function hasTrackedAccessKeyLimitRemaining(
       .where('confirmed_at', 'is not', null)
       .where('confirmed_at', '>=', usedSince)
       .execute()
-    const used = tips.reduce((total, tip) => total + BigInt(tip.amount), 0n)
+    const pendingTips = await db
+      .selectFrom('pending_tip')
+      .select('amount')
+      .where('access_key_id', '=', input.accessKeyId)
+      .where('sender_id', '=', input.accountId)
+      .where('chain_id', '=', input.chainId)
+      .where('token_address', '=', Address.checksum(input.tokenAddress))
+      .where('status', 'in', ['pending', 'sending'])
+      .where('expires_at', '>', new Date().toISOString())
+      .$if(Boolean(input.excludePendingTipId), (qb) =>
+        qb.where('id', '!=', input.excludePendingTipId!),
+      )
+      .execute()
+    const used = [...tips, ...pendingTips].reduce((total, tip) => total + BigInt(tip.amount), 0n)
     if (used + BigInt(input.amount) <= limit.limit) return true
   }
   return false


### PR DESCRIPTION
Adds pending-tip queueing for explicit multi-recipient Slack tips while continuing to skip unconnected group and channel recipients.