### PR TITLE
feat: add Tipbot receipt pages

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -671,7 +671,7 @@ export const api = new Hono<{
                 url.searchParams.set('message', receipt.message_ts)
                 return ` <${url}|this message>`
               })()
-              const receiptLink = `<${Tempo.formatTxLink(result.chainId, result.transactionHash)}|Receipt>`
+              const receiptLink = `<${Tempo.formatReceiptLink(c.env, result.transactionHash)}|Receipt>`
               const text = `<@${result.senderProviderUserId}> boosted${originalReceiptLink} · ${receiptLink}`
               const body = new URLSearchParams()
               body.set(
@@ -764,7 +764,7 @@ export const api = new Hono<{
                     ].join('\n')}`
                   : `<@${result.senderProviderUserId}> ${result.memo ? 'sent' : 'tipped'} <@${result.recipientProviderUserId}> ${amount}${result.memo ? ` for ${result.memo}` : ''}.`
               const receiptText = text.replace(/\.$/, '')
-              const receiptLink = `<${Tempo.formatTxLink(result.chainId, result.transactionHash)}|Receipt>`
+              const receiptLink = `<${Tempo.formatReceiptLink(c.env, result.transactionHash)}|Receipt>`
               const receiptMessage = (() => {
                 const lineBreakIndex = receiptText.indexOf('\n')
                 if (lineBreakIndex === -1) return `${receiptText} · ${receiptLink}`

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -2190,7 +2190,7 @@ async function handleSlackReactionTip(event: Slack.ReactionEvent, context: React
       )
         return null
       const transactionHash = JSON.stringify(message ?? {}).match(
-        /\/receipt\/(0x[0-9a-fA-F]{64})/,
+        /\/(?:receipt|r)\/(0x[0-9a-fA-F]{64})/,
       )?.[1]
       if (!transactionHash) return null
       const batch = await db
@@ -3008,7 +3008,7 @@ export async function updateReceiptBoostAggregate(
       )
         return groups
       const group = groups.find((group) => group.messageTs === messageTs)
-      const line = `• <@${row.sender_provider_user_id}> boosted · <${Tempo.formatTxLink(row.chain_id, row.transaction_hash)}|Receipt>`
+      const line = `• <@${row.sender_provider_user_id}> boosted · <${Tempo.formatReceiptLink(env, row.transaction_hash)}|Receipt>`
       if (group) {
         group.lines.push(line)
         return groups
@@ -4173,7 +4173,7 @@ async function reactionTipAggregateText(
         createdAt: row.created_at,
         messageTs: row.message_ts,
         recipientProviderUserId: row.recipient_provider_user_id,
-        text: `• :${row.reaction}: <@${row.sender_provider_user_id}> tipped ${displayAmount} · <${Tempo.formatTxLink(row.chain_id, row.transaction_hash!)}|Receipt>`,
+        text: `• :${row.reaction}: <@${row.sender_provider_user_id}> tipped ${displayAmount} · <${Tempo.formatReceiptLink(env, row.transaction_hash!)}|Receipt>`,
       }
     }),
   )
@@ -4223,7 +4223,7 @@ async function reactionTipAggregateText(
         createdAt: row.created_at,
         messageTs: reactionTip.messageTs,
         recipientProviderUserId: row.recipient_provider_user_id,
-        text: `• :${reactionTip.reaction}: <@${row.sender_provider_user_id}> tipped ${displayAmount} · <${Tempo.formatTxLink(row.chain_id, row.transaction_hash!)}|Receipt>`,
+        text: `• :${reactionTip.reaction}: <@${row.sender_provider_user_id}> tipped ${displayAmount} · <${Tempo.formatReceiptLink(env, row.transaction_hash!)}|Receipt>`,
       }
     }),
   )
@@ -4273,7 +4273,7 @@ async function postSlackReceiptMessage(
   event: TipEvent,
   ctx: HandlerContext,
   text: string,
-  chainId: number,
+  _chainId: number,
   transactionHash: string,
   user?: chat.Author,
   context?: string,
@@ -4288,7 +4288,7 @@ async function postSlackReceiptMessage(
     'blocks',
     JSON.stringify(
       (() => {
-        const receiptLink = `<${Tempo.formatTxLink(chainId, transactionHash)}|Receipt>`
+        const receiptLink = `<${Tempo.formatReceiptLink(env, transactionHash)}|Receipt>`
         return [
           {
             text: {
@@ -4424,7 +4424,7 @@ export async function updateSlackPendingTipMessage(db: DB.Type, result: Tip.Pend
       ? `Expired before <@${result.pendingTip.recipient_provider_user_id}> connected. No payment was sent`
       : 'Could not be sent. No payment was sent'
   const receiptLink = result.ok
-    ? `<${Tempo.formatTxLink(result.chainId, result.transactionHash)}|Receipt>`
+    ? `<${Tempo.formatReceiptLink(env, result.transactionHash)}|Receipt>`
     : undefined
   const blocks = [
     {

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -790,7 +790,7 @@ async function buildHomeView(input: {
         : ''
       const status = row.failed_at ? ' · failed' : row.confirmed_at ? '' : ' · pending'
       const receipt = row.transaction_hash
-        ? ` · <${Tempo.formatTxLink(row.chain_id, row.transaction_hash)}|receipt>`
+        ? ` · <${Tempo.formatReceiptLink(input.env, row.transaction_hash)}|receipt>`
         : ''
       const timestamp = (() => {
         // Render compact relative timestamps for the activity list.

--- a/src/lib/tempo.test.ts
+++ b/src/lib/tempo.test.ts
@@ -76,4 +76,6 @@ test('formats Tempo token symbols and transaction links', () => {
     `/address/${Tempo.addressLookup.pathUsd}`,
   )
   expect(Tempo.formatTxLink(Tempo.chainLookup.testnet, '0xabc')).toContain('/receipt/0xabc')
+  expect(Tempo.formatReceiptPath('0xabc')).toBe('/r/0xabc')
+  expect(Tempo.formatReceiptLink({ HOST: 'tip.bot' }, '0xabc')).toBe('https://tip.bot/r/0xabc')
 })

--- a/src/lib/tempo.ts
+++ b/src/lib/tempo.ts
@@ -51,6 +51,14 @@ export function formatTxLink(chainId: number, transactionHash: string) {
   return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/receipt/${transactionHash}`
 }
 
