### PR TITLE
Show waiting state after onboarding tweet action

### DIFF
--- a/src/routes/link/x.tsx
+++ b/src/routes/link/x.tsx
@@ -31,6 +31,7 @@ function LinkPanel() {
   const connection = useConnection()
   const connectors = useConnectors()
   const disconnectWallet = useDisconnect()
+  const waitingForExampleTweetTimeout = React.useRef<number | null>(null)
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
   const [challenge, setChallenge] = React.useState<Challenge | null>(null)
@@ -42,6 +43,7 @@ function LinkPanel() {
   const [showManualVerification, setShowManualVerification] = React.useState(false)
   const [showTweetFallback, setShowTweetFallback] = React.useState(false)
   const [copiedExampleTweet, setCopiedExampleTweet] = React.useState(false)
+  const [waitingForExampleTweet, setWaitingForExampleTweet] = React.useState(false)
   const [tweetUrl, setTweetUrl] = React.useState('')
   const [xUsername, setXUsername] = React.useState('')
   const exampleTweet = '@tipbotgg @awkweb $0.01 for building tipbot'
@@ -283,6 +285,13 @@ function LinkPanel() {
   function composeExampleTweet() {
     const intentUrl = new URL('/intent/tweet', 'https://twitter.com')
     intentUrl.searchParams.set('text', exampleTweet)
+    setWaitingForExampleTweet(true)
+    if (waitingForExampleTweetTimeout.current)
+      window.clearTimeout(waitingForExampleTweetTimeout.current)
+    waitingForExampleTweetTimeout.current = window.setTimeout(() => {
+      setWaitingForExampleTweet(false)
+      waitingForExampleTweetTimeout.current = null
+    }, 15_000) // 15 seconds
     openTweetComposer(intentUrl.toString())
   }
 
@@ -314,6 +323,7 @@ function LinkPanel() {
                 <button
                   className="inline-flex h-10 items-center justify-center rounded-lg bg-green8 px-4 text-sm font-bold whitespace-nowrap text-white transition-colors outline-none hover:bg-green7 focus-visible:ring-2 focus-visible:ring-green9 focus-visible:ring-offset-2 focus-visible:ring-offset-bg2 focus-visible:outline-none"
                   onClick={composeExampleTweet}
+                  onPointerDown={() => setWaitingForExampleTweet(true)}
                   type="button"
                 >
                   Open in X
@@ -326,6 +336,18 @@ function LinkPanel() {
                   {copiedExampleTweet ? 'Copied' : 'Copy tweet'}
                 </button>
               </div>
+              {waitingForExampleTweet ? (
+                <p
+                  className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-gray8"
+                  role="status"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="size-4 rounded-full border-2 border-gray5 border-t-gray8 motion-safe:animate-spin"
+                  />
+                  Waiting for tweet
+                </p>
+              ) : null}
             </div>
           </div>
         ) : (

--- a/src/routes/link/x.tsx
+++ b/src/routes/link/x.tsx
@@ -323,7 +323,6 @@ function LinkPanel() {
                 <button
                   className="inline-flex h-10 items-center justify-center rounded-lg bg-green8 px-4 text-sm font-bold whitespace-nowrap text-white transition-colors outline-none hover:bg-green7 focus-visible:ring-2 focus-visible:ring-green9 focus-visible:ring-offset-2 focus-visible:ring-offset-bg2 focus-visible:outline-none"
                   onClick={composeExampleTweet}
-                  onPointerDown={() => setWaitingForExampleTweet(true)}
                   type="button"
                 >
                   Open in X

--- a/test/e2e/link_x.test.ts
+++ b/test/e2e/link_x.test.ts
@@ -9,7 +9,6 @@ test('visitor connects X account with OAuth', async ({ app, page }) => {
   const root = Account.fromSecp256k1(
     '0x0000000000000000000000000000000000000000000000000000000000000001',
   )
-
   await page.route('**/api/link/twitter/oauth/challenge', async (route) => {
     expect(route.request().method()).toBe('POST')
     const json = route.request().postDataJSON() as {
@@ -194,6 +193,14 @@ test('visitor connects X account with proof tweet', async ({ app, page }) => {
   await page.getByLabel('Paste your tweet URL').fill('https://x.com/tipbotgg/status/123')
 
   await expect(page.getByText('You can now receive and send tips on X.')).toBeVisible()
+  await expect(page.getByText('Waiting for tweet')).toBeHidden()
+  await page.getByRole('button', { name: 'Copy tweet' }).click()
+  await expect(page.getByText('Waiting for tweet')).toBeHidden()
+  await page.clock.install()
+  await page.getByRole('button', { name: 'Open in X' }).click()
+  await expect(page.getByText('Waiting for tweet')).toBeVisible()
+  await page.clock.fastForward(15_000)
+  await expect(page.getByText('Waiting for tweet')).toBeHidden()
 })
 
 test('visitor connects X account after automatic proof tweet polling', async ({ app, page }) => {


### PR DESCRIPTION
## Summary
- show a spinner and `Waiting for tweet` after users open the first-tip tweet
- cover the waiting state in the X linking e2e flow

## Test
- `PATH=/home/agent/.local/bin:$PATH corepack pnpm exec playwright test test/e2e/link_x.test.ts --config test/e2e.config.ts`
- `pnpm exec playwright test test/e2e/link_x.test.ts --config test/e2e.config.ts`

Prompted by: @tmm
