### PR TITLE
Sort tip entrants by amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tanstack/router-plugin": "1.167.35",
     "accounts": "^0.14.1",
     "chat": "4.27.0",
-    "hono": "4.12.18",
+    "hono": "4.12.21",
     "kysely": "0.28.17",
     "nanoid": "^5.1.11",
     "ox": "0.14.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ catalogs:
       version: 0.1.20
 
 overrides:
+  hono: 4.12.21
   protobufjs: 7.5.8
   tar: 7.5.11
   tmp: 0.2.6
@@ -43,7 +44,7 @@ importers:
         version: 1.2.1
       '@hono/zod-validator':
         specifier: ^0.8.0
-        version: 0.8.0(hono@4.12.18)(zod@4.4.3)
+        version: 0.8.0(hono@4.12.21)(zod@4.4.3)
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.2.5)
@@ -63,8 +64,8 @@ importers:
         specifier: 4.27.0
         version: 4.27.0
       hono:
-        specifier: 4.12.18
-        version: 4.12.18
+        specifier: 4.12.21
+        version: 4.12.21
       kysely:
         specifier: 0.28.17
         version: 0.28.17
@@ -140,7 +141,7 @@ importers:
         version: 12.9.0
       emulate:
         specifier: 0.5.0
-        version: 0.5.0(patch_hash=b2fb51af97ea1d50b418f6a8216cf9423b584f2f690e7d2beec2f6e10e5ca234)(hono@4.12.18)
+        version: 0.5.0(patch_hash=b2fb51af97ea1d50b418f6a8216cf9423b584f2f690e7d2beec2f6e10e5ca234)(hono@4.12.21)
       msw:
         specifier: 2.13.6
         version: 2.13.6(@types/node@22.19.17)(typescript@6.0.3)
@@ -607,12 +608,12 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.21
 
   '@hono/zod-validator@0.8.0':
     resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
     peerDependencies:
-      hono: '>=4.10.0'
+      hono: 4.12.21
       zod: ^3.25.0 || ^4.0.0
 
   '@iconify/json@2.2.467':
@@ -2611,8 +2612,8 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   htmlparser2@10.1.0:
@@ -3052,7 +3053,7 @@ packages:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.18'
+      hono: 4.12.21
       viem: '>=2.50.4'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -4458,13 +4459,13 @@ snapshots:
       protobufjs: 7.5.8
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
-  '@hono/zod-validator@0.8.0(hono@4.12.18)(zod@4.4.3)':
+  '@hono/zod-validator@0.8.0(hono@4.12.21)(zod@4.4.3)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
       zod: 4.4.3
 
   '@iconify/json@2.2.467':
