### PR TITLE
Add raffle tipets for others

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -780,6 +780,9 @@ const actions = {
   async tip_raffle_buy_5(event) {
     await handleTipRaffleBuy(event, { ticketCount: 5 })
   },
+  async tip_raffle_buy_for(event) {
+    await openTipRaffleBuyForModal(event)
+  },
   async config_edit(event) {
     const raw = z.parse(
       z.object({
@@ -1222,6 +1225,23 @@ const modalSubmits = {
       .values({ ...tipRaffle, provider_message_ts: json.ts })
       .execute()
   },
+  async tip_raffle_buy_for(event) {
+    const metadata = z.parse(
+      z.object({
+        tipRaffleId: z.string().min(1),
+      }),
+      JSON.parse(event.privateMetadata ?? '{}'),
+    )
+    const ticketCount = event.values.ticket_count === '5' ? 5 : 1
+    const recipientProviderUserId = event.values.recipient
+    if (!recipientProviderUserId)
+      return { action: 'errors' as const, errors: { recipient: 'Choose a recipient.' } }
+    await handleTipRaffleBuy(event, {
+      recipientProviderUserId,
+      ticketCount,
+      tipRaffleId: metadata.tipRaffleId,
+    })
+  },
   async config_edit(event) {
     const metadata = z.parse(
       z.object({
@@ -1465,7 +1485,7 @@ const handlers = {
           chat.TextInput({
             id: 'ticket_amount',
             initialValue: '0.01',
-            label: `Ticket price (${token.symbol})`,
+            label: `Tipet price (${token.symbol})`,
             placeholder: '0.01',
           }),
           chat.Select({
@@ -2551,8 +2571,14 @@ const actionNames = [
   'tip_ask_option_moneybag',
   'tip_raffle_buy_1',
   'tip_raffle_buy_5',
+  'tip_raffle_buy_for',
 ] as const
-const modalSubmitNames = ['config_edit', 'tip_airdrop_create', 'tip_raffle_create'] as const
+const modalSubmitNames = [
+  'config_edit',
+  'tip_airdrop_create',
+  'tip_raffle_buy_for',
+  'tip_raffle_create',
+] as const
 const tipAskIdempotencyPrefix = 'tip_ask:'
 const tipRaffleIdempotencyPrefix = 'tip_raffle:'
 const tipAskReactionNames = ['money_with_wings', 'dollar', 'moneybag'] as const
@@ -4135,7 +4161,7 @@ export async function closeExpiredTipRaffles() {
     })
 }
 
-async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount: 1 | 5 }) {
+function tipRaffleActionPayload(event: chat.ActionEvent) {
   const payload = z
     .object({
       nonce: z.string().min(1),
@@ -4150,11 +4176,85 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
         }
       })(),
     )
-  if (!payload.success) return
+  return payload.success ? payload.data : null
+}
+
+async function openTipRaffleBuyForModal(event: chat.ActionEvent) {
+  const payload = tipRaffleActionPayload(event)
+  if (!payload) return
 
   const raw = z.parse(
     z.object({
-      channel: z.object({ id: z.string().min(1) }),
+      team: z.object({ id: z.string().min(1) }),
+      trigger_id: z.string().min(1),
+    }),
+    event.raw,
+  )
+  const installation = await getSlack().getInstallation(raw.team.id)
+  if (!installation) return
+
+  const body = new URLSearchParams()
+  body.set('trigger_id', raw.trigger_id)
+  body.set(
+    'view',
+    JSON.stringify({
+      blocks: [
+        {
+          block_id: 'recipient',
+          element: { action_id: 'recipient', type: 'users_select' },
+          label: { text: 'Recipient', type: 'plain_text' },
+          type: 'input',
+        },
+        {
+          block_id: 'ticket_count',
+          element: {
+            action_id: 'ticket_count',
+            initial_option: { text: { text: '1 tipet', type: 'plain_text' }, value: '1' },
+            options: [
+              { text: { text: '1 tipet', type: 'plain_text' }, value: '1' },
+              { text: { text: '5 tipets', type: 'plain_text' }, value: '5' },
+            ],
+            type: 'static_select',
+          },
+          label: { text: 'Tipets', type: 'plain_text' },
+          type: 'input',
+        },
+      ],
+      callback_id: 'tip_raffle_buy_for',
+      private_metadata: JSON.stringify({ tipRaffleId: payload.tipRaffleId }),
+      submit: { text: 'Buy tipets', type: 'plain_text' },
+      title: { text: 'Buy tipets', type: 'plain_text' },
+      type: 'modal',
+    }),
+  )
+  const response = await getSlack().withBotToken(installation.botToken, () =>
+    fetch(`${env.SLACK_API_URL}/views.open`, {
+      body,
+      headers: { authorization: `Bearer ${installation.botToken}` },
+      method: 'POST',
+    }),
+  )
+  const json = z.parse(
+    z.object({
+      error: z.string().optional(),
+      ok: z.boolean().optional(),
+    }),
+    await response.json(),
+  )
+  if (!json.ok) throw Slack.slackApiError('views.open', json.error)
+}
+
+async function handleTipRaffleBuy(
+  event: chat.ActionEvent | chat.ModalSubmitEvent,
+  input: { recipientProviderUserId?: string; ticketCount: 1 | 5; tipRaffleId?: string },
+) {
+  const payload = 'value' in event ? tipRaffleActionPayload(event) : null
+  const tipRaffleId = input.tipRaffleId ?? payload?.tipRaffleId
+  if (!tipRaffleId) return
+
+  const raw = z.parse(
+    z.object({
+      channel: z.object({ id: z.string().min(1) }).optional(),
       team: z.object({ id: z.string().min(1) }),
     }),
     event.raw,
@@ -4176,7 +4276,7 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
       'workspace.id as workspace_id',
       'workspace.provider_id as workspace_provider_id',
     ])
-    .where('tip_raffle.id', '=', payload.data.tipRaffleId)
+    .where('tip_raffle.id', '=', tipRaffleId)
     .where('tip_raffle.provider_id', '=', raw.team.id)
     .executeTakeFirst()
   if (!tipRaffle) return
@@ -4184,14 +4284,15 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
     await closeTipRaffle(db, tipRaffle.id, tipRaffle.provider_id)
     await postSlackEphemeral(
       tipRaffle.provider_id,
-      raw.channel.id,
+      raw.channel?.id ?? tipRaffle.provider_channel_id,
       event.user.userId,
       'Raffle ended.',
     )
     return
   }
 
-  const ticketLockKey = `${tipRaffleIdempotencyPrefix}${tipRaffle.id}:ticket:${event.user.userId}:sending`
+  const recipientProviderUserId = input.recipientProviderUserId ?? event.user.userId
+  const ticketLockKey = `${tipRaffleIdempotencyPrefix}${tipRaffle.id}:ticket:${event.user.userId}:${recipientProviderUserId}:sending`
   const ticketLockTtlMs = 2 * 60 * 1000 // 2 minutes
   if (!(await getChat().getState().setIfNotExists(ticketLockKey, true, ticketLockTtlMs))) return
   try {
@@ -4224,22 +4325,34 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
       }
       await postSlackEphemeral(
         tipRaffle.provider_id,
-        raw.channel.id,
+        raw.channel?.id ?? tipRaffle.provider_channel_id,
         event.user.userId,
         accessKey.code === 'insufficient_funds'
-          ? 'Ticket not bought. Your wallet has insufficient funds.'
-          : 'Ticket not bought. Try again.',
+          ? 'Tipets not bought. Your wallet has insufficient funds.'
+          : 'Tipets not bought. Try again.',
       )
       return
     }
-    const buyerMemberId = accessKey.memberId
-    if (!buyerMemberId) return
+    const buyerMember = await getConnectedSlackMember(
+      db,
+      tipRaffle.workspace_id,
+      recipientProviderUserId,
+    )
+    if (!buyerMember) {
+      await postSlackEphemeral(
+        tipRaffle.provider_id,
+        raw.channel?.id ?? tipRaffle.provider_channel_id,
+        event.user.userId,
+        'Tipets not bought. The recipient needs to connect to Tipbot first.',
+      )
+      return
+    }
     const escrowMember = await ensureTipRaffleEscrowMember(db, {
       chainId: tipRaffle.chain_id,
       providerId: tipRaffle.provider_id,
       workspaceId: tipRaffle.workspace_id,
     })
-    const ticketIdempotencyKey = `${tipRaffleIdempotencyPrefix}${tipRaffle.id}:ticket:${event.user.userId}:${slackActionInteractionId(event) ?? payload.data.nonce}`
+    const ticketIdempotencyKey = `${tipRaffleIdempotencyPrefix}${tipRaffle.id}:ticket:${event.user.userId}:${recipientProviderUserId}:${slackActionInteractionId(event) ?? payload?.nonce ?? Nanoid.generate()}`
     const result = await Tip.handleTipRequest(env, {
       amount: input.ticketCount * tipRaffle.ticket_amount,
       chainId: tipRaffle.chain_id,
@@ -4292,11 +4405,11 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
       if (result.code === 'pending') return
       await postSlackEphemeral(
         tipRaffle.provider_id,
-        raw.channel.id,
+        raw.channel?.id ?? tipRaffle.provider_channel_id,
         event.user.userId,
         result.code === 'insufficient_funds'
-          ? 'Ticket not bought. Your wallet has insufficient funds.'
-          : 'Ticket not bought. Try again.',
+          ? 'Tipets not bought. Your wallet has insufficient funds.'
+          : 'Tipets not bought. Try again.',
       )
       return
     }
@@ -4304,7 +4417,7 @@ async function handleTipRaffleBuy(event: chat.ActionEvent, input: { ticketCount:
     await db
       .insertInto('tip_raffle_ticket')
       .values({
-        buyer_member_id: buyerMemberId,
+        buyer_member_id: buyerMember.memberId,
         created_at: new Date().toISOString(),
         id: Nanoid.generate(),
         idempotency_key: ticketIdempotencyKey,
@@ -4818,14 +4931,15 @@ function tipAskIdempotencyKey(input: {
   return `${tipAskIdempotencyPrefix}${input.tipAskId}:${input.reaction}:${input.providerUserId}${input.interactionId ? `:${input.interactionId}` : input.nonce ? `:${input.nonce}` : ''}`
 }
 
-function slackActionInteractionId(event: chat.ActionEvent) {
+function slackActionInteractionId(event: chat.ActionEvent | chat.ModalSubmitEvent) {
   const raw = z
     .looseObject({
       actions: z.array(z.looseObject({ action_ts: z.string().min(1).optional() })).optional(),
       trigger_id: z.string().min(1).optional(),
+      view: z.looseObject({ id: z.string().min(1).optional() }).optional(),
     })
     .safeParse(event.raw)
-  return event.triggerId ?? raw.data?.trigger_id ?? raw.data?.actions?.[0]?.action_ts
+  return event.triggerId ?? raw.data?.trigger_id ?? raw.data?.actions?.[0]?.action_ts ?? raw.data?.view?.id
 }
 
 function tipAskAmount(
@@ -4899,12 +5013,12 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
   )
   const title = `<@${tipRaffle.creator_provider_user_id}> opened a raffle: ${tipRaffle.memo}`
   const entrants = entrantLines.length ? `Entrants: ${entrantLines.join(', ')}` : null
-  const ticketContext = `Ticket: ${formatTipRaffleAmount(tipRaffle.ticket_amount)} · Tickets: ${ticketCount}`
+  const ticketContext = `Tipet: ${formatTipRaffleAmount(tipRaffle.ticket_amount)} · Tipets: ${ticketCount}`
   const summary = (() => {
     if (tipRaffle.status === 'ended') {
       if (!tipRaffle.winner_provider_user_id)
         return [
-          `Ended · No winner · ${ticketCount} ${ticketCount === 1 ? 'ticket' : 'tickets'}`,
+          `Ended · No winner · ${ticketCount} ${ticketCount === 1 ? 'tipet' : 'tipets'}`,
           ticketContext,
           ...(entrants ? [entrants] : []),
         ].join('\n')
@@ -4915,12 +5029,12 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
       return [
         `Ended · Winner: <@${tipRaffle.winner_provider_user_id}>`,
         `Paid out: ${paidOutText}`,
-        `Winning ticket: #${tipRaffle.winning_ticket_number}`,
+        `Winning tipet: #${tipRaffle.winning_ticket_number}`,
         ticketContext,
         ...(entrants ? [entrants] : []),
         ...(tipRaffle.failed_ticket_count
           ? [
-              `${tipRaffle.failed_ticket_count} ${tipRaffle.failed_ticket_count === 1 ? 'ticket' : 'tickets'} failed payment`,
+              `${tipRaffle.failed_ticket_count} ${tipRaffle.failed_ticket_count === 1 ? 'tipet' : 'tipets'} failed payment`,
             ]
           : []),
       ].join('\n')
@@ -4944,19 +5058,34 @@ async function tipRaffleMessage(db: DB.Type, tipRaffle: TipRaffleMessageInput) {
       ...(tipRaffle.status === 'open'
         ? [
             {
-              elements: [1, 5].map((ticketCount) => ({
-                action_id: `tip_raffle_buy_${ticketCount}`,
-                text: {
-                  emoji: true,
-                  text: `Buy ${ticketCount}`,
-                  type: 'plain_text',
+              elements: [
+                ...[1, 5].map((ticketCount) => ({
+                  action_id: `tip_raffle_buy_${ticketCount}`,
+                  text: {
+                    emoji: true,
+                    text: `Buy ${ticketCount}`,
+                    type: 'plain_text',
+                  },
+                  type: 'button',
+                  value: JSON.stringify({
+                    nonce: Nanoid.generate(),
+                    tipRaffleId: tipRaffle.id,
+                  }),
+                })),
+                {
+                  action_id: 'tip_raffle_buy_for',
+                  text: {
+                    emoji: true,
+                    text: 'Buy for someone',
+                    type: 'plain_text',
+                  },
+                  type: 'button',
+                  value: JSON.stringify({
+                    nonce: Nanoid.generate(),
+                    tipRaffleId: tipRaffle.id,
+                  }),
                 },
-                type: 'button',
-                value: JSON.stringify({
-                  nonce: Nanoid.generate(),
-                  tipRaffleId: tipRaffle.id,
-                }),
-              })),
+              ],
               type: 'actions',
             },
             {

--- a/src/chat.workers.test.ts
+++ b/src/chat.workers.test.ts
@@ -2573,8 +2573,8 @@ test('/tip raffle create modal posts raffle message', async () => {
     ticket_amount: 10_000,
   })
   await expectSlackMessage(`<@${Constants.slack.adminUserId}> opened a raffle: team lunch`)
-  await expectSlackMessage('Ticket: $0.01')
-  await expectSlackMessage('Tickets: 0')
+  await expectSlackMessage('Tipet: $0.01')
+  await expectSlackMessage('Tipets: 0')
 })
 
 test('/tip raffle buy button records tickets and updates message', async () => {
@@ -2624,7 +2624,7 @@ test('/tip raffle buy button records tickets and updates message', async () => {
     .where(
       'tip.idempotency_key',
       '=',
-      `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:tip-raffle-buy-5-trigger`,
+      `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.adminUserId}:tip-raffle-buy-5-trigger`,
     )
     .executeTakeFirstOrThrow()
 
@@ -2639,7 +2639,7 @@ test('/tip raffle buy button records tickets and updates message', async () => {
     sender_provider_user_id: Constants.slack.adminUserId,
   })
   await expectSlackMessage('Pot: $0.005')
-  await expectSlackMessage('Ticket: $0.001 · Tickets: 5')
+  await expectSlackMessage('Tipet: $0.001 · Tipets: 5')
   if (!connected.recipientMember) throw new Error('Expected connected recipient.')
   await db
     .insertInto('tip_raffle_ticket')
@@ -2657,7 +2657,82 @@ test('/tip raffle buy button records tickets and updates message', async () => {
   )
   const history = await slack.conversations.history({ channel: Constants.slack.channelId })
   const message = history.messages?.find((message) => message.text?.includes('Pot: $0.015'))
-  expect(message?.text).toMatch(/Ends:[\s\S]*Entrants:[\s\S]*Ticket:/)
+  expect(message?.text).toMatch(/Ends:[\s\S]*Entrants:[\s\S]*Tipet:/)
+})
+
+test('/tip raffle buy for someone records tipets for selected recipient', async () => {
+  await connectTipAccounts()
+  await postSlackInteraction(createRaffleViewSubmissionPayload({ amount: '0.001' }))
+  const tipRaffle = await db
+    .selectFrom('tip_raffle')
+    .selectAll()
+    .where('provider_id', '=', providerId)
+    .executeTakeFirstOrThrow()
+
+  const response = await postSlackInteraction({
+    team: { id: providerId },
+    type: 'view_submission',
+    user: { id: Constants.slack.adminUserId, name: Constants.slack.adminUserName },
+    view: {
+      callback_id: 'tip_raffle_buy_for',
+      id: 'tip-raffle-buy-for-view',
+      private_metadata: JSON.stringify({ tipRaffleId: tipRaffle.id }),
+      state: {
+        values: {
+          recipient: {
+            recipient: {
+              selected_user: Constants.slack.memberUserId,
+              type: 'users_select',
+            },
+          },
+          ticket_count: {
+            ticket_count: {
+              selected_option: {
+                text: { text: '5 tipets', type: 'plain_text' },
+                value: '5',
+              },
+              type: 'static_select',
+            },
+          },
+        },
+      },
+    },
+  })
+  const ticket = await db
+    .selectFrom('tip_raffle_ticket')
+    .innerJoin('member', 'member.id', 'tip_raffle_ticket.buyer_member_id')
+    .select(['member.provider_user_id', 'tip_raffle_ticket.ticket_count'])
+    .where('tip_raffle_ticket.raffle_id', '=', tipRaffle.id)
+    .executeTakeFirstOrThrow()
+  const escrowTip = await db
+    .selectFrom('tip')
+    .innerJoin('member as recipient', 'recipient.id', 'tip.recipient_member_id')
+    .innerJoin('member as sender', 'sender.id', 'tip.sender_member_id')
+    .select([
+      'recipient.provider_user_id as recipient_provider_user_id',
+      'sender.provider_user_id as sender_provider_user_id',
+      'tip.amount',
+    ])
+    .where(
+      'tip.idempotency_key',
+      '=',
+      `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.memberUserId}:tip-raffle-buy-for-view`,
+    )
+    .executeTakeFirstOrThrow()
+
+  expect(response.status).toBe(200)
+  expect(ticket).toEqual({
+    provider_user_id: Constants.slack.memberUserId,
+    ticket_count: 5,
+  })
+  expect(escrowTip).toEqual({
+    amount: 5000,
+    recipient_provider_user_id: Constants.slack.botUserId,
+    sender_provider_user_id: Constants.slack.adminUserId,
+  })
+  await expectSlackMessage(
+    `Entrants: <@${Constants.slack.memberUserId}> x5`,
+  )
 })
 
 test('/tip raffle buy button uses raffle chain when workspace network changes after creation', async () => {
@@ -2705,14 +2780,14 @@ test('/tip raffle buy button uses raffle chain when workspace network changes af
     .where(
       'idempotency_key',
       '=',
-      `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:tip-raffle-buy-chain-change-trigger`,
+      `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.adminUserId}:tip-raffle-buy-chain-change-trigger`,
     )
     .executeTakeFirstOrThrow()
 
   expect(response.status).toBe(200)
   expect(ticket.ticket_count).toBe(1)
   expect(escrowTip).toEqual({ amount: 1000, chain_id: tipRaffle.chain_id })
-  await expectSlackMessageNotContaining('Ticket not bought. Try again.')
+  await expectSlackMessageNotContaining('Tipets not bought. Try again.')
 })
 
 test('/tip raffle buy button does not record tickets when escrow payment fails', async () => {
@@ -2753,7 +2828,7 @@ test('/tip raffle buy button does not record tickets when escrow payment fails',
 
   expect(response.status).toBe(200)
   expect(ticket).toBeUndefined()
-  await expectSlackMessage('Ticket not bought. Your wallet has insufficient funds.')
+  await expectSlackMessage('Tipets not bought. Your wallet has insufficient funds.')
 })
 
 test('/tip raffle buy button can retry after a failed ticket payment', async () => {
@@ -2824,14 +2899,14 @@ test('/tip raffle buy button can retry after a failed ticket payment', async () 
   expect(retryResponse.status).toBe(200)
   expect(handleTipRequest).toHaveBeenCalledTimes(2)
   expect(handleTipRequest.mock.calls.map((call) => call[1].idempotencyKey)).toEqual([
-    `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:tip-raffle-buy-retry-failed-trigger`,
-    `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:tip-raffle-buy-retry-success-trigger`,
+    `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.adminUserId}:tip-raffle-buy-retry-failed-trigger`,
+    `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.adminUserId}:tip-raffle-buy-retry-success-trigger`,
   ])
   expect(ticket).toEqual({
-    idempotency_key: `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:tip-raffle-buy-retry-success-trigger`,
+    idempotency_key: `tip_raffle:${tipRaffle.id}:ticket:${Constants.slack.adminUserId}:${Constants.slack.adminUserId}:tip-raffle-buy-retry-success-trigger`,
     ticket_count: 1,
   })
-  await expectSlackMessage('Ticket not bought. Try again.')
+  await expectSlackMessage('Tipets not bought. Try again.')
 })
 
 test('/tip raffle buy button does not spam while ticket payment is pending', async () => {
@@ -2958,7 +3033,7 @@ test('/tip raffle buy button offers refresh when ticket payment requires confirm
   expect(response.status).toBe(200)
   expect(ticket).toBeUndefined()
   await expectSlackMessage('Link expires in 10 minutes')
-  await expectSlackMessageNotContaining('Ticket not bought. Try again.')
+  await expectSlackMessageNotContaining('Tipets not bought. Try again.')
 })
 
 test('/tip raffle cron ends without winner when fewer than two buyers enter', async () => {
@@ -3002,8 +3077,8 @@ test('/tip raffle cron ends without winner when fewer than two buyers enter', as
     winning_ticket_number: null,
   })
   expect(initializeSpy).toHaveBeenCalled()
-  await expectSlackMessage('Ended · No winner · 5 tickets')
-  await expectSlackMessage('Ticket: $0.001 · Tickets: 5')
+  await expectSlackMessage('Ended · No winner · 5 tipets')
+  await expectSlackMessage('Tipet: $0.001 · Tipets: 5')
   await expectSlackMessage(`Entrants: <@${Constants.slack.adminUserId}> x5`)
 })
 
@@ -3051,7 +3126,7 @@ test('/tip raffle cron retries stale settling raffle', async () => {
     winner_member_id: null,
     winning_ticket_number: null,
   })
-  await expectSlackMessage('Ended · No winner · 5 tickets')
+  await expectSlackMessage('Ended · No winner · 5 tipets')
 })
 
 test('/tip raffle cron reuses winner selected before stale settlement retry', async () => {
@@ -3210,7 +3285,7 @@ test('/tip raffle cron retries stale ended raffle message update', async () => {
     .executeTakeFirstOrThrow()
 
   expect(updated.updated_at).not.toBe(updated.ended_at)
-  await expectSlackMessage('Ended · No winner · 0 tickets')
+  await expectSlackMessage('Ended · No winner · 0 tipets')
 })
 
 test('/tip raffle cron skips stale ended raffle message that no longer exists', async () => {
@@ -3259,7 +3334,7 @@ test('/tip raffle cron skips stale ended raffle message that no longer exists', 
 
   expect(rows.find((row) => row.id === missing.id)?.updated_at).not.toBe(missingEndedAt)
   expect(rows.find((row) => row.id === visible.id)?.updated_at).not.toBe(visibleEndedAt)
-  await expectSlackMessage('Ended · No winner · 0 tickets')
+  await expectSlackMessage('Ended · No winner · 0 tipets')
 })
 
 test('/tip raffle closes expired raffle and settles winner payout', async () => {
@@ -3352,7 +3427,7 @@ test('/tip raffle closes expired raffle and settles winner payout', async () => 
   await expectSlackMessage('Paid out: $0.002')
   await expectSlackMessageNotContaining('Paid out: $0.002 / $0.002')
   await expectSlackMessageNotContaining('Paid out: $0.001 / $0.002')
-  await expectSlackMessage('Ticket: $0.001 · Tickets: 2')
+  await expectSlackMessage('Tipet: $0.001 · Tipets: 2')
   await expectSlackMessage(`<@${Constants.slack.adminUserId}> x1`)
   await expectSlackMessage(`<@${Constants.slack.memberUserId}> x1`)
   if (!tipRaffle.provider_message_ts) throw new Error('Expected raffle message timestamp.')


### PR DESCRIPTION
## Summary
- rename raffle ticket UI copy to tipets
- add a Buy for someone flow with a Slack user picker
- charge the buyer while recording tipets for the selected connected recipient

## Tests
- Not run: Corepack could not download pnpm@11.0.7 from registry.npmjs.org due network timeouts.

Prompted by: @jxom