### PR TITLE
Add custom presets for /tip ask

### DIFF
--- a/db/migrations/0022_tip_ask_presets.sql
+++ b/db/migrations/0022_tip_ask_presets.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tip_ask"
+ADD COLUMN "preset_options" TEXT;

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -202,6 +202,7 @@ export const tip_ask = z.object({
   memo: z.string().nullable(),
   money_with_wings_amount: z.number(),
   moneybag_amount: z.number(),
+  preset_options: z.string().nullable(),
   provider_channel_id: z.string(),
   provider_id: z.string(),
   provider_message_ts: z.string(),

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -224,6 +224,7 @@ type tip_ask = {
   memo: string | null
   money_with_wings_amount: number
   moneybag_amount: number
+  preset_options: string | null
   provider_channel_id: string
   provider_id: string
   provider_message_ts: string

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -383,7 +383,7 @@ const actions = {
     const payload = z
       .object({
         nonce: z.string().min(1).optional(),
-        reaction: z.enum(tipAskReactionNames),
+        reaction: z.string().min(1),
         tipAskId: z.string().min(1),
       })
       .safeParse(
@@ -417,6 +417,7 @@ const actions = {
         'tip_ask.memo',
         'tip_ask.money_with_wings_amount',
         'tip_ask.moneybag_amount',
+        'tip_ask.preset_options',
         'tip_ask.provider_channel_id',
         'tip_ask.provider_id',
         'tip_ask.provider_message_ts',
@@ -445,8 +446,10 @@ const actions = {
       reaction: payload.data.reaction,
       tipAskId: tipAsk.id,
     })
+    const amount = tipAskAmount(tipAsk, payload.data.reaction)
+    if (!amount) return
     const result = await Tip.handleTipRequest(env, {
-      amount: tipAskAmount(tipAsk, payload.data.reaction),
+      amount,
       idempotencyKey,
       memo: tipAsk.memo,
       provider: 'slack',
@@ -983,14 +986,8 @@ const handlers = {
     )
   },
   async ask(event, ctx) {
-    const memo = (() => {
-      const value = ctx.text
-        .replace(/^for\s+/i, '')
-        .trim()
-        .replace(/\.+$/, '')
-        .trim()
-      return value || null
-    })()
+    const input = parseTipAskInput(ctx.text)
+    const memo = input.memo
     if (Slack.isDMChannelId(event.channel.id)) {
       await postPrivateReply(event, event.user, 'Tip jars can only be opened in channels.')
       return
@@ -1031,12 +1028,31 @@ const handlers = {
 
     const configs = await getReactionTipConfigs(ctx.db, workspace.id)
     const configByReaction = new Map(configs.map((config) => [config.emoji, config.amount]))
-    const amounts = {
-      dollar: configByReaction.get('dollar'),
-      money_with_wings: configByReaction.get('money_with_wings'),
-      moneybag: configByReaction.get('moneybag'),
+    const defaultPresetOptions = defaultTipAskReactions.reduce<TipAskPresetOption[]>(
+      (options, reaction) => {
+        const amount = configByReaction.get(reaction.name)
+        if (amount) options.push({ amount, emoji: reaction.emoji, name: reaction.name })
+        return options
+      },
+      [],
+    )
+    const missingPreset = input.presetNames.find((name) => !configByReaction.has(name))
+    if (missingPreset) {
+      await postPrivateReply(
+        event,
+        event.user,
+        `Tip jar not opened. Configure ${missingPreset} as a reaction tip amount first.`,
+      )
+      return
     }
-    if (!amounts.dollar || !amounts.money_with_wings || !amounts.moneybag) {
+    const presetOptions = input.presetNames.length
+      ? input.presetNames.map((name) => ({
+          amount: configByReaction.get(name) ?? 1,
+          emoji: formatSlackEmoji(name),
+          name,
+        }))
+      : defaultPresetOptions
+    if (presetOptions.length === 0) {
       await postPrivateReply(
         event,
         event.user,
@@ -1044,6 +1060,7 @@ const handlers = {
       )
       return
     }
+    const amountByPreset = new Map(presetOptions.map((option) => [option.name, option.amount]))
 
     const installation = await getSlack().getInstallation(ctx.provider.id)
     if (!installation) return
@@ -1052,11 +1069,13 @@ const handlers = {
     const tipAsk = {
       chain_id: workspace.chain_id,
       created_at: now,
-      dollar_amount: amounts.dollar,
+      dollar_amount: amountByPreset.get('dollar') ?? configByReaction.get('dollar') ?? 1,
       id: tipAskId,
       memo,
-      money_with_wings_amount: amounts.money_with_wings,
-      moneybag_amount: amounts.moneybag,
+      money_with_wings_amount:
+        amountByPreset.get('money_with_wings') ?? configByReaction.get('money_with_wings') ?? 1,
+      moneybag_amount: amountByPreset.get('moneybag') ?? configByReaction.get('moneybag') ?? 1,
+      preset_options: JSON.stringify(presetOptions),
       provider_channel_id: Slack.getChannelId(event.channel.id),
       provider_id: ctx.provider.id,
       provider_message_ts: 'pending',
@@ -1988,7 +2007,7 @@ const modalSubmitNames = ['config_edit', 'tip_raffle_create'] as const
 const tipAskIdempotencyPrefix = 'tip_ask:'
 const tipRaffleIdempotencyPrefix = 'tip_raffle:'
 const tipAskReactionNames = ['money_with_wings', 'dollar', 'moneybag'] as const
-const tipAskReactions = [
+const defaultTipAskReactions = [
   { emoji: '💸', name: 'money_with_wings' },
   { emoji: '💵', name: 'dollar' },
   { emoji: '💰', name: 'moneybag' },
@@ -2051,6 +2070,7 @@ type ReactionHandlerContext = {
 type ReactionTipConfig = Pick<DB_gen.Selectable.reaction_tip_config, 'amount' | 'emoji'>
 
 type TipAskReaction = (typeof tipAskReactionNames)[number]
+type TipAskPresetOption = { amount: number; emoji: string; name: string }
 
 type TipAskMessageInput = Pick<
   DB_gen.Selectable.tip_ask,
@@ -2059,6 +2079,7 @@ type TipAskMessageInput = Pick<
   | 'memo'
   | 'money_with_wings_amount'
   | 'moneybag_amount'
+  | 'preset_options'
   | 'token_address'
   | 'chain_id'
 > & {
@@ -3363,6 +3384,7 @@ export async function updateTipAskMessage(providerId: string, options: { tipAskI
       'tip_ask.memo',
       'tip_ask.money_with_wings_amount',
       'tip_ask.moneybag_amount',
+      'tip_ask.preset_options',
       'tip_ask.provider_channel_id',
       'tip_ask.provider_message_ts',
       'tip_ask.token_address',
@@ -3693,7 +3715,7 @@ export function getTipAskIdFromIdempotencyKey(value: string) {
 function tipAskIdempotencyKey(input: {
   nonce?: string
   providerUserId: string
-  reaction: TipAskReaction
+  reaction: string
   tipAskId: string
 }) {
   return `${tipAskIdempotencyPrefix}${input.tipAskId}:${input.reaction}:${input.providerUserId}${input.nonce ? `:${input.nonce}` : ''}`
@@ -3702,13 +3724,69 @@ function tipAskIdempotencyKey(input: {
 function tipAskAmount(
   tipAsk: Pick<
     DB_gen.Selectable.tip_ask,
-    'dollar_amount' | 'money_with_wings_amount' | 'moneybag_amount'
+    'dollar_amount' | 'money_with_wings_amount' | 'moneybag_amount' | 'preset_options'
   >,
-  reaction: TipAskReaction,
+  reaction: string,
 ) {
+  const preset = tipAskPresetOptions(tipAsk).find((option) => option.name === reaction)
+  if (preset) return preset.amount
   if (reaction === 'dollar') return tipAsk.dollar_amount
   if (reaction === 'moneybag') return tipAsk.moneybag_amount
-  return tipAsk.money_with_wings_amount
+  if (reaction === 'money_with_wings') return tipAsk.money_with_wings_amount
+  return null
+}
+
+function tipAskPresetOptions(
+  tipAsk: Pick<
+    DB_gen.Selectable.tip_ask,
+    'dollar_amount' | 'money_with_wings_amount' | 'moneybag_amount' | 'preset_options'
+  >,
+): TipAskPresetOption[] {
+  if (tipAsk.preset_options) {
+    let rawPresetOptions: unknown
+    try {
+      rawPresetOptions = JSON.parse(tipAsk.preset_options)
+    } catch {
+      rawPresetOptions = null
+    }
+    const presetOptions = z
+      .array(
+        z.object({
+          amount: z.number().int().positive(),
+          emoji: z.string().min(1),
+          name: z.string().min(1),
+        }),
+      )
+      .safeParse(rawPresetOptions)
+    if (presetOptions.success && presetOptions.data.length) return presetOptions.data
+  }
+  return defaultTipAskReactions.map((reaction) => ({
+    amount:
+      reaction.name === 'dollar'
+        ? tipAsk.dollar_amount
+        : reaction.name === 'moneybag'
+          ? tipAsk.moneybag_amount
+          : tipAsk.money_with_wings_amount,
+    emoji: reaction.emoji,
+    name: reaction.name,
+  }))
+}
+
+function parseTipAskInput(text: string) {
+  const match = text.match(/\sfor\s/i)
+  const emojiOnly = /^(:[A-Za-z0-9_+-]+:\s*)+$/.test(text.trim())
+  const presetText = (match ? text.slice(0, match.index) : emojiOnly ? text : '').trim()
+  const memoText = (match ? text.slice((match.index ?? 0) + match[0].length) : text)
+    .replace(/^for\s+/i, '')
+    .trim()
+    .replace(/\.+$/, '')
+    .trim()
+  const presetNames = [...presetText.matchAll(/:([A-Za-z0-9_+-]+):/g)].map((match) => match[1])
+  return { memo: emojiOnly && !match ? null : memoText || null, presetNames }
+}
+
+function formatSlackEmoji(name: string) {
+  return defaultTipAskReactions.find((reaction) => reaction.name === name)?.emoji ?? `:${name}:`
 }
 
 async function selectTipRaffleMessageInput(db: DB.Type, tipRaffleId: string) {
@@ -3862,7 +3940,8 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
   const summary = tipCount
     ? `${tipCount} ${tipCount === 1 ? 'tip' : 'tips'} · ${formatTipAskAmount(total)} total`
     : 'No tips yet'
-  const reactionLines = tipAskReactions
+  const presetOptions = tipAskPresetOptions(tipAsk)
+  const reactionLines = presetOptions
     .map((reaction) => {
       const tipperCounts = new Map<string, number>()
       for (const row of rows) {
@@ -3883,11 +3962,8 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
     `<@${tipAsk.requester_provider_user_id}> opened a tip jar${tipAsk.memo ? ` for ${tipAsk.memo}` : ''}`,
     summary,
     '',
-    tipAskReactions
-      .map(
-        (reaction) =>
-          `[${reaction.emoji} ${formatTipAskAmount(tipAskAmount(tipAsk, reaction.name))}]`,
-      )
+    presetOptions
+      .map((reaction) => `[${reaction.emoji} ${formatTipAskAmount(reaction.amount)}]`)
       .join(' '),
     ...(reactionLines.length ? ['', ...reactionLines] : []),
   ].join('\n')
@@ -3901,11 +3977,13 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
         type: 'section',
       },
       {
-        elements: tipAskReactions.map((reaction) => ({
-          action_id: `tip_ask_option_${reaction.name}`,
+        elements: presetOptions.map((reaction) => ({
+          action_id: tipAskReactionNames.includes(reaction.name as TipAskReaction)
+            ? `tip_ask_option_${reaction.name}`
+            : 'tip_ask_option',
           text: {
             emoji: true,
-            text: `${reaction.emoji} ${formatTipAskAmount(tipAskAmount(tipAsk, reaction.name))}`,
+            text: `${reaction.emoji} ${formatTipAskAmount(reaction.amount)}`,
             type: 'plain_text',
           },
           type: 'button',

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1351,6 +1351,113 @@ test('/tip ask opens a tip jar and updates totals when a preset is clicked', asy
   await expectSlackMessage(`💵 <@${Constants.slack.memberUserId}> x2`)
 }, 20_000) // 20 seconds
 
+test('/tip ask supports custom presets', async () => {
+  const connected = await connectTipAccounts({
+    recipient: false,
+    senderProviderUserId: Constants.slack.memberUserId,
+  })
+  await insertMember({
+    account_id: connected.recipientAccount.id,
+    provider_user_id: Constants.slack.adminUserId,
+    workspace_id: connected.workspace.id,
+  })
+  await db
+    .insertInto('reaction_tip_config')
+    .values({
+      amount: 25_000,
+      emoji: 'rocket',
+      id: Nanoid.generate(),
+      workspace_id: connected.workspace.id,
+    })
+    .execute()
+
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  const response = await postSlashCommand('ask :moneybag: :rocket: for launch.')
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .selectAll()
+    .where('workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(tipAsk.memo).toBe('launch')
+  expect(JSON.parse(tipAsk.preset_options ?? '[]')).toEqual([
+    { amount: 100_000, emoji: '💰', name: 'moneybag' },
+    { amount: 25_000, emoji: ':rocket:', name: 'rocket' },
+  ])
+  await expectSlackMessage('[💰 $0.10] [:rocket: $0.025]')
+
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return (
+      url.endsWith('/chat.postMessage') &&
+      params.get('text')?.includes(`<@${Constants.slack.adminUserId}> opened a tip jar for launch`)
+    )
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+  const buttons = (
+    blocks as Array<{
+      elements?: Array<{ action_id?: string; text?: { text?: string }; value?: string }>
+    }>
+  ).flatMap((block) => block.elements ?? [])
+  expect(buttons.map((button) => button.action_id)).toEqual([
+    'tip_ask_option_moneybag',
+    'tip_ask_option',
+  ])
+  expect(buttons.map((button) => button.text?.text)).toEqual(['💰 $0.10', ':rocket: $0.025'])
+  const rocketButtonPayload = JSON.parse(
+    buttons.find((button) => button.text?.text === ':rocket: $0.025')?.value ?? 'null',
+  ) as {
+    nonce: string
+    reaction: 'rocket'
+    tipAskId: string
+  }
+
+  const clickResponse = await postSlackInteraction({
+    actions: [
+      {
+        action_id: 'tip_ask_option',
+        type: 'button',
+        value: JSON.stringify(rocketButtonPayload),
+      },
+    ],
+    channel: { id: Constants.slack.channelId },
+    container: {
+      channel_id: Constants.slack.channelId,
+      message_ts: tipAsk.provider_message_ts,
+      type: 'message',
+    },
+    message: { ts: tipAsk.provider_message_ts },
+    team: { id: providerId },
+    trigger_id: 'tip-ask-rocket-trigger',
+    type: 'block_actions',
+    user: { id: Constants.slack.memberUserId, name: Constants.slack.memberUserName },
+  })
+  const tip = await db
+    .selectFrom('tip')
+    .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
+    .select(['sender.provider_user_id as sender_provider_user_id', 'tip.amount', 'tip.memo'])
+    .where(
+      'tip.idempotency_key',
+      'like',
+      `tip_ask:${tipAsk.id}:rocket:${Constants.slack.memberUserId}:%`,
+    )
+    .executeTakeFirstOrThrow()
+
+  expect(clickResponse.status).toBe(200)
+  expect(tip).toMatchObject({
+    amount: 25_000,
+    memo: 'launch',
+    sender_provider_user_id: Constants.slack.memberUserId,
+  })
+  await expectSlackMessage('1 tip · $0.025 total')
+  await expectSlackMessage(`:rocket: <@${Constants.slack.memberUserId}>`)
+}, 20_000) // 20 seconds
+
 test('/tip ask requires the asker to be connected', async () => {
   const response = await postSlashCommand('ask for lunch')
   const tipAsks = await db


### PR DESCRIPTION
## Summary
- allow `/tip ask` to accept configured emoji presets before `for`, e.g. `/tip ask :moneybag: :rocket: for launch`
- persist selected ask preset options so message updates keep the same buttons and amounts
- add worker coverage for custom ask presets

## Tests
- `PATH=/tmp/tipbot-bin:$PATH pnpm run check:types`
- `git diff --check`
- `PATH=/tmp/tipbot-bin:$PATH pnpm test -- src/chat.workers.test.ts -t '/tip ask'` (blocked: worker global setup failed while local Tempo RPC returned HTTP 400 for `eth_getTransactionCount` during fee-payer mint)\n\nPrompted by: @jxom