+export function formatReceiptPath(transactionHash: string) {
+  return `/r/${transactionHash}`
+}
+
+export function formatReceiptLink(env: Pick<Env, 'HOST'>, transactionHash: string) {
+  return `https://${env.HOST}${formatReceiptPath(transactionHash)}`
+}
+
 export function explorerLink(chainId: number, address: string) {
   const chain = getChain(chainId)
   return `${chain.blockExplorers?.default.url ?? chain.rpcUrls.default.http[0]}/address/${address}`

--- a/src/lib/twitter.test.ts
+++ b/src/lib/twitter.test.ts
@@ -113,11 +113,12 @@ test('formats Twitter receipt reply like Slack without sentence-ending period', 
       chainId: Tempo.chainLookup.testnet,
       memo: 'coffee',
       recipientHandle: 'alice',
+      receiptUrl: Tempo.formatReceiptLink({ HOST: 'tip.bot' }, transactionHash),
       senderHandle: '@bob',
       transactionHash,
     }),
   ).toBe(
-    `@bob sent @alice $1 for coffee\nReceipt: ${Tempo.formatTxLink(Tempo.chainLookup.testnet, transactionHash)}`,
+    `@bob sent @alice $1 for coffee\nReceipt: ${Tempo.formatReceiptLink({ HOST: 'tip.bot' }, transactionHash)}`,
   )
   expect(
     formatTwitterReceiptText({
@@ -125,10 +126,11 @@ test('formats Twitter receipt reply like Slack without sentence-ending period', 
       chainId: Tempo.chainLookup.testnet,
       memo: null,
       recipientHandle: 'alice',
+      receiptUrl: Tempo.formatReceiptLink({ HOST: 'tip.bot' }, transactionHash),
       senderHandle: '@bob',
       transactionHash,
     }),
   ).toBe(
-    `@bob tipped @alice $1\nReceipt: ${Tempo.formatTxLink(Tempo.chainLookup.testnet, transactionHash)}`,
+    `@bob tipped @alice $1\nReceipt: ${Tempo.formatReceiptLink({ HOST: 'tip.bot' }, transactionHash)}`,
   )
 })

