### PR TITLE
feat: open tip jars for beneficiaries

### DIFF
--- a/db/migrations/0023_tip_ask_beneficiary.sql
+++ b/db/migrations/0023_tip_ask_beneficiary.sql
@@ -1,0 +1,3 @@
+-- Track beneficiary tip jars and creator fees for jars opened on behalf of another Slack account.
+ALTER TABLE "tip_ask" ADD COLUMN "beneficiary_provider_user_id" TEXT;
+ALTER TABLE "tip_ask" ADD COLUMN "creator_fee_basis_points" INTEGER NOT NULL DEFAULT 0 CHECK ("creator_fee_basis_points" >= 0 AND "creator_fee_basis_points" <= 10000);

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -195,9 +195,11 @@ export const tip = z.object({
 })
 
 export const tip_ask = z.object({
+  beneficiary_provider_user_id: z.string().nullable(),
   chain_id: z.number(),
   closed_at: z.string().nullable(),
   created_at: z.string(),
+  creator_fee_basis_points: z.number(),
   dollar_amount: z.number(),
   id: z.string(),
   memo: z.string().nullable(),

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -217,9 +217,11 @@ type tip = {
 }
 
 type tip_ask = {
+  beneficiary_provider_user_id: string | null
   chain_id: number
   closed_at: string | null
   created_at: k.Generated<string>
+  creator_fee_basis_points: k.Generated<number>
   dollar_amount: number
   id: string
   memo: string | null

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1001,17 +1001,6 @@ const modalSubmits = {
 >
 
 const handlers = {
-  async open(event, ctx) {
-    const match = ctx.text.match(/^tipjar\s+for\s+<@([A-Z0-9_]+)(?:\|[^>]+)?>\s*([\s\S]*)$/i)
-    if (!match) {
-      await postInvalidUsage(event, ctx)
-      return
-    }
-    await openTipJar(event, ctx, {
-      beneficiaryProviderUserId: match[1]!,
-      memo: match[2]?.replace(/^for\s+/i, '').trim() || null,
-    })
-  },
   async raffle(event, ctx) {
     if (Slack.isDMChannelId(event.channel.id)) {
       await postPrivateReply(event, event.user, 'Raffles can only be opened in channels.')
@@ -1081,7 +1070,9 @@ const handlers = {
     )
   },
   async jar(event, ctx) {
+    const beneficiary = ctx.text.match(/^for\s+<@([A-Z0-9_]+)(?:\|[^>]+)?>\s*([\s\S]*)$/i)
     const memo = (() => {
+      if (beneficiary) return beneficiary[2]?.replace(/^for\s+/i, '').trim() || null
       const value = ctx.text
         .replace(/^for\s+/i, '')
         .trim()
@@ -1089,7 +1080,10 @@ const handlers = {
         .trim()
       return value || null
     })()
-    await openTipJar(event, ctx, { memo })
+    await openTipJar(event, ctx, {
+      ...(beneficiary ? { beneficiaryProviderUserId: beneficiary[1]! } : {}),
+      memo,
+    })
   },
   async balance(event, ctx) {
     if (ctx.text) {
@@ -1273,11 +1267,8 @@ const handlers = {
       [`${getSlackCommand(env.HOST)} disconnect`, 'Disconnect from Tipbot'],
       [`${getSlackCommand(env.HOST)} help`, 'Show help message'],
       [`${getSlackCommand(env.HOST)} jar [memo]`, 'Open a tip jar'],
+      [`${getSlackCommand(env.HOST)} jar for @account [memo]`, 'Open a tip jar for someone'],
       [`${getSlackCommand(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
-      [
-        `${getSlackCommand(env.HOST)} open tipjar for @account [memo]`,
-        'Open a tip jar for someone',
-      ],
       [`${getSlackCommand(env.HOST)} raffle`, 'Start a raffle'],
       [`${getSlackCommand(env.HOST)} stats`, 'Show your tip stats'],
       [`${getSlackCommand(env.HOST)} status`, 'Check connection status'],
@@ -1301,11 +1292,11 @@ const handlers = {
       [`@${getSlackBotDisplayName(env.HOST)} disconnect`, 'Disconnect from Tipbot'],
       [`@${getSlackBotDisplayName(env.HOST)} help`, 'Show help message'],
       [`@${getSlackBotDisplayName(env.HOST)} jar [memo]`, 'Open a tip jar'],
-      [`@${getSlackBotDisplayName(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
       [
-        `@${getSlackBotDisplayName(env.HOST)} open tipjar for @account [memo]`,
+        `@${getSlackBotDisplayName(env.HOST)} jar for @account [memo]`,
         'Open a tip jar for someone',
       ],
+      [`@${getSlackBotDisplayName(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
       [`@${getSlackBotDisplayName(env.HOST)} stats`, 'Show your tip stats'],
       [`@${getSlackBotDisplayName(env.HOST)} status`, 'Check connection status'],
       [`@${getSlackBotDisplayName(env.HOST)} @account for coffee`, 'Send default amount with memo'],
@@ -1968,7 +1959,6 @@ const commandNames = [
   'help',
   'jar',
   'leaderboard',
-  'open',
   'raffle',
   'stats',
   'status',

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -411,8 +411,10 @@ const actions = {
       .innerJoin('member as requester', 'requester.id', 'tip_ask.requester_member_id')
       .select([
         'requester.provider_user_id as requester_provider_user_id',
+        'tip_ask.beneficiary_provider_user_id',
         'tip_ask.chain_id',
         'tip_ask.closed_at',
+        'tip_ask.creator_fee_basis_points',
         'tip_ask.dollar_amount',
         'tip_ask.id',
         'tip_ask.memo',
@@ -458,12 +460,13 @@ const actions = {
     })
     const result = await Tip.handleTipRequest(env, {
       amount: tipAskAmount(tipAsk, payload.data.reaction),
-      idempotencyKey,
+      idempotencyKey: `${idempotencyKey}:beneficiary`,
       memo: tipAsk.memo,
       provider: 'slack',
       providerChannelId: tipAsk.provider_channel_id,
       providerId: tipAsk.provider_id,
-      recipientProviderUserId: tipAsk.requester_provider_user_id,
+      recipientProviderUserId:
+        tipAsk.beneficiary_provider_user_id ?? tipAsk.requester_provider_user_id,
       senderProviderUserId: event.user.userId,
       source: 'command',
       tokenAddress: tipAsk.token_address,
@@ -478,6 +481,25 @@ const actions = {
     )
 
     if (result.ok) {
+      const feeAmount = Math.floor(
+        (tipAskAmount(tipAsk, payload.data.reaction) * tipAsk.creator_fee_basis_points) / 10_000,
+      )
+      if (feeAmount > 0 && event.user.userId !== tipAsk.requester_provider_user_id)
+        await Tip.handleTipRequest(env, {
+          amount: feeAmount,
+          idempotencyKey: `${idempotencyKey}:creator_fee`,
+          memo: tipAsk.memo,
+          provider: 'slack',
+          providerChannelId: tipAsk.provider_channel_id,
+          providerId: tipAsk.provider_id,
+          recipientProviderUserId: tipAsk.requester_provider_user_id,
+          senderProviderUserId: event.user.userId,
+          source: 'command',
+          tokenAddress: tipAsk.token_address,
+          workspaceProviderId: tipAsk.workspace_provider_id,
+        }).catch((error) => {
+          console.error('Failed to send tip jar creator fee:', error)
+        })
       await updateTipAskMessage(tipAsk.provider_id, { tipAskId: tipAsk.id }).catch((error) => {
         console.error('Failed to update Slack tip jar:', error)
       })
@@ -979,6 +1001,17 @@ const modalSubmits = {
 >
 
 const handlers = {
+  async open(event, ctx) {
+    const match = ctx.text.match(/^tipjar\s+for\s+<@([A-Z0-9_]+)(?:\|[^>]+)?>\s*([\s\S]*)$/i)
+    if (!match) {
+      await postInvalidUsage(event, ctx)
+      return
+    }
+    await openTipJar(event, ctx, {
+      beneficiaryProviderUserId: match[1]!,
+      memo: match[2]?.replace(/^for\s+/i, '').trim() || null,
+    })
+  },
   async raffle(event, ctx) {
     if (Slack.isDMChannelId(event.channel.id)) {
       await postPrivateReply(event, event.user, 'Raffles can only be opened in channels.')
@@ -1056,142 +1089,7 @@ const handlers = {
         .trim()
       return value || null
     })()
-    if (Slack.isDMChannelId(event.channel.id)) {
-      await postPrivateReply(event, event.user, 'Tip jars can only be opened in channels.')
-      return
-    }
-    if (memo && Tip.isTransferMemoTooLong(memo)) {
-      await postPrivateReply(
-        event,
-        event.user,
-        'Tip jar not opened. Memo must be at most 32 bytes; shorten the text after `jar`.',
-      )
-      return
-    }
-
-    const workspace = await ctx.db
-      .selectFrom('workspace')
-      .selectAll()
-      .where('provider', '=', ctx.provider.type)
-      .where('provider_id', '=', ctx.provider.id)
-      .executeTakeFirst()
-    if (!workspace) {
-      await postPrivateReply(
-        event,
-        event.user,
-        'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
-      )
-      return
-    }
-
-    const requester = await getConnectedSlackMember(ctx.db, workspace.id, event.user.userId)
-    if (!requester) {
-      await postPrivateReply(
-        event,
-        event.user,
-        `Connect to Tipbot before opening a tip jar. Run \`${getSlackCommand(env.HOST)} connect\` first.`,
-      )
-      return
-    }
-
-    const configs = await getReactionTipConfigs(ctx.db, workspace.id)
-    const configByReaction = new Map(configs.map((config) => [config.emoji, config.amount]))
-    const amounts = {
-      dollar: configByReaction.get('dollar'),
-      money_with_wings: configByReaction.get('money_with_wings'),
-      moneybag: configByReaction.get('moneybag'),
-    }
-    if (!amounts.dollar || !amounts.money_with_wings || !amounts.moneybag) {
-      await postPrivateReply(
-        event,
-        event.user,
-        'Tip jar not opened. Configure money_with_wings, dollar, and moneybag reaction tip amounts first.',
-      )
-      return
-    }
-
-    const installation = await getSlack().getInstallation(ctx.provider.id)
-    if (!installation) return
-    const now = new Date().toISOString()
-    const tipAskId = Nanoid.generate()
-    const tipAsk = {
-      chain_id: workspace.chain_id,
-      closed_at: null,
-      created_at: now,
-      dollar_amount: amounts.dollar,
-      id: tipAskId,
-      memo,
-      money_with_wings_amount: amounts.money_with_wings,
-      moneybag_amount: amounts.moneybag,
-      provider_channel_id: Slack.getChannelId(event.channel.id),
-      provider_id: ctx.provider.id,
-      provider_message_ts: 'pending',
-      requester_member_id: requester.memberId,
-      token_address: workspace.default_token_address ?? Tempo.addressLookup.pathUsd,
-      updated_at: now,
-      workspace_id: workspace.id,
-    } satisfies DB_gen.Insertable.tip_ask
-    const message = await tipAskMessage(ctx.db, {
-      ...tipAsk,
-      requester_provider_user_id: event.user.userId,
-      workspace_default_token_address: workspace.default_token_address,
-    })
-    const body = new URLSearchParams()
-    body.set('blocks', JSON.stringify(message.blocks))
-    body.set('channel', Slack.getChannelId(event.channel.id))
-    body.set('text', message.text)
-    if (ctx.threadTs) body.set('thread_ts', ctx.threadTs)
-    body.set('unfurl_links', 'false')
-    body.set('unfurl_media', 'false')
-    const response = await getSlack().withBotToken(installation.botToken, () =>
-      fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
-        body,
-        headers: { authorization: `Bearer ${installation.botToken}` },
-        method: 'POST',
-      }),
-    )
-    const json = z.parse(
-      z.object({
-        error: z.string().optional(),
-        ok: z.boolean().optional(),
-        ts: z.string().optional(),
-      }),
-      await response.json(),
-    )
-    if (!json.ok || !json.ts) throw Slack.slackApiError('chat.postMessage', json.error)
-    await ctx.db
-      .insertInto('tip_ask')
-      .values({ ...tipAsk, provider_message_ts: json.ts })
-      .execute()
-    await postSlackEphemeral(
-      ctx.provider.id,
-      Slack.getChannelId(event.channel.id),
-      event.user.userId,
-      'Manage your tip jar.',
-      {
-        blocks: [
-          {
-            text: { text: 'Manage your tip jar.', type: 'mrkdwn' },
-            type: 'section',
-          },
-          {
-            elements: [
-              {
-                action_id: 'tip_ask_close',
-                style: 'danger',
-                text: { emoji: true, text: 'Close tip jar', type: 'plain_text' },
-                type: 'button',
-                value: JSON.stringify({ tipAskId }),
-              },
-            ],
-            type: 'actions',
-          },
-        ],
-        threadTs: ctx.threadTs,
-      },
-    ).catch((error) => {
-      console.error('Failed to post Slack tip jar controls:', error)
-    })
+    await openTipJar(event, ctx, { memo })
   },
   async balance(event, ctx) {
     if (ctx.text) {
@@ -1376,6 +1274,10 @@ const handlers = {
       [`${getSlackCommand(env.HOST)} help`, 'Show help message'],
       [`${getSlackCommand(env.HOST)} jar [memo]`, 'Open a tip jar'],
       [`${getSlackCommand(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
+      [
+        `${getSlackCommand(env.HOST)} open tipjar for @account [memo]`,
+        'Open a tip jar for someone',
+      ],
       [`${getSlackCommand(env.HOST)} raffle`, 'Start a raffle'],
       [`${getSlackCommand(env.HOST)} stats`, 'Show your tip stats'],
       [`${getSlackCommand(env.HOST)} status`, 'Check connection status'],
@@ -1400,6 +1302,10 @@ const handlers = {
       [`@${getSlackBotDisplayName(env.HOST)} help`, 'Show help message'],
       [`@${getSlackBotDisplayName(env.HOST)} jar [memo]`, 'Open a tip jar'],
       [`@${getSlackBotDisplayName(env.HOST)} leaderboard`, 'Show top tippers and recipients'],
+      [
+        `@${getSlackBotDisplayName(env.HOST)} open tipjar for @account [memo]`,
+        'Open a tip jar for someone',
+      ],
       [`@${getSlackBotDisplayName(env.HOST)} stats`, 'Show your tip stats'],
       [`@${getSlackBotDisplayName(env.HOST)} status`, 'Check connection status'],
       [`@${getSlackBotDisplayName(env.HOST)} @account for coffee`, 'Send default amount with memo'],
@@ -2062,6 +1968,7 @@ const commandNames = [
   'help',
   'jar',
   'leaderboard',
+  'open',
   'raffle',
   'stats',
   'status',
@@ -2151,7 +2058,9 @@ type TipAskReaction = (typeof tipAskReactionNames)[number]
 
 type TipAskMessageInput = Pick<
   DB_gen.Selectable.tip_ask,
+  | 'beneficiary_provider_user_id'
   | 'closed_at'
+  | 'creator_fee_basis_points'
   | 'dollar_amount'
   | 'id'
   | 'memo'
@@ -2209,6 +2118,153 @@ type PendingSlackTip = {
 }
 
 type ParsedTipBatch = NonNullable<ReturnType<typeof Tip.parseTipBatchText>>
+
+async function openTipJar(
+  event: chat.SlashCommandEvent | TipEvent,
+  ctx: HandlerContext,
+  input: { beneficiaryProviderUserId?: string; memo: string | null },
+) {
+  if (Slack.isDMChannelId(event.channel.id)) {
+    await postPrivateReply(event, event.user, 'Tip jars can only be opened in channels.')
+    return
+  }
+  if (input.memo && Tip.isTransferMemoTooLong(input.memo)) {
+    await postPrivateReply(
+      event,
+      event.user,
+      'Tip jar not opened. Memo must be at most 32 bytes; shorten the text after `jar`.',
+    )
+    return
+  }
+
+  const workspace = await ctx.db
+    .selectFrom('workspace')
+    .selectAll()
+    .where('provider', '=', ctx.provider.type)
+    .where('provider_id', '=', ctx.provider.id)
+    .executeTakeFirst()
+  if (!workspace) {
+    await postPrivateReply(
+      event,
+      event.user,
+      'Tipbot not configured for this workspace. Reinstall Tipbot and try again.',
+    )
+    return
+  }
+
+  const requester = await getConnectedSlackMember(ctx.db, workspace.id, event.user.userId)
+  if (!requester) {
+    await postPrivateReply(
+      event,
+      event.user,
+      `Connect to Tipbot before opening a tip jar. Run \`${getSlackCommand(env.HOST)} connect\` first.`,
+    )
+    return
+  }
+
+  const configs = await getReactionTipConfigs(ctx.db, workspace.id)
+  const configByReaction = new Map(configs.map((config) => [config.emoji, config.amount]))
+  const amounts = {
+    dollar: configByReaction.get('dollar'),
+    money_with_wings: configByReaction.get('money_with_wings'),
+    moneybag: configByReaction.get('moneybag'),
+  }
+  if (!amounts.dollar || !amounts.money_with_wings || !amounts.moneybag) {
+    await postPrivateReply(
+      event,
+      event.user,
+      'Tip jar not opened. Configure money_with_wings, dollar, and moneybag reaction tip amounts first.',
+    )
+    return
+  }
+
+  const installation = await getSlack().getInstallation(ctx.provider.id)
+  if (!installation) return
+  const now = new Date().toISOString()
+  const tipAskId = Nanoid.generate()
+  const beneficiaryProviderUserId = input.beneficiaryProviderUserId ?? event.user.userId
+  const tipAsk = {
+    beneficiary_provider_user_id:
+      beneficiaryProviderUserId === event.user.userId ? null : beneficiaryProviderUserId,
+    chain_id: workspace.chain_id,
+    closed_at: null,
+    created_at: now,
+    creator_fee_basis_points: beneficiaryProviderUserId === event.user.userId ? 0 : 100,
+    dollar_amount: amounts.dollar,
+    id: tipAskId,
+    memo: input.memo,
+    money_with_wings_amount: amounts.money_with_wings,
+    moneybag_amount: amounts.moneybag,
+    provider_channel_id: Slack.getChannelId(event.channel.id),
+    provider_id: ctx.provider.id,
+    provider_message_ts: 'pending',
+    requester_member_id: requester.memberId,
+    token_address: workspace.default_token_address ?? Tempo.addressLookup.pathUsd,
+    updated_at: now,
+    workspace_id: workspace.id,
+  } satisfies DB_gen.Insertable.tip_ask
+  const message = await tipAskMessage(ctx.db, {
+    ...tipAsk,
+    requester_provider_user_id: event.user.userId,
+    workspace_default_token_address: workspace.default_token_address,
+  })
+  const body = new URLSearchParams()
+  body.set('blocks', JSON.stringify(message.blocks))
+  body.set('channel', Slack.getChannelId(event.channel.id))
+  body.set('text', message.text)
+  if (ctx.threadTs) body.set('thread_ts', ctx.threadTs)
+  body.set('unfurl_links', 'false')
+  body.set('unfurl_media', 'false')
+  const response = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/chat.postMessage`, {
+      body,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      error: z.string().optional(),
+      ok: z.boolean().optional(),
+      ts: z.string().optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok || !json.ts) throw Slack.slackApiError('chat.postMessage', json.error)
+  await ctx.db
+    .insertInto('tip_ask')
+    .values({ ...tipAsk, provider_message_ts: json.ts })
+    .execute()
+  await postSlackEphemeral(
+    ctx.provider.id,
+    Slack.getChannelId(event.channel.id),
+    event.user.userId,
+    'Manage your tip jar.',
+    {
+      blocks: [
+        {
+          text: { text: 'Manage your tip jar.', type: 'mrkdwn' },
+          type: 'section',
+        },
+        {
+          elements: [
+            {
+              action_id: 'tip_ask_close',
+              style: 'danger',
+              text: { emoji: true, text: 'Close tip jar', type: 'plain_text' },
+              type: 'button',
+              value: JSON.stringify({ tipAskId }),
+            },
+          ],
+          type: 'actions',
+        },
+      ],
+      threadTs: ctx.threadTs,
+    },
+  ).catch((error) => {
+    console.error('Failed to post Slack tip jar controls:', error)
+  })
+}
 
 export const reactionTipIdempotencyPrefix = 'reaction:'
 export const receiptBoostIdempotencyPrefix = 'boost:'
@@ -3473,8 +3529,10 @@ export async function updateTipAskMessage(providerId: string, options: { tipAskI
     .innerJoin('member as requester', 'requester.id', 'tip_ask.requester_member_id')
     .select([
       'requester.provider_user_id as requester_provider_user_id',
+      'tip_ask.beneficiary_provider_user_id',
       'tip_ask.chain_id',
       'tip_ask.closed_at',
+      'tip_ask.creator_fee_basis_points',
       'tip_ask.dollar_amount',
       'tip_ask.id',
       'tip_ask.memo',
@@ -4064,18 +4122,34 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
       ? formatCurrencyAmount(value, token.currency)
       : formatTipAmount(value, token.currency, token.symbol)
   }
-  const rows = await db
-    .selectFrom('tip')
-    .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
-    .select([
-      'sender.provider_user_id as sender_provider_user_id',
-      'tip.amount',
-      'tip.idempotency_key',
-    ])
-    .where('tip.idempotency_key', 'like', `${tipAskIdempotencyPrefix}${tipAsk.id}:%`)
-    .where('tip.confirmed_at', 'is not', null)
-    .orderBy('tip.created_at', 'asc')
-    .execute()
+  const tipRows = (
+    await db
+      .selectFrom('tip')
+      .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
+      .select([
+        'sender.provider_user_id as sender_provider_user_id',
+        'tip.amount',
+        'tip.idempotency_key',
+      ])
+      .where('tip.idempotency_key', 'like', `${tipAskIdempotencyPrefix}${tipAsk.id}:%`)
+      .where('tip.confirmed_at', 'is not', null)
+      .orderBy('tip.created_at', 'asc')
+      .execute()
+  ).filter((row) => !row.idempotency_key.endsWith(':creator_fee'))
+  const pendingRows = (
+    await db
+      .selectFrom('pending_tip')
+      .select([
+        'pending_tip.amount',
+        'pending_tip.idempotency_key',
+        'pending_tip.sender_provider_user_id',
+      ])
+      .where('pending_tip.idempotency_key', 'like', `${tipAskIdempotencyPrefix}${tipAsk.id}:%`)
+      .where('pending_tip.status', 'in', ['pending', 'sending', 'sent'])
+      .orderBy('pending_tip.created_at', 'asc')
+      .execute()
+  ).filter((row) => !row.idempotency_key.endsWith(':creator_fee'))
+  const rows = [...tipRows, ...pendingRows]
   const tipCount = rows.length
   const total = rows.reduce((total, row) => total + row.amount, 0)
   const summary = tipCount
@@ -4099,8 +4173,11 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
       return `${reaction.emoji} ${tippers.join(' ')}`
     })
     .filter((line) => line !== null)
+  const title = tipAsk.beneficiary_provider_user_id
+    ? `<@${tipAsk.requester_provider_user_id}> opened a tip jar for <@${tipAsk.beneficiary_provider_user_id}>${tipAsk.memo ? `'s ${tipAsk.memo}` : ''}`
+    : `<@${tipAsk.requester_provider_user_id}> opened a tip jar${tipAsk.memo ? ` for ${tipAsk.memo}` : ''}`
   const text = [
-    `<@${tipAsk.requester_provider_user_id}> opened a tip jar${tipAsk.memo ? ` for ${tipAsk.memo}` : ''}`,
+    title,
     ...(status ? [status] : []),
     summary,
     ...(tipAsk.closed_at
@@ -4120,7 +4197,7 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
     blocks: [
       {
         text: {
-          text: `<@${tipAsk.requester_provider_user_id}> opened a tip jar${tipAsk.memo ? ` for ${tipAsk.memo}` : ''}\n${[...(status ? [status] : []), summary].join('\n')}`,
+          text: `${title}\n${[...(status ? [status] : []), summary].join('\n')}`,
           type: 'mrkdwn',
         },
         type: 'section',

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1503,6 +1503,215 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
   await expectSlackMessage('Tip jar is closed.')
 }, 20_000) // 20 seconds
 
+test('/tip open tipjar for account sends beneficiary tip and creator fee', async () => {
+  const connected = await connectTipAccounts({
+    senderProviderUserId: Constants.slack.unconnectedUserId,
+  })
+  const creatorAccount = await factory.account.insert({
+    address: '0x0000000000000000000000000000000000000101',
+  })
+  const creatorMember = await insertMember({
+    account_id: creatorAccount.id,
+    provider_user_id: Constants.slack.adminUserId,
+    workspace_id: connected.workspace.id,
+  })
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+  const response = await postSlashCommand(
+    `open tipjar for <@${Constants.slack.memberUserId}> rehab`,
+  )
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .selectAll()
+    .where('workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(tipAsk).toMatchObject({
+    beneficiary_provider_user_id: Constants.slack.memberUserId,
+    creator_fee_basis_points: 100,
+    memo: 'rehab',
+    requester_member_id: creatorMember.id,
+  })
+  await expectSlackMessage(
+    `<@${Constants.slack.adminUserId}> opened a tip jar for <@${Constants.slack.memberUserId}>'s rehab`,
+  )
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return (
+      url.endsWith('/chat.postMessage') &&
+      params
+        .get('text')
+        ?.includes(
+          `<@${Constants.slack.adminUserId}> opened a tip jar for <@${Constants.slack.memberUserId}>'s rehab`,
+        )
+    )
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+  const dollarButton = blocks
+    .flatMap(
+      (block: { elements?: Array<{ action_id?: string; value?: string }> }) => block.elements ?? [],
+    )
+    .find((element: { action_id?: string }) => element.action_id === 'tip_ask_option_dollar')
+  const dollarButtonPayload = JSON.parse(dollarButton?.value ?? 'null') as {
+    nonce: string
+    reaction: 'dollar'
+    tipAskId: string
+  }
+
+  const clickResponse = await postSlackInteraction({
+    actions: [
+      {
+        action_id: 'tip_ask_option_dollar',
+        type: 'button',
+        value: JSON.stringify(dollarButtonPayload),
+      },
+    ],
+    channel: { id: Constants.slack.channelId },
+    container: {
+      channel_id: Constants.slack.channelId,
+      message_ts: tipAsk.provider_message_ts,
+      type: 'message',
+    },
+    message: { ts: tipAsk.provider_message_ts },
+    team: { id: providerId },
+    trigger_id: 'tip-ask-beneficiary-dollar-trigger',
+    type: 'block_actions',
+    user: { id: Constants.slack.unconnectedUserId, name: Constants.slack.unconnectedUserName },
+  })
+  const tips = await db
+    .selectFrom('tip')
+    .innerJoin('member as recipient', 'recipient.id', 'tip.recipient_member_id')
+    .select([
+      'recipient.provider_user_id as recipient_provider_user_id',
+      'tip.amount',
+      'tip.idempotency_key',
+    ])
+    .where(
+      'tip.idempotency_key',
+      'like',
+      `tip_ask:${tipAsk.id}:dollar:${Constants.slack.unconnectedUserId}:%`,
+    )
+    .orderBy('tip.amount', 'desc')
+    .execute()
+
+  expect(clickResponse.status).toBe(200)
+  expect(tips).toEqual([
+    expect.objectContaining({
+      amount: 10_000,
+      idempotency_key: expect.stringMatching(/:beneficiary$/),
+      recipient_provider_user_id: Constants.slack.memberUserId,
+    }),
+    expect.objectContaining({
+      amount: 100,
+      idempotency_key: expect.stringMatching(/:creator_fee$/),
+      recipient_provider_user_id: Constants.slack.adminUserId,
+    }),
+  ])
+  await expectSlackMessage('1 tip · $0.01 total')
+  await expectSlackMessage(`💵 <@${Constants.slack.unconnectedUserId}>`)
+})
+
+test('/tip open tipjar for unconnected account queues beneficiary tip and pays creator fee', async () => {
+  const connected = await connectTipAccounts({
+    recipient: false,
+    senderProviderUserId: Constants.slack.memberUserId,
+  })
+  const creatorAccount = await factory.account.insert({
+    address: '0x0000000000000000000000000000000000000102',
+  })
+  await insertMember({
+    account_id: creatorAccount.id,
+    provider_user_id: Constants.slack.adminUserId,
+    workspace_id: connected.workspace.id,
+  })
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+  const response = await postSlashCommand(
+    `open tipjar for <@${Constants.slack.unconnectedUserId}> rehab`,
+  )
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .selectAll()
+    .where('workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return url.endsWith('/chat.postMessage') && params.get('text')?.includes('opened a tip jar')
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+  const dollarButton = blocks
+    .flatMap(
+      (block: { elements?: Array<{ action_id?: string; value?: string }> }) => block.elements ?? [],
+    )
+    .find((element: { action_id?: string }) => element.action_id === 'tip_ask_option_dollar')
+
+  const clickResponse = await postSlackInteraction({
+    actions: [
+      {
+        action_id: 'tip_ask_option_dollar',
+        type: 'button',
+        value: dollarButton?.value,
+      },
+    ],
+    channel: { id: Constants.slack.channelId },
+    container: {
+      channel_id: Constants.slack.channelId,
+      message_ts: tipAsk.provider_message_ts,
+      type: 'message',
+    },
+    message: { ts: tipAsk.provider_message_ts },
+    team: { id: providerId },
+    trigger_id: 'tip-ask-unconnected-dollar-trigger',
+    type: 'block_actions',
+    user: { id: Constants.slack.memberUserId, name: Constants.slack.memberUserName },
+  })
+  const pendingTip = await db
+    .selectFrom('pending_tip')
+    .select(['amount', 'recipient_provider_user_id'])
+    .where(
+      'idempotency_key',
+      'like',
+      `tip_ask:${tipAsk.id}:dollar:${Constants.slack.memberUserId}:%`,
+    )
+    .executeTakeFirstOrThrow()
+  const creatorFees = await db
+    .selectFrom('tip')
+    .innerJoin('member as recipient', 'recipient.id', 'tip.recipient_member_id')
+    .select([
+      'recipient.provider_user_id as recipient_provider_user_id',
+      'tip.amount',
+      'tip.idempotency_key',
+    ])
+    .where(
+      'tip.idempotency_key',
+      'like',
+      `tip_ask:${tipAsk.id}:dollar:${Constants.slack.memberUserId}:%`,
+    )
+    .execute()
+  const creatorFee = creatorFees.find((tip) => tip.idempotency_key.endsWith(':creator_fee'))
+
+  expect(response.status).toBe(200)
+  expect(clickResponse.status).toBe(200)
+  expect(pendingTip).toEqual({
+    amount: 10_000,
+    recipient_provider_user_id: Constants.slack.unconnectedUserId,
+  })
+  expect(creatorFee).toMatchObject({
+    amount: 100,
+    recipient_provider_user_id: Constants.slack.adminUserId,
+  })
+  await expectSlackMessage('1 tip · $0.01 total')
+})
+
 test('/tip jar requires the opener to be connected', async () => {
   const response = await postSlashCommand('jar for lunch')
   const tipAsks = await db

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1503,7 +1503,7 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
   await expectSlackMessage('Tip jar is closed.')
 }, 20_000) // 20 seconds
 
-test('/tip open tipjar for account sends beneficiary tip and creator fee', async () => {
+test('/tip jar for account sends beneficiary tip and creator fee', async () => {
   const connected = await connectTipAccounts({
     senderProviderUserId: Constants.slack.unconnectedUserId,
   })
@@ -1517,9 +1517,7 @@ test('/tip open tipjar for account sends beneficiary tip and creator fee', async
   })
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
-  const response = await postSlashCommand(
-    `open tipjar for <@${Constants.slack.memberUserId}> rehab`,
-  )
+  const response = await postSlashCommand(`jar for <@${Constants.slack.memberUserId}> rehab`)
   const tipAsk = await db
     .selectFrom('tip_ask')
     .selectAll()
@@ -1616,7 +1614,7 @@ test('/tip open tipjar for account sends beneficiary tip and creator fee', async
   await expectSlackMessage(`💵 <@${Constants.slack.unconnectedUserId}>`)
 })
 
-test('/tip open tipjar for unconnected account queues beneficiary tip and pays creator fee', async () => {
+test('/tip jar for unconnected account queues beneficiary tip and pays creator fee', async () => {
   const connected = await connectTipAccounts({
     recipient: false,
     senderProviderUserId: Constants.slack.memberUserId,
@@ -1631,9 +1629,7 @@ test('/tip open tipjar for unconnected account queues beneficiary tip and pays c
   })
   const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
-  const response = await postSlashCommand(
-    `open tipjar for <@${Constants.slack.unconnectedUserId}> rehab`,
-  )
+  const response = await postSlashCommand(`jar for <@${Constants.slack.unconnectedUserId}> rehab`)
   const tipAsk = await db
     .selectFrom('tip_ask')
     .selectAll()
@@ -1970,6 +1966,38 @@ test('@Tipbot mention supports jar command', async () => {
   expect(tipAsk).toEqual({ memo: 'lunch', provider_user_id: Constants.slack.adminUserId })
   await expectSlackMessage(`<@${Constants.slack.adminUserId}> opened a tip jar for lunch`)
   await expectSlackMessage('[💸 $0.001] [💵 $0.01] [💰 $0.10]')
+})
+
+test('@Tipbot mention supports jar for account command', async () => {
+  const connected = await connectTipAccounts()
+  const messageTs = `1700000030.${Nanoid.generate().slice(0, 6)}`
+
+  const response = await postSlackAppMention({
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> jar for <@${Constants.slack.memberUserId}> rehab`,
+  })
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .innerJoin('member', 'member.id', 'tip_ask.requester_member_id')
+    .select([
+      'member.provider_user_id',
+      'tip_ask.beneficiary_provider_user_id',
+      'tip_ask.creator_fee_basis_points',
+      'tip_ask.memo',
+    ])
+    .where('tip_ask.workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(tipAsk).toEqual({
+    beneficiary_provider_user_id: Constants.slack.memberUserId,
+    creator_fee_basis_points: 100,
+    memo: 'rehab',
+    provider_user_id: Constants.slack.adminUserId,
+  })
+  await expectSlackMessage(
+    `<@${Constants.slack.adminUserId}> opened a tip jar for <@${Constants.slack.memberUserId}>'s rehab`,
+  )
 })
 
 test('@Tipbot thread mention posts jar in the source thread', async () => {


### PR DESCRIPTION
## Summary
- add `/tip jar for @account [memo]` / `@Tipbot jar for @account [memo]`
- route behalf-jar tips to the beneficiary, including unconnected recipients via pending tips
- pay the jar creator a 1% fee on each successful preset tip and exclude creator fees from jar totals

## Tests
- `pnpm check`
- `pnpm check:types`
- `pnpm test src/chat.workers.test.ts -t "jar for"`
- `pnpm test`
- `pnpm test:e2e`
