### PR TITLE
Fix Twitter tip verb amount parsing

### DIFF
--- a/src/api.workers.test.ts
+++ b/src/api.workers.test.ts
@@ -206,6 +206,29 @@ describe('/api/chat/twitter', () => {
     })
   })
 
+  test('parses Twitter tip verb before recipient amount', async () => {
+    server.use(
+      mswHttp.get('https://api.twitter.com/2/users/by/username/christopherwxyz', () =>
+        HttpResponse.json({ data: { id: '200', username: 'christopherwxyz' } }),
+      ),
+    )
+
+    await expect(
+      Twitter.parseTwitterTip(env, {
+        authorHandle: 'itokenize',
+        authorId: '100',
+        id: 'tweet-parse-tip-verb',
+        text: '@tipbotgg tip @christopherwxyz $1 for this demo :saluting_face:',
+      }),
+    ).resolves.toEqual({
+      amount: 1_000_000,
+      memo: 'this demo :saluting_face:',
+      ok: true,
+      recipients: [{ recipientProviderLabel: '@christopherwxyz', recipientProviderUserId: '200' }],
+      tokenAddress: null,
+    })
+  })
+
   test('real v2 Twitter webhook payload sends a tip for connected X accounts', async () => {
     const senderProviderUserId = twitterProviderUserId()
     const recipientProviderUserId = twitterProviderUserId()

--- a/src/lib/twitter.test.ts
+++ b/src/lib/twitter.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import * as Tempo from '#/lib/tempo.ts'
-import { formatTwitterReceiptText, parseWebhookTweets } from '#/lib/twitter.ts'
+import { formatTwitterReceiptText, parseWebhookTweets, stripTwitterTipVerb } from '#/lib/twitter.ts'
 
 test('parses simple Twitter webhook test payload', () => {
   expect(
@@ -131,4 +131,12 @@ test('formats Twitter receipt reply like Slack without sentence-ending period', 
   ).toBe(
     `@bob tipped @alice $1\nReceipt: ${Tempo.formatTxLink(Tempo.chainLookup.testnet, transactionHash)}`,
   )
+})
+
+test('strips Twitter tip verb only before explicit amounts', () => {
+  expect(stripTwitterTipVerb('tip $1 for this demo :saluting_face:')).toBe(
+    '$1 for this demo :saluting_face:',
+  )
+  expect(stripTwitterTipVerb('send .25 for coffee')).toBe('.25 for coffee')
+  expect(stripTwitterTipVerb('tip jar for coffee')).toBe('tip jar for coffee')
 })

--- a/src/lib/twitter.ts
+++ b/src/lib/twitter.ts
@@ -1076,7 +1076,7 @@ export async function parseTwitterTip(env: Env, input: TwitterTweetInput) {
       new RegExp(`(^|[^\\p{L}\\p{N}_])@${escapeRegex(handle)}\\b`, 'giu'),
       '$1',
     )
-  remaining = remaining.trim()
+  remaining = stripTwitterTipVerb(remaining.trim())
   if (!uniqueHandles.length && !remaining) return null
 
   const parsed = Tip.parseTipBatchText(
@@ -1097,6 +1097,10 @@ export async function parseTwitterTip(env: Env, input: TwitterTweetInput) {
     recipients: parsed.recipients,
     tokenAddress,
   }
+}
+
+export function stripTwitterTipVerb(value: string) {
+  return value.replace(/^(?:tip|send)\s+(?=\$?(?:\d|\.\d))/i, '')
 }
 
 async function resolveTwitterTipRecipients(env: Env, recipients: Tip.TipRecipientInput[]) {


### PR DESCRIPTION
## Summary
- Strip a leading Twitter `tip`/`send` verb when it appears before an explicit amount after handles are removed.
- Add regression coverage for `@tipbotgg tip @christopherwxyz $1 ...` so it parses as `$1` instead of defaulting to `$0.01` with `tip $1` as memo.

## Tests
- `./node_modules/.bin/vp test src/lib/twitter.test.ts`
- `./node_modules/.bin/vp test src/api.workers.test.ts` *(blocked in local worker setup: timed out minting fee payer; Tempo RPC returned 400 for `eth_getTransactionCount`)*

Prompted by: @tmm