@@ -5583,10 +5584,10 @@ snapshots:
 
   accounts@0.14.1(@types/react@19.2.14)(@wagmi/core@3.4.11)(react@19.2.5)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.14):
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@6.0.3)
-      mppx: 0.6.27(hono@4.12.18)(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
+      mppx: 0.6.27(hono@4.12.21)(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3))
       ox: 0.14.20(typescript@6.0.3)(zod@4.4.3)
       webauthx: 0.1.2(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
@@ -6019,9 +6020,9 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  emulate@0.5.0(patch_hash=b2fb51af97ea1d50b418f6a8216cf9423b584f2f690e7d2beec2f6e10e5ca234)(hono@4.12.18):
+  emulate@0.5.0(patch_hash=b2fb51af97ea1d50b418f6a8216cf9423b584f2f690e7d2beec2f6e10e5ca234)(hono@4.12.21):
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       commander: 14.0.3
       picocolors: 1.1.1
       yaml: 2.8.4
@@ -6266,7 +6267,7 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -6827,14 +6828,14 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
-  mppx@0.6.27(hono@4.12.18)(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.6.27(hono@4.12.21)(typescript@6.0.3)(viem@2.50.4(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.5
       ox: 0.14.22(typescript@6.0.3)(zod@4.4.3)
       viem: 2.50.4(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      hono: 4.12.18
+      hono: 4.12.21
     transitivePeerDependencies:
       - typescript
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ minimumReleaseAgeExclude:
   - viem
 minimumReleaseAgeStrict: true
 overrides:
+  hono: 4.12.21
   protobufjs: 7.5.8
   tar: 7.5.11
   tmp: 0.2.6

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -4008,6 +4008,7 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
     ])
     .where('tip_raffle_ticket.raffle_id', '=', tipRaffle.id)
     .groupBy('buyer.provider_user_id')
+    .orderBy('ticket_count', 'desc')
     .orderBy('buyer.provider_user_id', 'asc')
     .execute()
   const ticketCount = rows.reduce((total, row) => total + Number(row.ticket_count), 0)
@@ -4146,16 +4147,27 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
   const reactionLines = tipAskReactions
     .map((reaction) => {
       const tipperCounts = new Map<string, number>()
+      const tipperAmounts = new Map<string, number>()
       for (const row of rows) {
         if (row.idempotency_key.split(':')[2] !== reaction.name) continue
         tipperCounts.set(
           row.sender_provider_user_id,
           (tipperCounts.get(row.sender_provider_user_id) ?? 0) + 1,
         )
+        tipperAmounts.set(
+          row.sender_provider_user_id,
+          (tipperAmounts.get(row.sender_provider_user_id) ?? 0) + row.amount,
+        )
       }
-      const tippers = [...tipperCounts].map(
-        ([providerUserId, count]) => `<@${providerUserId}>${count > 1 ? ` x${count}` : ''}`,
-      )
+      const tippers = [...tipperCounts]
+        .sort(([providerUserIdA, countA], [providerUserIdB, countB]) => {
+          const amountA = tipperAmounts.get(providerUserIdA) ?? 0
+          const amountB = tipperAmounts.get(providerUserIdB) ?? 0
+          if (amountA !== amountB) return amountB - amountA
+          if (countA !== countB) return countB - countA
+          return providerUserIdA.localeCompare(providerUserIdB)
+        })
+        .map(([providerUserId, count]) => `<@${providerUserId}>${count > 1 ? ` x${count}` : ''}`)
       if (!tippers.length) return null
       return `${reaction.emoji} ${tippers.join(' ')}`
     })

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1684,46 +1684,6 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
   const closeButtonPayload = JSON.parse(closeButton?.value ?? 'null') as { tipAskId: string }
   expect(closeButtonPayload).toEqual({ tipAskId: tipAsk.id })
 
-  await factory.tip.insert(
-    {
-      amount: 100_000,
-      confirmed_at: new Date().toISOString(),
-      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.adminUserId}:one`,
-      recipient_id: connected.recipientAccount.id,
-      recipient_member_id: adminMember.id,
-      sender_id: connected.recipientAccount.id,
-      sender_member_id: adminMember.id,
-      token_address: Tempo.addressLookup.pathUsd,
-      workspace_id: connected.workspace.id,
-    },
-    {
-      amount: 100_000,
-      confirmed_at: new Date().toISOString(),
-      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:one`,
-      recipient_id: connected.recipientAccount.id,
-      recipient_member_id: adminMember.id,
-      sender_id: connected.senderAccount.id,
-      sender_member_id: connected.senderMember.id,
-      token_address: Tempo.addressLookup.pathUsd,
-      workspace_id: connected.workspace.id,
-    },
-    {
-      amount: 100_000,
-      confirmed_at: new Date().toISOString(),
-      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:two`,
-      recipient_id: connected.recipientAccount.id,
-      recipient_member_id: adminMember.id,
-      sender_id: connected.senderAccount.id,
-      sender_member_id: connected.senderMember.id,
-      token_address: Tempo.addressLookup.pathUsd,
-      workspace_id: connected.workspace.id,
-    },
-  )
-  await Chat.updateTipAskMessage(providerId, { tipAskId: tipAsk.id })
-  await expectSlackMessage(
-    `💰 <@${Constants.slack.memberUserId}> x2 <@${Constants.slack.adminUserId}>`,
-  )
-
   const unauthorizedCloseResponse = await postSlackInteraction({
     actions: [
       {
@@ -1919,6 +1879,46 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
   expect(thirdClickResponse.status).toBe(200)
   expect(tipCountAfterClose.count).toBe(2)
   await expectSlackMessage('Tip jar is closed.')
+
+  await factory.tip.insert(
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.adminUserId}:one`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.recipientAccount.id,
+      sender_member_id: adminMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:one`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.senderAccount.id,
+      sender_member_id: connected.senderMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:two`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.senderAccount.id,
+      sender_member_id: connected.senderMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+  )
+  await Chat.updateTipAskMessage(providerId, { tipAskId: tipAsk.id })
+  await expectSlackMessage(
+    `💰 <@${Constants.slack.memberUserId}> x2 <@${Constants.slack.adminUserId}>`,
+  )
 }, 20_000) // 20 seconds
 
 test('/tip jar for account sends beneficiary tip and creator fee', async () => {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -1238,7 +1238,7 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
     recipient: false,
     senderProviderUserId: Constants.slack.memberUserId,
   })
-  await insertMember({
+  const adminMember = await insertMember({
     account_id: connected.recipientAccount.id,
     provider_user_id: Constants.slack.adminUserId,
     workspace_id: connected.workspace.id,
@@ -1308,6 +1308,46 @@ test('/tip jar opens a tip jar and updates totals when a preset is clicked', asy
     .find((element: { action_id?: string }) => element.action_id === 'tip_ask_close')
   const closeButtonPayload = JSON.parse(closeButton?.value ?? 'null') as { tipAskId: string }
   expect(closeButtonPayload).toEqual({ tipAskId: tipAsk.id })
+
+  await factory.tip.insert(
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.adminUserId}:one`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.recipientAccount.id,
+      sender_member_id: adminMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:one`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.senderAccount.id,
+      sender_member_id: connected.senderMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+    {
+      amount: 100_000,
+      confirmed_at: new Date().toISOString(),
+      idempotency_key: `tip_ask:${tipAsk.id}:moneybag:${Constants.slack.memberUserId}:two`,
+      recipient_id: connected.recipientAccount.id,
+      recipient_member_id: adminMember.id,
+      sender_id: connected.senderAccount.id,
+      sender_member_id: connected.senderMember.id,
+      token_address: Tempo.addressLookup.pathUsd,
+      workspace_id: connected.workspace.id,
+    },
+  )
+  await Chat.updateTipAskMessage(providerId, { tipAskId: tipAsk.id })
+  await expectSlackMessage(
+    `💰 <@${Constants.slack.memberUserId}> x2 <@${Constants.slack.adminUserId}>`,
+  )
 
   const unauthorizedCloseResponse = await postSlackInteraction({
     actions: [
@@ -2080,7 +2120,7 @@ test('/tip raffle create modal posts raffle message', async () => {
 })
 
 test('/tip raffle buy button records tickets and updates message', async () => {
-  await connectTipAccounts()
+  const connected = await connectTipAccounts()
   await postSlackInteraction(createRaffleViewSubmissionPayload({ amount: '0.001' }))
   const tipRaffle = await db
     .selectFrom('tip_raffle')
@@ -2122,8 +2162,23 @@ test('/tip raffle buy button records tickets and updates message', async () => {
   })
   await expectSlackMessage('Pot: $0.005')
   await expectSlackMessage('Ticket: $0.001 · Tickets: 5')
+  if (!connected.recipientMember) throw new Error('Expected connected recipient.')
+  await db
+    .insertInto('tip_raffle_ticket')
+    .values({
+      buyer_member_id: connected.recipientMember.id,
+      id: Nanoid.generate(),
+      idempotency_key: `test-raffle-ticket:${Nanoid.generate()}`,
+      raffle_id: tipRaffle.id,
+      ticket_count: 10,
+    })
+    .execute()
+  await Chat.updateTipRaffleMessage(providerId, { tipRaffleId: tipRaffle.id })
+  await expectSlackMessage(
+    `Entrants: <@${Constants.slack.memberUserId}> x10, <@${Constants.slack.adminUserId}> x5`,
+  )
   const history = await slack.conversations.history({ channel: Constants.slack.channelId })
-  const message = history.messages?.find((message) => message.text?.includes('Pot: $0.005'))
+  const message = history.messages?.find((message) => message.text?.includes('Pot: $0.015'))
   expect(message?.text).toMatch(/Ends:[\s\S]*Entrants:[\s\S]*Ticket:/)
 })
 


### PR DESCRIPTION
## Summary
- Sort raffle entrants by total ticket count, highest first
- Sort tip jar tippers by total donated amount within each preset, highest first
- Add worker-test coverage for both rendered orders

## Tests
- pnpm check
- pnpm check:types
- pnpm test src/chat.workers.test.ts -t "tip jar opens|tip raffle buy" *(blocked: local Tempo setup timed out minting fee payer; eth_getTransactionCount returned HTTP 400)*

Prompted by: @DaniPopes