### PR TITLE
Add raffle bulk-buy buttons

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -603,6 +603,9 @@ const actions = {
   async tip_raffle_buy_5(event) {
     await handleTipRaffleBuy(event, { ticketCount: 5 })
   },
+  async tip_raffle_buy_25(event) {
+    await handleTipRaffleBuy(event, { ticketCount: 25 })
+  },
   async tip_raffle_buy_100(event) {
     await handleTipRaffleBuy(event, { ticketCount: 100 })
   },
@@ -2123,6 +2126,7 @@ const actionNames = [
   'tip_ask_option_moneybag',
   'tip_raffle_buy_1',
   'tip_raffle_buy_5',
+  'tip_raffle_buy_25',
   'tip_raffle_buy_100',
 ] as const
 const modalSubmitNames = ['config_edit', 'tip_raffle_create'] as const
@@ -3651,7 +3655,10 @@ export async function closeExpiredTipRaffles() {
     })
 }
 
-async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount: 1 | 5 | 100 }) {
+async function handleTipRaffleBuy(
+  event: chat.ActionEvent,
+  input: { ticketCount: 1 | 5 | 25 | 100 },
+) {
   const payload = z
     .object({
       nonce: z.string().min(1),
@@ -4071,7 +4078,7 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
       ...(tipRaffle.status === 'open'
         ? [
             {
-              elements: [1, 5, 100].map((ticketCount) => ({
+              elements: [1, 5, 25, 100].map((ticketCount) => ({
                 action_id: `tip_raffle_buy_${ticketCount}`,
                 text: {
                   emoji: true,

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -603,6 +603,9 @@ const actions = {
   async tip_raffle_buy_5(event) {
     await handleTipRaffleBuy(event, { ticketCount: 5 })
   },
+  async tip_raffle_buy_100(event) {
+    await handleTipRaffleBuy(event, { ticketCount: 100 })
+  },
   async config_edit(event) {
     const raw = z.parse(
       z.object({
@@ -2120,6 +2123,7 @@ const actionNames = [
   'tip_ask_option_moneybag',
   'tip_raffle_buy_1',
   'tip_raffle_buy_5',
+  'tip_raffle_buy_100',
 ] as const
 const modalSubmitNames = ['config_edit', 'tip_raffle_create'] as const
 const tipAskIdempotencyPrefix = 'tip_ask:'
@@ -3647,7 +3651,7 @@ export async function closeExpiredTipRaffles() {
     })
 }
 
-async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount: 1 | 5 }) {
+async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount: 1 | 5 | 100 }) {
   const payload = z
     .object({
       nonce: z.string().min(1),
@@ -4067,7 +4071,7 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
       ...(tipRaffle.status === 'open'
         ? [
             {
-              elements: [1, 5].map((ticketCount) => ({
+              elements: [1, 5, 100].map((ticketCount) => ({
                 action_id: `tip_raffle_buy_${ticketCount}`,
                 text: {
                   emoji: true,

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2059,6 +2059,7 @@ test('/tip raffle opens create modal', async () => {
 
 test('/tip raffle create modal posts raffle message', async () => {
   await connectTipAccounts()
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
   const response = await postSlackInteraction(createRaffleViewSubmissionPayload())
   const tipRaffle = await db
@@ -2077,12 +2078,30 @@ test('/tip raffle create modal posts raffle message', async () => {
   await expectSlackMessage(`<@${Constants.slack.adminUserId}> opened a raffle: team lunch`)
   await expectSlackMessage('Ticket: $0.01')
   await expectSlackMessage('Tickets: 0')
-  const history = await slack.conversations.history({ channel: Constants.slack.channelId })
-  const message = history.messages?.find((message) =>
-    message.text?.includes('opened a raffle: team lunch'),
+  await expectSlackPostMessageCall(
+    fetchSpy,
+    Constants.slack.channelId,
+    '"action_id":"tip_raffle_buy_1"',
   )
-  expect(JSON.stringify(message?.blocks)).toContain('"action_id":"tip_raffle_buy_100"')
-  expect(JSON.stringify(message?.blocks)).toContain('"text":"Buy 100"')
+  await expectSlackPostMessageCall(
+    fetchSpy,
+    Constants.slack.channelId,
+    '"action_id":"tip_raffle_buy_5"',
+  )
+  await expectSlackPostMessageCall(
+    fetchSpy,
+    Constants.slack.channelId,
+    '"action_id":"tip_raffle_buy_25"',
+  )
+  await expectSlackPostMessageCall(
+    fetchSpy,
+    Constants.slack.channelId,
+    '"action_id":"tip_raffle_buy_100"',
+  )
+  await expectSlackPostMessageCall(fetchSpy, Constants.slack.channelId, '"text":"Buy 1"')
+  await expectSlackPostMessageCall(fetchSpy, Constants.slack.channelId, '"text":"Buy 5"')
+  await expectSlackPostMessageCall(fetchSpy, Constants.slack.channelId, '"text":"Buy 25"')
+  await expectSlackPostMessageCall(fetchSpy, Constants.slack.channelId, '"text":"Buy 100"')
 })
 
 test('/tip raffle buy button records tickets and updates message', async () => {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2077,6 +2077,12 @@ test('/tip raffle create modal posts raffle message', async () => {
   await expectSlackMessage(`<@${Constants.slack.adminUserId}> opened a raffle: team lunch`)
   await expectSlackMessage('Ticket: $0.01')
   await expectSlackMessage('Tickets: 0')
+  const history = await slack.conversations.history({ channel: Constants.slack.channelId })
+  const message = history.messages?.find((message) =>
+    message.text?.includes('opened a raffle: team lunch'),
+  )
+  expect(JSON.stringify(message?.blocks)).toContain('"action_id":"tip_raffle_buy_100"')
+  expect(JSON.stringify(message?.blocks)).toContain('"text":"Buy 100"')
 })
 
 test('/tip raffle buy button records tickets and updates message', async () => {
@@ -2091,9 +2097,9 @@ test('/tip raffle buy button records tickets and updates message', async () => {
   const response = await postSlackInteraction({
     actions: [
       {
-        action_id: 'tip_raffle_buy_5',
+        action_id: 'tip_raffle_buy_100',
         type: 'button',
-        value: JSON.stringify({ nonce: 'buy-five', tipRaffleId: tipRaffle.id }),
+        value: JSON.stringify({ nonce: 'buy-one-hundred', tipRaffleId: tipRaffle.id }),
       },
     ],
     channel: { id: Constants.slack.channelId },
@@ -2104,7 +2110,7 @@ test('/tip raffle buy button records tickets and updates message', async () => {
     },
     message: { ts: tipRaffle.provider_message_ts },
     team: { id: providerId },
-    trigger_id: 'tip-raffle-buy-5-trigger',
+    trigger_id: 'tip-raffle-buy-100-trigger',
     type: 'block_actions',
     user: { id: Constants.slack.adminUserId, name: Constants.slack.adminUserName },
   })
@@ -2118,12 +2124,12 @@ test('/tip raffle buy button records tickets and updates message', async () => {
   expect(response.status).toBe(200)
   expect(ticket).toEqual({
     provider_user_id: Constants.slack.adminUserId,
-    ticket_count: 5,
+    ticket_count: 100,
   })
-  await expectSlackMessage('Pot: $0.005')
-  await expectSlackMessage('Ticket: $0.001 · Tickets: 5')
+  await expectSlackMessage('Pot: $0.10')
+  await expectSlackMessage('Ticket: $0.001 · Tickets: 100')
   const history = await slack.conversations.history({ channel: Constants.slack.channelId })
-  const message = history.messages?.find((message) => message.text?.includes('Pot: $0.005'))
+  const message = history.messages?.find((message) => message.text?.includes('Pot: $0.10'))
   expect(message?.text).toMatch(/Ends:[\s\S]*Entrants:[\s\S]*Ticket:/)
 })
 


### PR DESCRIPTION
## Summary
- add Buy 25 and Buy 100 raffle buttons to open raffle Slack messages
- route both actions through the existing raffle ticket purchase handler
- fix the worker test assertion to inspect the outbound Slack block payload instead of normalized history messages

## Validation
- pnpm check:types
- pnpm check --fix

Prompted by: @brendanjryan