### PR TITLE
fix: address tip jar review comments

### DIFF
--- a/db/migrations/0024_tip_ask_beneficiary_workspace.sql
+++ b/db/migrations/0024_tip_ask_beneficiary_workspace.sql
@@ -1,0 +1,2 @@
+-- Track Slack Connect beneficiary workspaces for jars opened on behalf of external accounts.
+ALTER TABLE "tip_ask" ADD COLUMN "beneficiary_provider_workspace_id" TEXT;

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -196,6 +196,7 @@ export const tip = z.object({
 
 export const tip_ask = z.object({
   beneficiary_provider_user_id: z.string().nullable(),
+  beneficiary_provider_workspace_id: z.string().nullable(),
   chain_id: z.number(),
   closed_at: z.string().nullable(),
   created_at: z.string(),

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -218,6 +218,7 @@ type tip = {
 
 type tip_ask = {
   beneficiary_provider_user_id: string | null
+  beneficiary_provider_workspace_id: string | null
   chain_id: number
   closed_at: string | null
   created_at: k.Generated<string>

--- a/src/api.ts
+++ b/src/api.ts
@@ -782,6 +782,22 @@ export const api = new Hono<{
           )
         else if (
           result.status === 'sent' &&
+          Chat.isTipAskIdempotencyKey(data.payload.idempotencyKey)
+        )
+          c.executionCtx.waitUntil(
+            (async () => {
+              await Chat.getChat().initialize()
+              await Chat.sendTipAskCreatorFee(data.payload.providerId, {
+                idempotencyKey: data.payload.idempotencyKey,
+              })
+              const tipAskId = Chat.getTipAskIdFromIdempotencyKey(data.payload.idempotencyKey)
+              if (tipAskId) await Chat.updateTipAskMessage(data.payload.providerId, { tipAskId })
+            })().catch((error) => {
+              console.error('Failed to settle Slack tip jar after confirmation:', error)
+            }),
+          )
+        else if (
+          result.status === 'sent' &&
           Chat.isReceiptBoostIdempotencyKey(data.payload.idempotencyKey)
         )
           c.executionCtx.waitUntil(
@@ -898,19 +914,6 @@ export const api = new Hono<{
               }
             })().catch((error) => {
               console.error('Failed to post Slack boost receipt after confirmation:', error)
-            }),
-          )
-        else if (
-          result.status === 'sent' &&
-          Chat.isTipAskIdempotencyKey(data.payload.idempotencyKey)
-        )
-          c.executionCtx.waitUntil(
-            (async () => {
-              const tipAskId = Chat.getTipAskIdFromIdempotencyKey(data.payload.idempotencyKey)
-              if (!tipAskId) return
-              await Chat.updateTipAskMessage(data.payload.providerId, { tipAskId })
-            })().catch((error) => {
-              console.error('Failed to update Slack tip jar after confirmation:', error)
             }),
           )
         else if (result.status === 'sent')

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -412,6 +412,7 @@ const actions = {
       .select([
         'requester.provider_user_id as requester_provider_user_id',
         'tip_ask.beneficiary_provider_user_id',
+        'tip_ask.beneficiary_provider_workspace_id',
         'tip_ask.chain_id',
         'tip_ask.closed_at',
         'tip_ask.creator_fee_basis_points',
@@ -442,6 +443,8 @@ const actions = {
       return
     }
 
+    const amount = tipAskAmount(tipAsk, payload.data.reaction)
+    const feeAmount = Math.floor((amount * tipAsk.creator_fee_basis_points) / 10_000)
     const tipEvent = {
       channel: getChat().channel(`slack:${tipAsk.provider_channel_id}`),
       user: event.user,
@@ -462,7 +465,10 @@ const actions = {
       ? `${idempotencyKey}:beneficiary`
       : idempotencyKey
     const result = await Tip.handleTipRequest(env, {
-      amount: tipAskAmount(tipAsk, payload.data.reaction),
+      amount,
+      ...(feeAmount > 0 && event.user.userId !== tipAsk.requester_provider_user_id
+        ? { confirmationAccessKeyLimit: amount + feeAmount }
+        : {}),
       idempotencyKey: beneficiaryIdempotencyKey,
       memo: tipAsk.memo,
       provider: 'slack',
@@ -474,6 +480,7 @@ const actions = {
       source: 'command',
       tokenAddress: tipAsk.token_address,
       workspaceProviderId: tipAsk.workspace_provider_id,
+      recipientProviderWorkspaceId: tipAsk.beneficiary_provider_workspace_id ?? undefined,
     }).catch(
       (error) =>
         ({
@@ -484,25 +491,11 @@ const actions = {
     )
 
     if (result.ok) {
-      const feeAmount = Math.floor(
-        (tipAskAmount(tipAsk, payload.data.reaction) * tipAsk.creator_fee_basis_points) / 10_000,
-      )
-      if (feeAmount > 0 && event.user.userId !== tipAsk.requester_provider_user_id)
-        await Tip.handleTipRequest(env, {
-          amount: feeAmount,
-          idempotencyKey: `${idempotencyKey}:creator_fee`,
-          memo: tipAsk.memo,
-          provider: 'slack',
-          providerChannelId: tipAsk.provider_channel_id,
-          providerId: tipAsk.provider_id,
-          recipientProviderUserId: tipAsk.requester_provider_user_id,
-          senderProviderUserId: event.user.userId,
-          source: 'command',
-          tokenAddress: tipAsk.token_address,
-          workspaceProviderId: tipAsk.workspace_provider_id,
-        }).catch((error) => {
-          console.error('Failed to send tip jar creator fee:', error)
-        })
+      await sendTipAskCreatorFee(tipAsk.provider_id, {
+        idempotencyKey,
+      }).catch((error) => {
+        console.error('Failed to send tip jar creator fee:', error)
+      })
       await updateTipAskMessage(tipAsk.provider_id, { tipAskId: tipAsk.id }).catch((error) => {
         console.error('Failed to update Slack tip jar:', error)
       })
@@ -1074,6 +1067,12 @@ const handlers = {
   },
   async jar(event, ctx) {
     const parsed = (() => {
+      const beneficiaryAfterFor = ctx.text.match(/^for\s+<@([A-Z0-9_]+)(?:\|[^>]+)?>\s*([\s\S]*)$/i)
+      if (beneficiaryAfterFor)
+        return {
+          beneficiaryProviderUserId: beneficiaryAfterFor[1]!,
+          memo: beneficiaryAfterFor[2]?.trim() || null,
+        }
       const beneficiary = ctx.text.match(/^<@([A-Z0-9_]+)(?:\|[^>]+)?>\s*(?:for\s+([\s\S]*))?$/i)
       if (beneficiary)
         return {
@@ -1143,17 +1142,51 @@ const handlers = {
 
     const installation = await getSlack().getInstallation(ctx.provider.id)
     if (!installation) return
+    const beneficiary = await (async () => {
+      if (parsed.beneficiaryProviderUserId === event.user.userId) return null
+      const conversation = await Slack.getConversationInfo({
+        apiUrl: env.SLACK_API_URL,
+        botToken: installation.botToken,
+        channelId: event.channel.id,
+        withBotToken: (botToken, fn) => getSlack().withBotToken(botToken, fn),
+      })
+      if (!conversation.isShared) return { providerUserId: parsed.beneficiaryProviderUserId }
+      const resolvedRecipient = await resolveSlackConnectRecipient(
+        ctx,
+        conversation.teamIds,
+        { recipientProviderUserId: parsed.beneficiaryProviderUserId },
+        { allowUnconnected: true },
+      )
+      if ('message' in resolvedRecipient) {
+        await postPrivateReply(
+          event,
+          event.user,
+          resolvedRecipient.message ??
+            'Tip jar not opened. Recipient could not be resolved safely.',
+        )
+        return false
+      }
+      return {
+        providerUserId:
+          resolvedRecipient.value?.recipientProviderUserId ?? parsed.beneficiaryProviderUserId,
+        providerWorkspaceId: resolvedRecipient.value?.recipientProviderWorkspaceId,
+      }
+    })()
+    if (beneficiary === false) return
     const now = new Date().toISOString()
     const tipAskId = Nanoid.generate()
+    const beneficiaryProviderUserId = beneficiary?.providerUserId ?? event.user.userId
     const tipAsk = {
       beneficiary_provider_user_id:
-        parsed.beneficiaryProviderUserId === event.user.userId
+        beneficiaryProviderUserId === event.user.userId ? null : beneficiaryProviderUserId,
+      beneficiary_provider_workspace_id:
+        beneficiaryProviderUserId === event.user.userId
           ? null
-          : parsed.beneficiaryProviderUserId,
+          : (beneficiary?.providerWorkspaceId ?? null),
       chain_id: workspace.chain_id,
       closed_at: null,
       created_at: now,
-      creator_fee_basis_points: parsed.beneficiaryProviderUserId === event.user.userId ? 0 : 100,
+      creator_fee_basis_points: beneficiaryProviderUserId === event.user.userId ? 0 : 100,
       dollar_amount: amounts.dollar,
       id: tipAskId,
       memo: parsed.memo,
@@ -3565,6 +3598,59 @@ export async function updateTipAskMessage(providerId: string, options: { tipAskI
     .set({ updated_at: new Date().toISOString() })
     .where('id', '=', tipAsk.id)
     .execute()
+}
+
+export async function sendTipAskCreatorFee(
+  providerId: string,
+  options: { idempotencyKey: string },
+) {
+  const idempotencyKey = options.idempotencyKey.replace(/:(?:beneficiary|creator_fee)$/, '')
+  const parts = idempotencyKey.split(':')
+  const reaction = z.enum(tipAskReactionNames).safeParse(parts[2])
+  const senderProviderUserId = parts[3]
+  if (parts[0] !== 'tip_ask' || !parts[1] || !reaction.success || !senderProviderUserId) return
+
+  const db = DB.create(env.DB)
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .innerJoin('workspace', 'workspace.id', 'tip_ask.workspace_id')
+    .innerJoin('member as requester', 'requester.id', 'tip_ask.requester_member_id')
+    .select([
+      'requester.provider_user_id as requester_provider_user_id',
+      'tip_ask.creator_fee_basis_points',
+      'tip_ask.dollar_amount',
+      'tip_ask.id',
+      'tip_ask.memo',
+      'tip_ask.money_with_wings_amount',
+      'tip_ask.moneybag_amount',
+      'tip_ask.provider_channel_id',
+      'tip_ask.provider_id',
+      'tip_ask.token_address',
+      'workspace.provider_id as workspace_provider_id',
+    ])
+    .where('tip_ask.id', '=', parts[1])
+    .where('tip_ask.provider_id', '=', providerId)
+    .executeTakeFirst()
+  if (!tipAsk || senderProviderUserId === tipAsk.requester_provider_user_id) return
+
+  const amount = Math.floor(
+    (tipAskAmount(tipAsk, reaction.data) * tipAsk.creator_fee_basis_points) / 10_000,
+  )
+  if (amount <= 0) return
+
+  await Tip.handleTipRequest(env, {
+    amount,
+    idempotencyKey: `${idempotencyKey}:creator_fee`,
+    memo: tipAsk.memo,
+    provider: 'slack',
+    providerChannelId: tipAsk.provider_channel_id,
+    providerId: tipAsk.provider_id,
+    recipientProviderUserId: tipAsk.requester_provider_user_id,
+    senderProviderUserId,
+    source: 'command',
+    tokenAddress: tipAsk.token_address,
+    workspaceProviderId: tipAsk.workspace_provider_id,
+  })
 }
 
 export async function updateTipRaffleMessage(providerId: string, options: { tipRaffleId: string }) {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1530,6 +1530,7 @@ test('/tip jar for account sends beneficiary tip and creator fee', async () => {
   expect(response.status).toBe(200)
   expect(tipAsk).toMatchObject({
     beneficiary_provider_user_id: Constants.slack.memberUserId,
+    beneficiary_provider_workspace_id: null,
     creator_fee_basis_points: 100,
     memo: 'rehab',
     requester_member_id: creatorMember.id,
@@ -1709,6 +1710,82 @@ test('/tip jar for unconnected account queues beneficiary tip and pays creator f
     recipient_provider_user_id: Constants.slack.adminUserId,
   })
   await expectSlackMessage('1 tip · $0.01 total')
+})
+
+test('/tip jar for account approval requests enough access key allowance for creator fee', async () => {
+  const connected = await connectTipAccounts({
+    senderProviderUserId: Constants.slack.unconnectedUserId,
+  })
+  const creatorAccount = await factory.account.insert({
+    address: '0x0000000000000000000000000000000000000103',
+  })
+  await insertMember({
+    account_id: creatorAccount.id,
+    provider_user_id: Constants.slack.adminUserId,
+    workspace_id: connected.workspace.id,
+  })
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+  const response = await postSlashCommand(`jar for <@${Constants.slack.memberUserId}> rehab`)
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .selectAll()
+    .where('workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return url.endsWith('/chat.postMessage') && params.get('text')?.includes('opened a tip jar')
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+  const dollarButton = blocks
+    .flatMap(
+      (block: { elements?: Array<{ action_id?: string; value?: string }> }) => block.elements ?? [],
+    )
+    .find((element: { action_id?: string }) => element.action_id === 'tip_ask_option_dollar')
+  const handleTipRequest = vi.spyOn(Tip, 'handleTipRequest').mockResolvedValue({
+    code: 'confirmation_required',
+    confirmUrl: `https://${env.HOST}/confirm/test-token`,
+    ok: false,
+  })
+
+  const clickResponse = await postSlackInteraction({
+    actions: [
+      {
+        action_id: 'tip_ask_option_dollar',
+        type: 'button',
+        value: dollarButton?.value,
+      },
+    ],
+    channel: { id: Constants.slack.channelId },
+    container: {
+      channel_id: Constants.slack.channelId,
+      message_ts: tipAsk.provider_message_ts,
+      type: 'message',
+    },
+    message: { ts: tipAsk.provider_message_ts },
+    team: { id: providerId },
+    trigger_id: 'tip-ask-confirmation-required-trigger',
+    type: 'block_actions',
+    user: { id: Constants.slack.unconnectedUserId, name: Constants.slack.unconnectedUserName },
+  })
+
+  expect(response.status).toBe(200)
+  expect(clickResponse.status).toBe(200)
+  expect(handleTipRequest).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      amount: 10_000,
+      confirmationAccessKeyLimit: 10_100,
+      recipientProviderUserId: Constants.slack.memberUserId,
+      senderProviderUserId: Constants.slack.unconnectedUserId,
+    }),
+  )
+  await expectSlackMessage('Tipbot needs your approval to send this payment.')
+  handleTipRequest.mockRestore()
 })
 
 test('/tip jar requires the opener to be connected', async () => {
@@ -1985,6 +2062,7 @@ test('@Tipbot mention supports jar for account command', async () => {
     .select([
       'member.provider_user_id',
       'tip_ask.beneficiary_provider_user_id',
+      'tip_ask.beneficiary_provider_workspace_id',
       'tip_ask.creator_fee_basis_points',
       'tip_ask.memo',
     ])
@@ -1994,6 +2072,7 @@ test('@Tipbot mention supports jar for account command', async () => {
   expect(response.status).toBe(200)
   expect(tipAsk).toEqual({
     beneficiary_provider_user_id: Constants.slack.memberUserId,
+    beneficiary_provider_workspace_id: null,
     creator_fee_basis_points: 100,
     memo: 'rehab',
     provider_user_id: Constants.slack.adminUserId,
@@ -2001,6 +2080,105 @@ test('@Tipbot mention supports jar for account command', async () => {
   await expectSlackMessage(
     `<@${Constants.slack.adminUserId}> opened a tip jar for <@${Constants.slack.memberUserId}>'s rehab`,
   )
+})
+
+test('@Tipbot mention jar for Slack Connect account stores beneficiary workspace and tips it', async () => {
+  await deleteSlackConnectWorkspace()
+  await Chat.getSlack().setInstallation(Constants.slackConnect.teamId, {
+    botToken: Constants.slackConnect.teamBotToken,
+    botUserId: Constants.slackConnect.teamBotUserId,
+    teamName: Constants.slackConnect.teamName,
+  })
+  const connected = await connectTipAccounts({ recipient: false })
+  const connectWorkspace = await factory.workspace.insert({
+    chain_id: Tempo.chainLookup.localnet,
+    name: Constants.slackConnect.teamName,
+    provider_id: Constants.slackConnect.teamId,
+  })
+  await insertMember({
+    account_id: connected.recipientAccount.id,
+    provider_user_id: Constants.slackConnect.userId,
+    workspace_id: connectWorkspace.id,
+  })
+  const channelId = await getSlackConnectChannelId()
+  const messageTs = `1700000030.${Nanoid.generate().slice(0, 6)}`
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  await expectSlackConnectEmulator(channelId)
+
+  const response = await postSlackAppMention({
+    channelId,
+    messageTs,
+    text: `<@${Constants.slack.botUserId}> jar for <@${Constants.slackConnect.userId}> rehab`,
+  })
+  const tipAsk = await db
+    .selectFrom('tip_ask')
+    .selectAll()
+    .where('workspace_id', '=', connected.workspace.id)
+    .executeTakeFirstOrThrow()
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return url.endsWith('/chat.postMessage') && params.get('text')?.includes('opened a tip jar')
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+  const dollarButton = blocks
+    .flatMap(
+      (block: { elements?: Array<{ action_id?: string; value?: string }> }) => block.elements ?? [],
+    )
+    .find((element: { action_id?: string }) => element.action_id === 'tip_ask_option_dollar')
+  const handleTipRequest = vi.spyOn(Tip, 'handleTipRequest').mockResolvedValue({
+    amount: '0.01',
+    chainId: connected.workspace.chain_id,
+    feePayer: 'sponsor',
+    isDefaultToken: true,
+    memo: 'rehab',
+    ok: true,
+    recipientProviderUserId: Constants.slackConnect.userId,
+    senderProviderUserId: Constants.slack.memberUserId,
+    status: 'sent',
+    tokenCurrency: 'usd',
+    tokenSymbol: 'USDC',
+    transactionHash: `0x${'1'.repeat(64)}`,
+  })
+
+  const clickResponse = await postSlackInteraction({
+    actions: [
+      {
+        action_id: 'tip_ask_option_dollar',
+        type: 'button',
+        value: dollarButton?.value,
+      },
+    ],
+    channel: { id: channelId },
+    container: {
+      channel_id: channelId,
+      message_ts: tipAsk.provider_message_ts,
+      type: 'message',
+    },
+    message: { ts: tipAsk.provider_message_ts },
+    team: { id: providerId },
+    trigger_id: 'tip-ask-slack-connect-dollar-trigger',
+    type: 'block_actions',
+    user: { id: Constants.slack.memberUserId, name: Constants.slack.memberUserName },
+  })
+
+  expect(response.status).toBe(200)
+  expect(clickResponse.status).toBe(200)
+  expect(tipAsk).toMatchObject({
+    beneficiary_provider_user_id: Constants.slackConnect.userId,
+    beneficiary_provider_workspace_id: Constants.slackConnect.teamId,
+  })
+  expect(handleTipRequest).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      recipientProviderUserId: Constants.slackConnect.userId,
+      recipientProviderWorkspaceId: Constants.slackConnect.teamId,
+    }),
+  )
+  handleTipRequest.mockRestore()
 })
 
 test('@Tipbot thread mention posts jar in the source thread', async () => {

--- a/src/lib/tip.ts
+++ b/src/lib/tip.ts
@@ -151,6 +151,7 @@ export async function handleTipRequest(
   env: Env,
   input: {
     amount?: number
+    confirmationAccessKeyLimit?: number
     idempotencyKey: string
     memo: string | null
     provider: Database.Selectable.workspace['provider']
@@ -278,9 +279,16 @@ export async function handleTipRequest(
     return { accessKey, trackedAccessKeyLimitExceeded }
   })()
   if (!accessKey)
-    return await createConfirmationRequired(env, input, executionWorkspace, amount, tokenAddress, {
-      kind: trackedAccessKeyLimitExceeded ? 'onetime_payment' : undefined,
-    })
+    return await createConfirmationRequired(
+      env,
+      input,
+      executionWorkspace,
+      amount,
+      tokenAddress,
+      input.confirmationAccessKeyLimit
+        ? { accessKeyLimit: BigInt(input.confirmationAccessKeyLimit), kind: 'reusable_access_key' }
+        : { kind: trackedAccessKeyLimitExceeded ? 'onetime_payment' : undefined },
+    )
 
   if (!recipient)
     return await createPendingTip(env, db, {


### PR DESCRIPTION
## Summary
- persist Slack Connect beneficiary workspace IDs for `jar for @account` jars and pass them into tip delivery
- keep creator fees through payment approval by requesting enough reusable access-key allowance and settling the fee after confirmation
- add coverage for Slack Connect beneficiary jars and approval allowance sizing

## Tests
- `pnpm check`
- `pnpm check:types`
- `pnpm test src/chat.workers.test.ts -t "jar for"`
- `pnpm test`
- `pnpm test:e2e`
