### PR TITLE
Keep funded airdrops open past expiry

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -478,13 +478,20 @@ const actions = {
     }
 
     const remainingAmount = tipAirdrop.total_amount - tipAirdrop.claimed_amount
-    if (
-      tipAirdrop.status !== 'open' ||
-      Date.parse(tipAirdrop.ends_at) <= Date.now() ||
-      remainingAmount <= 0
-    ) {
+    if (tipAirdrop.status !== 'open' || remainingAmount <= 0) {
       await closeAirdrop()
       return
+    }
+    if (Date.parse(tipAirdrop.ends_at) <= Date.now()) {
+      const endsAt = new Date(Date.now() + airdropExpiryExtensionMs).toISOString()
+      await ctx.db
+        .updateTable('tip_airdrop')
+        .set({ ends_at: endsAt, updated_at: new Date().toISOString() })
+        .where('id', '=', tipAirdrop.id)
+        .where('status', '=', 'open')
+        .whereRef('claimed_amount', '<', 'total_amount')
+        .execute()
+      tipAirdrop.ends_at = endsAt
     }
 
     const recipient = await getConnectedSlackMember(
@@ -540,10 +547,10 @@ const actions = {
         claimed_amount: sql<number>`min("total_amount", "claimed_amount" + ${amount})`,
         ended_at: sql<
           string | null
-        >`case when "claimed_amount" + ${amount} >= "total_amount" then ${now} else null end`,
+        >`case when min("total_amount", "claimed_amount" + ${amount}) >= "total_amount" then ${now} else null end`,
         status: sql<
           DB_gen.Selectable.tip_airdrop['status']
-        >`case when "claimed_amount" + ${amount} >= "total_amount" then 'ended' else 'open' end`,
+        >`case when min("total_amount", "claimed_amount" + ${amount}) >= "total_amount" then 'ended' else 'open' end`,
         updated_at: now,
       })
       .where('id', '=', tipAirdrop.id)
@@ -5719,7 +5726,14 @@ export async function closeExpiredTipAirdrops() {
   const db = DB.create(env.DB)
   const rows = await db
     .selectFrom('tip_airdrop')
-    .select(['id', 'provider_channel_id', 'provider_id', 'provider_message_ts'])
+    .select([
+      'claimed_amount',
+      'id',
+      'provider_channel_id',
+      'provider_id',
+      'provider_message_ts',
+      'total_amount',
+    ])
     .where('status', '=', 'open')
     .where('ends_at', '<=', new Date().toISOString())
     .orderBy('ends_at', 'asc')
@@ -5727,6 +5741,35 @@ export async function closeExpiredTipAirdrops() {
     .execute()
   for (const row of rows) {
     const now = new Date().toISOString()
+    if (row.claimed_amount < row.total_amount) {
+      await db
+        .updateTable('tip_airdrop')
+        .set({
+          ends_at: new Date(Date.now() + airdropExpiryExtensionMs).toISOString(),
+          updated_at: now,
+        })
+        .where('id', '=', row.id)
+        .where('status', '=', 'open')
+        .whereRef('claimed_amount', '<', 'total_amount')
+        .execute()
+      await updateAirdropMessage(
+        row.provider_id,
+        row.provider_channel_id,
+        row.provider_message_ts,
+        row.id,
+      ).catch(async (error) => {
+        if ((error as { code?: unknown }).code !== 'message_not_found') {
+          console.error('Failed to update extended airdrop message:', row.id, error)
+          return
+        }
+        await db
+          .updateTable('tip_airdrop')
+          .set({ updated_at: new Date().toISOString() })
+          .where('id', '=', row.id)
+          .execute()
+      })
+      continue
+    }
     await db
       .updateTable('tip_airdrop')
       .set({ ended_at: now, status: 'ended', updated_at: now })
@@ -5779,6 +5822,7 @@ export async function closeExpiredTipAirdrops() {
 }
 
 const airdropClaimAmount = 10_000 // $0.01
+const airdropExpiryExtensionMs = 5 * 60 * 1000 // 5 minutes
 
 async function tipAirdropMessage(db: DB.Type, input: TipAirdropMessageInput | string) {
   const tipAirdrop =

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -301,7 +301,7 @@ test('/tip airdrop claim prompts unconnected claimers to connect', async () => {
   await expectSlackMessage('Link expires in 10 minutes.')
 })
 
-test('/tip airdrop claim fails after the airdrop ends even with pot remaining', async () => {
+test('/tip airdrop claim extends an expired airdrop with pot remaining', async () => {
   await connectTipAccounts()
   await postSlackInteraction(createAirdropViewSubmissionPayload())
   const tipAirdrop = await db
@@ -323,23 +323,24 @@ test('/tip airdrop claim fails after the airdrop ends even with pot remaining', 
   )
   const tips = await db
     .selectFrom('tip')
-    .select('id')
+    .select(['amount', 'id'])
     .where('idempotency_key', 'like', `tip_airdrop:${tipAirdrop.id}:claim:%`)
     .execute()
   const updatedAirdrop = await db
     .selectFrom('tip_airdrop')
-    .select(['claimed_amount', 'status'])
+    .select(['claimed_amount', 'ended_at', 'ends_at', 'status'])
     .where('id', '=', tipAirdrop.id)
     .executeTakeFirstOrThrow()
 
   expect(clickResponse.status).toBe(200)
-  expect(tips).toEqual([])
-  expect(updatedAirdrop).toEqual({ claimed_amount: 0, status: 'ended' })
-  await expectSlackMessage('Ended · Pot: $0.02 left of $0.02')
+  expect(tips).toEqual([expect.objectContaining({ amount: 10_000 })])
+  expect(updatedAirdrop).toMatchObject({ claimed_amount: 10_000, ended_at: null, status: 'open' })
+  expect(new Date(updatedAirdrop.ends_at).getTime()).toBeGreaterThan(Date.now() + 4 * 60 * 1000) // 4 minutes
+  await expectSlackMessage('Pot: $0.01 left of $0.02')
   await expectSlackMessageNotContaining('Not eligible for airdrop. Sorry :(')
 })
 
-test('/tip airdrop cron closes expired airdrop and updates message', async () => {
+test('/tip airdrop cron extends expired airdrop with pot remaining', async () => {
   await connectTipAccounts()
   await postSlackInteraction(createAirdropViewSubmissionPayload())
   const tipAirdrop = await db
@@ -358,7 +359,7 @@ test('/tip airdrop cron closes expired airdrop and updates message', async () =>
   await waitOnExecutionContext(ctx)
   const updatedAirdrop = await db
     .selectFrom('tip_airdrop')
-    .select(['ended_at', 'status', 'updated_at'])
+    .select(['ended_at', 'ends_at', 'status'])
     .where('id', '=', tipAirdrop.id)
     .executeTakeFirstOrThrow()
   const history = await slack.conversations.history({ channel: Constants.slack.channelId })
@@ -368,12 +369,13 @@ test('/tip airdrop cron closes expired airdrop and updates message', async () =>
   )
   const messageJson = JSON.stringify(message)
 
-  expect(updatedAirdrop.status).toBe('ended')
-  expect(updatedAirdrop.ended_at).toEqual(expect.any(String))
-  expect(updatedAirdrop.updated_at).not.toBe(updatedAirdrop.ended_at)
-  expect(actionBlocks).toEqual([])
-  expect(messageJson).not.toContain('Claim while supplies last!')
-  await expectSlackMessage('Ended · Pot: $0.02 left of $0.02')
+  expect(updatedAirdrop.status).toBe('open')
+  expect(updatedAirdrop.ended_at).toBeNull()
+  expect(new Date(updatedAirdrop.ends_at).getTime()).toBeGreaterThan(Date.now() + 4 * 60 * 1000) // 4 minutes
+  expect(actionBlocks).toHaveLength(1)
+  expect(messageJson).toContain('Claim while supplies last!')
+  await expectSlackMessage('Pot: $0.02 left of $0.02')
+  await expectSlackMessageNotContaining('Ended · Pot: $0.02 left of $0.02')
 })
 
 test('/tip airdrop create modal uses selected duration', async () => {


### PR DESCRIPTION
## Summary
- Keep airdrops open when the timer expires but funded pot remains by extending ends_at 5 minutes.
- Let claim clicks after expiry proceed when there is still pot left, instead of closing the airdrop as ended.
- Keep the depleted-pot path ending immediately, and base the ended transition on the capped claimed amount.
- Update worker tests for expired-with-pot claim and cron behavior.

## Tests
- PASS: PATH=/home/agent/.local/bin:$PATH corepack pnpm check
- PASS: pre-commit staged checks (vp check --fix, pnpm check:types)
- BLOCKED: PATH=/home/agent/.local/bin:$PATH corepack pnpm test src/chat.workers.test.ts -- --runInBand did not reach tests because local Tempo setup timed out minting the fee payer with HTTP 400 from eth_getTransactionCount.