--- a/src/lib/twitter.ts
+++ b/src/lib/twitter.ts
@@ -229,6 +229,7 @@ export async function handleTweet(env: Env, input: TwitterTweetInput) {
         chainId: result.chainId,
         memo: result.memo,
         recipientHandle: parsed.recipientHandle,
+        receiptUrl: Tempo.formatReceiptLink(env, result.transactionHash),
         senderHandle: input.authorHandle,
         transactionHash: result.transactionHash,
       }),
@@ -318,6 +319,7 @@ export async function updatePendingTipMessage(env: Env, result: Tip.PendingTipCl
         chainId: result.chainId,
         memo: result.memo,
         recipientHandle,
+        receiptUrl: Tempo.formatReceiptLink(env, result.transactionHash),
         senderHandle,
         transactionHash: result.transactionHash,
       })
@@ -336,10 +338,13 @@ export function formatTwitterReceiptText(input: {
   chainId: number
   memo: string | null | undefined
   recipientHandle: string | undefined
+  receiptUrl: string
   senderHandle: string | undefined
   transactionHash: string
 }) {
-  return `${formatHandle(input.senderHandle)} ${input.memo ? 'sent' : 'tipped'} ${formatHandle(input.recipientHandle)} ${input.amount}${input.memo ? ` for ${input.memo}` : ''}\nReceipt: ${Tempo.formatTxLink(input.chainId, input.transactionHash)}`
+  void input.chainId
+  void input.transactionHash
+  return `${formatHandle(input.senderHandle)} ${input.memo ? 'sent' : 'tipped'} ${formatHandle(input.recipientHandle)} ${input.amount}${input.memo ? ` for ${input.memo}` : ''}\nReceipt: ${input.receiptUrl}`
 }
 
 export function parseWebhookTweets(body: unknown): TwitterTweetInput[] {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as RHashRouteImport } from './routes/r/$hash'
 import { Route as LinkXRouteImport } from './routes/link/x'
 import { Route as InstallSlackRouteImport } from './routes/install/slack'
 import { Route as ConnectTokenRouteImport } from './routes/connect/$token'
