### PR TITLE
feat: add tip rain command

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -914,6 +914,10 @@ const modalSubmits = {
 >
 
 const handlers = {
+  async rain(event, ctx) {
+    const text = ['<!channel>', ctx.text].filter(Boolean).join(' ')
+    await handlers.default(event, { ...ctx, text })
+  },
   async raffle(event, ctx) {
     if (Slack.isDMChannelId(event.channel.id)) {
       await postPrivateReply(event, event.user, 'Raffles can only be opened in channels.')
@@ -1967,6 +1971,7 @@ const commandNames = [
   'disconnect',
   'help',
   'leaderboard',
+  'rain',
   'raffle',
   'stats',
   'status',

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -289,6 +289,21 @@ describe('/tip @account', () => {
     await expectSlackMessageNotContaining('Receipt')
   })
 
+  test('previews rain command through channel membership', async () => {
+    await connectTipAccounts()
+    await memberSlack.conversations.join({ channel: Constants.slack.channelId })
+
+    const response = await postSlashCommand('rain')
+
+    expect(response.status).toBe(200)
+    await expectSlackMessage(
+      `You’re about to tip <!channel> <@${Constants.slack.memberUserId}> $0.001 each.`,
+    )
+    await expectSlackMessage(`• <@${Constants.slack.memberUserId}>`)
+    await expectSlackMessageNotContaining(`• <@${Constants.slack.adminUserId}> (you)`)
+    await expectSlackMessageNotContaining('Receipt')
+  })
+
   test('previews channel tip through paginated channel membership', async () => {
     const originalFetch = globalThis.fetch
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((async (input, init) => {


### PR DESCRIPTION
## Summary
- add `/tip rain` as a channel-wide tip alias using existing channel-tip handling
- cover the rain command with a worker test

## Validation
- `PATH=/home/agent/bin:$PATH pnpm check`
- `PATH=/home/agent/bin:$PATH pnpm test -- src/chat.workers.test.ts -t "rain command"` *(blocked: worker global setup local Tempo RPC returned HTTP 400 for `eth_getTransactionCount` while minting test funds)*

Prompted by: @jxom