### PR TITLE
feat: add tip jar image attachments

### DIFF
--- a/db/migrations/0025_tip_ask_image_file.sql
+++ b/db/migrations/0025_tip_ask_image_file.sql
@@ -1,0 +1,12 @@
+-- Store Slack image file references attached to tip jars.
+CREATE TABLE "tip_ask_image_file" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "tip_ask_id" TEXT NOT NULL REFERENCES "tip_ask" ("id") ON DELETE CASCADE,
+  "provider_file_id" TEXT NOT NULL,
+  "alt_text" TEXT NOT NULL,
+  "position" INTEGER NOT NULL CHECK ("position" >= 0),
+  "created_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "tip_ask_image_file_position_idx" ON "tip_ask_image_file" ("tip_ask_id", "position");

--- a/db/schemas.gen.ts
+++ b/db/schemas.gen.ts
@@ -244,6 +244,16 @@ export const tip_ask = z.object({
   workspace_id: z.string(),
 })
 
+export const tip_ask_image_file = z.object({
+  alt_text: z.string(),
+  created_at: z.string(),
+  id: z.string(),
+  position: z.number(),
+  provider_file_id: z.string(),
+  tip_ask_id: z.string(),
+  updated_at: z.string(),
+})
+
 export const tip_batch = z.object({
   amount_each: z.number(),
   created_at: z.string(),
@@ -347,6 +357,7 @@ export const db = {
   tip_airdrop: tip_airdrop,
   tip_airdrop_claim: tip_airdrop_claim,
   tip_ask: tip_ask,
+  tip_ask_image_file: tip_ask_image_file,
   tip_batch: tip_batch,
   tip_raffle: tip_raffle,
   tip_raffle_ticket: tip_raffle_ticket,

--- a/db/types.gen.ts
+++ b/db/types.gen.ts
@@ -19,6 +19,7 @@ export interface DB {
   tip_airdrop: tip_airdrop
   tip_airdrop_claim: tip_airdrop_claim
   tip_ask: tip_ask
+  tip_ask_image_file: tip_ask_image_file
   tip_batch: tip_batch
   tip_raffle: tip_raffle
   tip_raffle_ticket: tip_raffle_ticket
@@ -268,6 +269,16 @@ type tip_ask = {
   workspace_id: string
 }
 
+type tip_ask_image_file = {
+  alt_text: string
+  created_at: k.Generated<string>
+  id: string
+  position: number
+  provider_file_id: string
+  tip_ask_id: string
+  updated_at: k.Generated<string>
+}
+
 type tip_batch = {
   amount_each: number
   created_at: k.Generated<string>
@@ -364,6 +375,7 @@ export declare namespace DB {
   type tip_airdrop = k.Selectable<DB['tip_airdrop']>
   type tip_airdrop_claim = k.Selectable<DB['tip_airdrop_claim']>
   type tip_ask = k.Selectable<DB['tip_ask']>
+  type tip_ask_image_file = k.Selectable<DB['tip_ask_image_file']>
   type tip_batch = k.Selectable<DB['tip_batch']>
   type tip_raffle = k.Selectable<DB['tip_raffle']>
   type tip_raffle_ticket = k.Selectable<DB['tip_raffle_ticket']>
@@ -387,6 +399,7 @@ export declare namespace DB {
     type tip_airdrop = k.Insertable<DB['tip_airdrop']>
     type tip_airdrop_claim = k.Insertable<DB['tip_airdrop_claim']>
     type tip_ask = k.Insertable<DB['tip_ask']>
+    type tip_ask_image_file = k.Insertable<DB['tip_ask_image_file']>
     type tip_batch = k.Insertable<DB['tip_batch']>
     type tip_raffle = k.Insertable<DB['tip_raffle']>
     type tip_raffle_ticket = k.Insertable<DB['tip_raffle_ticket']>
@@ -411,6 +424,7 @@ export declare namespace DB {
     type tip_airdrop = k.Selectable<DB['tip_airdrop']>
     type tip_airdrop_claim = k.Selectable<DB['tip_airdrop_claim']>
     type tip_ask = k.Selectable<DB['tip_ask']>
+    type tip_ask_image_file = k.Selectable<DB['tip_ask_image_file']>
     type tip_batch = k.Selectable<DB['tip_batch']>
     type tip_raffle = k.Selectable<DB['tip_raffle']>
     type tip_raffle_ticket = k.Selectable<DB['tip_raffle_ticket']>
@@ -435,6 +449,7 @@ export declare namespace DB {
     type tip_airdrop = k.Updateable<DB['tip_airdrop']>
     type tip_airdrop_claim = k.Updateable<DB['tip_airdrop_claim']>
     type tip_ask = k.Updateable<DB['tip_ask']>
+    type tip_ask_image_file = k.Updateable<DB['tip_ask_image_file']>
     type tip_batch = k.Updateable<DB['tip_batch']>
     type tip_raffle = k.Updateable<DB['tip_raffle']>
     type tip_raffle_ticket = k.Updateable<DB['tip_raffle_ticket']>

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -63,6 +63,17 @@ export function getChat() {
           .optional(),
         channel: z.string().min(1),
         context_team_id: z.string().min(1).nullable().optional(),
+        files: z
+          .array(
+            z.object({
+              filetype: z.string().optional(),
+              id: z.string().min(1).optional(),
+              mimetype: z.string().optional(),
+              name: z.string().optional(),
+              title: z.string().optional(),
+            }),
+          )
+          .optional(),
         subtype: z.string().min(1).optional(),
         team: z.string().min(1).optional(),
         team_id: z.string().min(1).optional(),
@@ -74,7 +85,8 @@ export function getChat() {
       }),
       message.raw,
     )
-    if (raw.subtype && !['reply_broadcast', 'thread_broadcast'].includes(raw.subtype)) return
+    if (raw.subtype && !['file_share', 'reply_broadcast', 'thread_broadcast'].includes(raw.subtype))
+      return
 
     const providerId = (() => {
       const mentioned = new Set(
@@ -199,6 +211,7 @@ export function getChat() {
       provider: { id: providerId, type: 'slack' },
       text: Slack.parseMentionTipText(mentionText) ?? '',
       threadTs: privateThreadTs,
+      tipAskImageFiles: slackTipAskImageFiles(raw.files),
     } satisfies HandlerContext
 
     if (mentionText.toLowerCase() === 'introduce yourself') {
@@ -1571,6 +1584,7 @@ const handlers = {
     } satisfies DB_gen.Insertable.tip_ask
     const message = await tipAskMessage(ctx.db, {
       ...tipAsk,
+      image_files: ctx.tipAskImageFiles ?? [],
       requester_provider_user_id: event.user.userId,
       workspace_default_token_address: workspace.default_token_address,
     })
@@ -1601,6 +1615,19 @@ const handlers = {
       .insertInto('tip_ask')
       .values({ ...tipAsk, provider_message_ts: json.ts })
       .execute()
+    if (ctx.tipAskImageFiles?.length)
+      await ctx.db
+        .insertInto('tip_ask_image_file')
+        .values(
+          ctx.tipAskImageFiles.map((imageFile, position) => ({
+            alt_text: imageFile.alt_text,
+            id: Nanoid.generate(),
+            position,
+            provider_file_id: imageFile.provider_file_id,
+            tip_ask_id: tipAskId,
+          })),
+        )
+        .execute()
     await postSlackEphemeral(
       ctx.provider.id,
       Slack.getChannelId(event.channel.id),
@@ -2529,6 +2556,7 @@ const modalSubmitNames = ['config_edit', 'tip_airdrop_create', 'tip_raffle_creat
 const tipAskIdempotencyPrefix = 'tip_ask:'
 const tipRaffleIdempotencyPrefix = 'tip_raffle:'
 const tipAskReactionNames = ['money_with_wings', 'dollar', 'moneybag'] as const
+const tipAskImageFileLimit = 5
 const tipAskReactions = [
   { emoji: '💸', name: 'money_with_wings' },
   { emoji: '💵', name: 'dollar' },
@@ -2573,6 +2601,7 @@ type HandlerContext = {
   settingsProviderId?: string
   text: string
   threadTs?: string
+  tipAskImageFiles?: TipAskImageFile[]
 }
 
 type ProviderContext = { id: string; type: 'slack' }
@@ -2607,9 +2636,12 @@ type TipAskMessageInput = Pick<
   | 'token_address'
   | 'chain_id'
 > & {
+  image_files: TipAskImageFile[]
   requester_provider_user_id: string
   workspace_default_token_address: string | null
 }
+
+type TipAskImageFile = Pick<DB_gen.Selectable.tip_ask_image_file, 'alt_text' | 'provider_file_id'>
 
 type TipAirdropMessageInput = Pick<
   DB_gen.Selectable.tip_airdrop,
@@ -3987,7 +4019,13 @@ export async function updateTipAskMessage(providerId: string, options: { tipAskI
   const installation = await getSlack().getInstallation(providerId)
   if (!installation) return
 
-  const message = await tipAskMessage(db, tipAsk)
+  const imageFiles = await db
+    .selectFrom('tip_ask_image_file')
+    .select(['alt_text', 'provider_file_id'])
+    .where('tip_ask_id', '=', tipAsk.id)
+    .orderBy('position', 'asc')
+    .execute()
+  const message = await tipAskMessage(db, { ...tipAsk, image_files: imageFiles })
   const body = new URLSearchParams()
   body.set('blocks', JSON.stringify(message.blocks))
   body.set('channel', tipAsk.provider_channel_id)
@@ -5021,6 +5059,11 @@ async function tipAskMessage(db: DB.Type, tipAsk: TipAskMessageInput) {
         },
         type: 'section',
       },
+      ...tipAsk.image_files.map((imageFile) => ({
+        alt_text: imageFile.alt_text,
+        slack_file: { id: imageFile.provider_file_id },
+        type: 'image',
+      })),
       ...(tipAsk.closed_at
         ? []
         : [
@@ -7362,6 +7405,30 @@ function configToken(workspace: DB_gen.Selectable.workspace) {
   return Tempo.getTokenMetadataFallback(
     workspace.default_token_address ?? Tempo.addressLookup.pathUsd,
   )
+}
+
+function slackTipAskImageFiles(
+  files:
+    | Array<{
+        filetype?: string
+        id?: string
+        mimetype?: string
+        name?: string
+        title?: string
+      }>
+    | undefined,
+) {
+  return (files ?? [])
+    .filter((file) => {
+      if (!file.id) return false
+      if (['gif', 'jpeg', 'jpg', 'png'].includes(file.filetype ?? '')) return true
+      return ['image/gif', 'image/jpeg', 'image/png'].includes(file.mimetype ?? '')
+    })
+    .slice(0, tipAskImageFileLimit)
+    .map((file) => ({
+      alt_text: (file.title || file.name || 'Tip jar image').slice(0, 2000),
+      provider_file_id: file.id!,
+    }))
 }
 
 function workspaceTokenOptions(chainId?: number) {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2386,6 +2386,63 @@ test('@Tipbot mention supports jar command', async () => {
   await expectSlackMessage('[💸 $0.001] [💵 $0.01] [💰 $0.10]')
 })
 
+test('@Tipbot mention adds original message images to tip jars', async () => {
+  await connectTipAccounts()
+  const messageTs = `1700000029.${Nanoid.generate().slice(0, 6)}`
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+  const response = await postSlackAppMention({
+    files: [
+      {
+        filetype: 'png',
+        id: 'Ftipjarimage',
+        mimetype: 'image/png',
+        title: 'Jar photo',
+      },
+      {
+        filetype: 'pdf',
+        id: 'Fnotimage',
+        mimetype: 'application/pdf',
+        title: 'Not image',
+      },
+    ],
+    messageTs,
+    subtype: 'file_share',
+    text: `<@${Constants.slack.botUserId}> jar for lunch`,
+  })
+  const imageFiles = await db
+    .selectFrom('tip_ask_image_file')
+    .select(['alt_text', 'position', 'provider_file_id', 'tip_ask_id'])
+    .execute()
+  const tipAskPostMessageCall = fetchSpy.mock.calls.find((call) => {
+    const input = call[0]
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const params = slackFetchBodyParams(call[1]?.body)
+    return (
+      url.endsWith('/chat.postMessage') &&
+      params.get('text')?.includes(`<@${Constants.slack.adminUserId}> opened a tip jar for lunch`)
+    )
+  })
+  const blocks = JSON.parse(
+    slackFetchBodyParams(tipAskPostMessageCall?.[1]?.body).get('blocks') ?? '[]',
+  )
+
+  expect(response.status).toBe(200)
+  expect(imageFiles).toEqual([
+    {
+      alt_text: 'Jar photo',
+      position: 0,
+      provider_file_id: 'Ftipjarimage',
+      tip_ask_id: expect.any(String),
+    },
+  ])
+  expect(blocks).toContainEqual({
+    alt_text: 'Jar photo',
+    slack_file: { id: 'Ftipjarimage' },
+    type: 'image',
+  })
+})
+
 test('@Tipbot mention supports airdrop command', async () => {
   await connectTipAccounts()
   const messageTs = `1700000029.${Nanoid.generate().slice(0, 6)}`
@@ -8893,6 +8950,13 @@ async function postSlackAppMention(options: {
   channelId?: string
   contextTeamId?: string
   eventId?: string
+  files?: Array<{
+    filetype?: string
+    id?: string
+    mimetype?: string
+    name?: string
+    title?: string
+  }>
   messageTs: string
   subtype?: string
   teamId?: string
@@ -8908,6 +8972,7 @@ async function postSlackAppMention(options: {
       channel_type: 'channel',
       ...(options.contextTeamId ? { context_team_id: options.contextTeamId } : {}),
       event_ts: options.messageTs,
+      ...(options.files ? { files: options.files } : {}),
       ...(options.subtype ? { subtype: options.subtype } : {}),
       team: options.teamId ?? providerId,
       text: options.text,


### PR DESCRIPTION
## Summary
- capture image files from Slack app mention jar commands, including file_share messages
- persist tip jar image file refs and render them as Slack Block Kit image blocks
- keep images attached when tip jar messages update

## Tests
- pnpm check
- pnpm check:types
- pnpm test