@@ -18,6 +19,11 @@ import { Route as ConfirmTokenRouteImport } from './routes/confirm/$token'
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RHashRoute = RHashRouteImport.update({
+  id: '/r/$hash',
+  path: '/r/$hash',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LinkXRoute = LinkXRouteImport.update({
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/connect/$token': typeof ConnectTokenRoute
   '/install/slack': typeof InstallSlackRoute
   '/link/x': typeof LinkXRoute
+  '/r/$hash': typeof RHashRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/connect/$token': typeof ConnectTokenRoute
   '/install/slack': typeof InstallSlackRoute
   '/link/x': typeof LinkXRoute
+  '/r/$hash': typeof RHashRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,6 +70,7 @@ export interface FileRoutesById {
   '/connect/$token': typeof ConnectTokenRoute
   '/install/slack': typeof InstallSlackRoute
   '/link/x': typeof LinkXRoute
+  '/r/$hash': typeof RHashRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -71,8 +80,15 @@ export interface FileRouteTypes {
     | '/connect/$token'
     | '/install/slack'
     | '/link/x'
+    | '/r/$hash'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/confirm/$token' | '/connect/$token' | '/install/slack' | '/link/x'
+  to:
+    | '/'
+    | '/confirm/$token'
+    | '/connect/$token'
+    | '/install/slack'
+    | '/link/x'
+    | '/r/$hash'
   id:
     | '__root__'
     | '/'
@@ -80,6 +96,7 @@ export interface FileRouteTypes {
     | '/connect/$token'
     | '/install/slack'
     | '/link/x'
+    | '/r/$hash'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -88,6 +105,7 @@ export interface RootRouteChildren {
   ConnectTokenRoute: typeof ConnectTokenRoute
   InstallSlackRoute: typeof InstallSlackRoute
   LinkXRoute: typeof LinkXRoute
+  RHashRoute: typeof RHashRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -97,6 +115,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/r/$hash': {
+      id: '/r/$hash'
+      path: '/r/$hash'
+      fullPath: '/r/$hash'
+      preLoaderRoute: typeof RHashRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/link/x': {
@@ -136,6 +161,7 @@ const rootRouteChildren: RootRouteChildren = {
   ConnectTokenRoute: ConnectTokenRoute,
   InstallSlackRoute: InstallSlackRoute,
   LinkXRoute: LinkXRoute,
+  RHashRoute: RHashRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/confirm/$token.tsx
+++ b/src/routes/confirm/$token.tsx
@@ -181,9 +181,8 @@ function ConfirmPanel(props: {
             {transactionHash ? (
               <a
                 className="inline-flex text-base font-bold text-blue9 no-underline hover:underline"
-                href={Tempo.formatTxLink(data.chainId, transactionHash)}
+                href={Tempo.formatReceiptPath(transactionHash)}
                 rel="noreferrer"
-                target="_blank"
               >
                 View receipt
               </a>

--- a/src/routes/r/$hash.tsx
+++ b/src/routes/r/$hash.tsx
@@ -1,0 +1,350 @@
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+import { env } from 'cloudflare:workers'
+import * as React from 'react'
+import * as z from 'zod/mini'
+import * as DB from '#db/client.ts'
+import { tipbotImagePath } from '#/lib/app.ts'
+import { formatAmount, formatCurrencyAmount, formatTipAmount } from '#/lib/format.ts'
+import * as Tempo from '#/lib/tempo.ts'
+
+function Component() {
+  const data = Route.useLoaderData()
+  const [copied, setCopied] = React.useState(false)
+
+  return (
+    <main className="min-h-screen bg-bg2 px-6 pt-8 pb-12 text-gray10 sm:pt-16 lg:pt-24">
+      <section className="mx-auto flex max-w-2xl flex-col gap-8">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <img
+            alt="Tipbot"
+            className="size-24 rounded-3xl object-cover shadow-lg sm:size-28"
+            height={160}
+            src={tipbotImagePath}
+            width={160}
+          />
+          <div className="space-y-2">
+            <p className="text-sm font-bold tracking-[0.2em] text-gray8 uppercase">
+              Tipbot receipt
+            </p>
+            <h1 className="text-3xl font-bold tracking-[-0.03em] text-gray10 sm:text-4xl">
+              {data.sender.label} {data.memo ? 'sent' : 'tipped'} {data.recipientSummary}
+            </h1>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-gray5 bg-bg1 p-6 shadow-xl sm:p-8">
+          <div className="border-b border-gray5 pb-6 text-center">
+            <div className="text-4xl font-bold tracking-[-0.04em] text-gray10 sm:text-5xl">
+              {data.totalDisplay}
+            </div>
+            {data.recipientCount > 1 ? (
+              <p className="mt-2 text-base text-gray9">{data.amountEachDisplay} each</p>
+            ) : null}
+          </div>
+
+          <dl className="divide-y divide-gray5">
+            <ReceiptRow label="Status">
+              <span className="inline-flex items-center rounded-full border border-green6 bg-green2 px-2.5 py-1 text-sm font-bold text-green10">
+                Confirmed
+              </span>
+              {data.chain?.status === 'failed' ? (
+                <span className="ms-2 text-sm text-red9">Chain reports failed</span>
+              ) : null}
+              {data.chain?.status === 'pending_indexing' ? (
+                <span className="ms-2 text-sm text-gray8">Pending indexing</span>
+              ) : null}
+              {data.chain?.status === 'unavailable' ? (
+                <span className="ms-2 text-sm text-gray8">Chain details unavailable</span>
+              ) : null}
+            </ReceiptRow>
+            <ReceiptRow label="From">
+              <Identity identity={data.sender} />
+            </ReceiptRow>
+            <ReceiptRow label="To">
+              <div className="space-y-2">
+                {data.recipients.map((recipient) => (
+                  <div className="flex flex-col gap-1" key={recipient.id}>
+                    <Identity identity={recipient} />
+                    <span className="text-sm text-gray8">{recipient.amountDisplay}</span>
+                  </div>
+                ))}
+              </div>
+            </ReceiptRow>
+            {data.memo ? <ReceiptRow label="Memo">{data.memo}</ReceiptRow> : null}
+            <ReceiptRow label="Date">{data.dateDisplay}</ReceiptRow>
+            <ReceiptRow label="Network">{data.network}</ReceiptRow>
+            {data.feeDisplay ? <ReceiptRow label="Fee">{data.feeDisplay}</ReceiptRow> : null}
+            <ReceiptRow label="Transaction">
+              <button
+                className="font-mono text-sm text-blue9 no-underline hover:underline"
+                onClick={async () => {
+                  await navigator.clipboard.writeText(data.hash)
+                  setCopied(true)
+                }}
+                type="button"
+              >
+                {shortHash(data.hash)}
+              </button>
+              {copied ? <span className="ms-2 text-sm text-gray8">Copied</span> : null}
+            </ReceiptRow>
+          </dl>
+        </div>
+
+        <a
+          className="self-center text-sm font-medium text-gray8 no-underline hover:text-gray10 hover:underline"
+          href={data.explorerUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          View on Tempo Explorer
+        </a>
+      </section>
+    </main>
+  )
+}
+
+export const Route = createFileRoute('/r/$hash')({
+  component: Component,
+  async loader(options) {
+    const data = await getReceiptData({ data: options.params.hash })
+    if (!data.ok) throw notFound()
+    return data
+  },
+  notFoundComponent: ReceiptNotFound,
+})
+
+function ReceiptNotFound() {
+  return (
+    <main className="min-h-screen bg-bg2 px-6 pt-8 pb-12 text-gray10 sm:pt-16 lg:pt-24">
+      <section className="mx-auto flex max-w-xl flex-col items-center gap-8">
+        <img
+          alt="Tipbot"
+          className="size-28 rounded-3xl object-cover shadow-lg sm:size-36"
+          height={160}
+          src={tipbotImagePath}
+          width={160}
+        />
+        <div className="max-w-sm space-y-3 text-center">
+          <h1 className="text-3xl font-bold text-gray10">Receipt not found</h1>
+          <p className="text-base text-gray9">This is not a confirmed Tipbot receipt.</p>
+        </div>
+      </section>
+    </main>
+  )
+}
+
+function Identity(props: { identity: { address: string | null; label: string } }) {
+  return (
+    <span className="inline-flex flex-wrap items-baseline gap-x-2 gap-y-1">
+      <span className="font-semibold text-gray10">{props.identity.label}</span>
+      {props.identity.address ? (
+        <span className="font-mono text-sm text-gray8">{shortAddress(props.identity.address)}</span>
+      ) : null}
+    </span>
+  )
+}
+
+function ReceiptRow(props: React.PropsWithChildren<{ label: string }>) {
+  return (
+    <div className="grid gap-2 py-4 sm:grid-cols-[8rem_1fr] sm:gap-4">
+      <dt className="text-sm font-bold text-gray8">{props.label}</dt>
+      <dd className="min-w-0 text-base text-gray10">{props.children}</dd>
+    </div>
+  )
+}
+
+const getReceiptData = createServerFn({ method: 'GET' })
+  .inputValidator(z.string().check(z.minLength(1)))
+  .handler(async ({ data: rawHash }) => {
+    const hash = rawHash.toLowerCase()
+    if (!/^0x[0-9a-f]{64}$/.test(hash)) return { ok: false as const }
+
+    const batch = await DB.create(env.DB)
+      .selectFrom('tip_batch')
+      .innerJoin('workspace', 'workspace.id', 'tip_batch.workspace_id')
+      .innerJoin('member as sender_member', 'sender_member.id', 'tip_batch.sender_member_id')
+      .leftJoin(
+        'provider_identity as sender_identity',
+        'sender_identity.id',
+        'sender_member.provider_identity_id',
+      )
+      .leftJoin('account as sender_account', 'sender_account.id', 'sender_identity.account_id')
+      .select([
+        'sender_account.address as sender_address',
+        'sender_identity.display_name as sender_display_name',
+        'sender_identity.real_name as sender_real_name',
+        'sender_member.login as sender_login',
+        'sender_member.name as sender_name',
+        'sender_member.provider_user_id as sender_provider_user_id',
+        'tip_batch.amount_each',
+        'tip_batch.id',
+        'tip_batch.memo',
+        'tip_batch.recipient_count',
+        'tip_batch.source',
+        'tip_batch.token_address',
+        'tip_batch.total_amount',
+        'tip_batch.transaction_hash',
+        'tip_batch.updated_at',
+        'workspace.chain_id',
+        'workspace.default_token_address',
+        'workspace.id as workspace_id',
+      ])
+      .where('tip_batch.transaction_hash', '=', hash)
+      .where('tip_batch.status', '=', 'confirmed')
+      .executeTakeFirst()
+    if (!batch || !batch.transaction_hash) return { ok: false as const }
+
+    const tipRows = await DB.create(env.DB)
+      .selectFrom('tip')
+      .innerJoin('member as recipient_member', 'recipient_member.id', 'tip.recipient_member_id')
+      .leftJoin(
+        'provider_identity as recipient_identity',
+        'recipient_identity.id',
+        'recipient_member.provider_identity_id',
+      )
+      .innerJoin('account as recipient_account', 'recipient_account.id', 'tip.recipient_id')
+      .select([
+        'recipient_account.address as recipient_address',
+        'recipient_identity.display_name as recipient_display_name',
+        'recipient_identity.real_name as recipient_real_name',
+        'recipient_member.id as recipient_member_id',
+        'recipient_member.login as recipient_login',
+        'recipient_member.name as recipient_name',
+        'recipient_member.provider_user_id as recipient_provider_user_id',
+        'tip.amount',
+      ])
+      .where('tip.batch_id', '=', batch.id)
+      .execute()
+
+    const token = await Tempo.getTokenMetadata(env, batch.chain_id, batch.token_address)
+    const chain = await getChainReceipt(batch.chain_id, hash)
+    const date = chain.timestamp ?? batch.updated_at
+    const amountEach = formatAmount(Number(batch.amount_each))
+    const total = formatAmount(Number(batch.total_amount))
+    const isDefaultToken = batch.default_token_address
+      ? batch.default_token_address.toLowerCase() === batch.token_address.toLowerCase()
+      : batch.token_address.toLowerCase() === Tempo.addressLookup.pathUsd.toLowerCase()
+    const formatDisplay = (amount: string) =>
+      isDefaultToken
+        ? formatCurrencyAmount(amount, token.currency)
+        : formatTipAmount(amount, token.currency, token.symbol)
+
+    return {
+      amountEachDisplay: formatDisplay(amountEach),
+      chain,
+      dateDisplay: new Intl.DateTimeFormat('en', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(new Date(date)),
+      explorerUrl: Tempo.formatTxLink(batch.chain_id, hash),
+      feeDisplay: chain?.feeDisplay ?? null,
+      hash,
+      memo: batch.memo,
+      network: Tempo.getChainName(batch.chain_id),
+      ok: true as const,
+      recipientCount: batch.recipient_count,
+      recipientSummary:
+        tipRows.length === 1
+          ? displayLabel({
+              address: tipRows[0]!.recipient_address,
+              fallback: tipRows[0]!.recipient_provider_user_id,
+              login: tipRows[0]!.recipient_login,
+              name: tipRows[0]!.recipient_name,
+              providerDisplayName: tipRows[0]!.recipient_display_name,
+              providerRealName: tipRows[0]!.recipient_real_name,
+            })
+          : `${batch.recipient_count} accounts`,
+      recipients: tipRows.map((recipient) => ({
+        address: recipient.recipient_address,
+        amountDisplay: formatDisplay(formatAmount(Number(recipient.amount))),
+        id: recipient.recipient_member_id,
+        label: displayLabel({
+          address: recipient.recipient_address,
+          fallback: recipient.recipient_provider_user_id,
+          login: recipient.recipient_login,
+          name: recipient.recipient_name,
+          providerDisplayName: recipient.recipient_display_name,
+          providerRealName: recipient.recipient_real_name,
+        }),
+      })),
+      sender: {
+        address: batch.sender_address,
+        label: displayLabel({
+          address: batch.sender_address,
+          fallback: batch.sender_provider_user_id,
+          login: batch.sender_login,
+          name: batch.sender_name,
+          providerDisplayName: batch.sender_display_name,
+          providerRealName: batch.sender_real_name,
+        }),
+      },
+      totalDisplay: formatDisplay(total),
+    }
+  })
+
+async function getChainReceipt(
+  chainId: number,
+  hash: string,
+): Promise<{
+  feeDisplay: string | null
+  status: 'confirmed' | 'failed' | 'pending_indexing' | 'unavailable'
+  timestamp: string | null
+}> {
+  const endpoint = getTidxEndpoint(chainId)
+  if (!endpoint) return { feeDisplay: null, status: 'unavailable' as const, timestamp: null }
+  try {
+    const url = new URL('/query', endpoint)
+    url.searchParams.set('chainId', String(chainId))
+    url.searchParams.set(
+      'sql',
+      `SELECT block_timestamp, status FROM receipts WHERE tx_hash = decode('${hash.slice(2)}', 'hex') LIMIT 1`,
+    )
+    const tidxTimeoutMs = 2_000 // 2 seconds
+    const response = await fetch(url, { signal: AbortSignal.timeout(tidxTimeoutMs) })
+    if (!response.ok) return { feeDisplay: null, status: 'unavailable' as const, timestamp: null }
+    const json = (await response.json()) as {
+      columns?: string[]
+      rows?: unknown[][]
+    }
+    const row = json.rows?.[0]
+    if (!row) return { feeDisplay: null, status: 'pending_indexing' as const, timestamp: null }
+    const value = (column: string) => row[json.columns?.indexOf(column) ?? -1]
+    const timestamp = value('block_timestamp')
+    return {
+      feeDisplay: null,
+      status: Number(value('status')) === 1 ? ('confirmed' as const) : ('failed' as const),
+      timestamp: typeof timestamp === 'string' ? timestamp : null,
+    }
+  } catch {
+    return { feeDisplay: null, status: 'unavailable' as const, timestamp: null }
+  }
+}
+
+function displayLabel(input: {
+  address: string | null
+  fallback: string
+  login: string | null
+  name: string | null
+  providerDisplayName: string | null
+  providerRealName: string | null
+}) {
+  const label = input.login || input.name || input.providerDisplayName || input.providerRealName
+  if (label) return label.startsWith('@') ? label : `@${label}`
+  if (input.address) return shortAddress(input.address)
+  return input.fallback
+}
+
+function getTidxEndpoint(chainId: number) {
+  if (chainId === Tempo.chainLookup.mainnet) return 'https://indexer.tempo.xyz'
+  if (chainId === Tempo.chainLookup.testnet) return 'https://indexer.testnet.tempo.xyz'
+  return null
+}
+
+function shortAddress(address: string) {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`
+}
+
+function shortHash(hash: string) {
+  return `${hash.slice(0, 10)}…${hash.slice(-8)}`
+}

--- a/test/e2e/confirm.test.ts
+++ b/test/e2e/confirm.test.ts
@@ -171,7 +171,7 @@ test('slack member confirms payment with wallet approval', async ({ app, page })
   await expect(page.getByRole('heading', { name: 'Payment sent' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'View receipt' })).toHaveAttribute(
     'href',
-    Tempo.formatTxLink(Tempo.chainLookup.localnet, `0x${'1'.repeat(64)}`),
+    Tempo.formatReceiptPath(`0x${'1'.repeat(64)}`),
   )
   await expect(page.getByText('You can close this tab and return to Slack.')).toBeVisible()
 })
@@ -281,7 +281,7 @@ test('slack member confirms one-time payment with wallet signature', async ({
   await expect(page.getByRole('heading', { name: 'Payment sent' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'View receipt' })).toHaveAttribute(
     'href',
-    Tempo.formatTxLink(Tempo.chainLookup.testnet, `0x${'2'.repeat(64)}`),
+    Tempo.formatReceiptPath(`0x${'2'.repeat(64)}`),
   )
 })
 
@@ -430,7 +430,7 @@ test('slack member confirms receipt boost with wallet signature', async ({
   await expect(page.getByRole('heading', { name: 'Payment sent' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'View receipt' })).toHaveAttribute(
     'href',
-    Tempo.formatTxLink(Tempo.chainLookup.testnet, `0x${'4'.repeat(64)}`),
+    Tempo.formatReceiptPath(`0x${'4'.repeat(64)}`),
   )
 })
 
@@ -533,7 +533,7 @@ test('slack member confirms multi-recipient one-time payment with wallet signatu
   await expect(page.getByRole('heading', { name: 'Payment sent' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'View receipt' })).toHaveAttribute(
     'href',
-    Tempo.formatTxLink(Tempo.chainLookup.testnet, `0x${'3'.repeat(64)}`),
+    Tempo.formatReceiptPath(`0x${'3'.repeat(64)}`),
   )
 })
 

--- a/test/e2e/receipt.test.ts
+++ b/test/e2e/receipt.test.ts
@@ -1,0 +1,84 @@
+import * as Tempo from '#/lib/tempo.ts'
+import { expect, test } from './fixture.ts'
+
+test('visitor opens a confirmed Tipbot receipt', async ({ app, factory, page }) => {
+  const transactionHash = `0x${'1'.repeat(64)}`
+  const workspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    default_token_address: Tempo.addressLookup.pathUsd,
+    provider_id: `T${crypto.randomUUID().replaceAll('-', '')}`,
+  })
+  const senderAccount = await factory.account.insert({})
+  const recipientAccount = await factory.account.insert({})
+  const senderIdentity = await factory.provider_identity.insert({
+    account_id: senderAccount.id,
+    display_name: 'alice',
+    provider_user_id: 'U000000001',
+    provider_workspace_id: workspace.provider_id,
+  })
+  const recipientIdentity = await factory.provider_identity.insert({
+    account_id: recipientAccount.id,
+    display_name: 'bob',
+    provider_user_id: 'U000000002',
+    provider_workspace_id: workspace.provider_id,
+  })
+  const senderMember = await factory.member.insert({
+    provider_user_id: 'U000000001',
+    provider_identity_id: senderIdentity.id,
+    workspace_id: workspace.id,
+  })
+  const recipientMember = await factory.member.insert({
+    provider_user_id: 'U000000002',
+    provider_identity_id: recipientIdentity.id,
+    workspace_id: workspace.id,
+  })
+  const batch = await factory.tip_batch.insert({
+    amount_each: 5_000_000,
+    idempotency_key: `command:${crypto.randomUUID()}`,
+    memo: 'coffee',
+    provider: 'slack',
+    provider_channel_id: 'C000000001',
+    provider_id: workspace.provider_id,
+    recipient_count: 1,
+    sender_member_id: senderMember.id,
+    source: 'command',
+    status: 'confirmed',
+    token_address: Tempo.addressLookup.pathUsd,
+    total_amount: 5_000_000,
+    transaction_hash: transactionHash,
+    workspace_id: workspace.id,
+  })
+  await factory.tip.insert({
+    amount: 5_000_000,
+    batch_id: batch.id,
+    chain_id: workspace.chain_id,
+    confirmed_at: new Date().toISOString(),
+    idempotency_key: batch.idempotency_key,
+    recipient_id: recipientAccount.id,
+    recipient_member_id: recipientMember.id,
+    sender_id: senderAccount.id,
+    sender_member_id: senderMember.id,
+    token_address: Tempo.addressLookup.pathUsd,
+    workspace_id: workspace.id,
+  })
+
+  await page.goto(new URL(Tempo.formatReceiptPath(transactionHash), app.baseUrl).toString())
+
+  await expect(page.getByRole('heading', { name: '@alice sent @bob' })).toBeVisible()
+  await expect(page.getByText('$5.00').first()).toBeVisible()
+  await expect(page.getByText('coffee')).toBeVisible()
+  await expect(page.locator('dd').getByText('Tempo', { exact: true })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'View on Tempo Explorer' })).toHaveAttribute(
+    'href',
+    Tempo.formatTxLink(Tempo.chainLookup.localnet, transactionHash),
+  )
+})
+
+test('visitor opens a non Tipbot receipt link', async ({ app, page }) => {
+  const response = await page.goto(
+    new URL(Tempo.formatReceiptPath(`0x${'2'.repeat(64)}`), app.baseUrl).toString(),
+  )
+
+  expect(response?.status()).toBe(404)
+  await expect(page.getByRole('heading', { name: 'Receipt not found' })).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- add /r/:hash Tipbot receipt pages backed by local Tipbot receipt data and TIDX chain metadata
- switch generated receipt links from Tempo Explorer to tip.bot/r/:hash
- keep dim explorer link at bottom and 404 non-Tipbot hashes

## Verification
- pnpm check --fix
- pnpm check:types
- pnpm test src/lib/tempo.test.ts src/lib/twitter.test.ts
- pnpm test:e2e test/e2e/receipt.test.ts