### PR TITLE
chore: add GitHub STS trust policy for Slack config rotation

### DIFF
--- a/.github/sts/slack-config.sts.yaml
+++ b/.github/sts/slack-config.sts.yaml
@@ -1,0 +1,14 @@
+# Lets this repository's workflows mint a short-lived token that can write
+# repository Actions secrets, so setup-slack-config-token can persist the
+# rotated SLACK_CONFIG_REFRESH_TOKEN after calling Slack's tooling.tokens.rotate
+# (rotation invalidates the previous refresh token, so the new one must be
+# stored immediately). Replaces the SLACK_GH_TOKEN fine-grained PAT.
+#
+# refs/heads/main covers the production deploy and the scheduled preview sweep;
+# pull_request covers preview deploy/destroy runs.
+subject:
+  - repo:tempoxyz@211589300/tip.bot@1232143975:ref:refs/heads/main
+  - repo:tempoxyz@211589300/tip.bot@1232143975:pull_request
+
+permissions:
+  secrets: write


### PR DESCRIPTION
Adds `.github/sts/slack-config.sts.yaml`, a github-sts trust policy that lets this repository's own workflows mint a short-lived token with `secrets: write` on this repository. The `setup-slack-config-token` action needs that to persist the rotated `SLACK_CONFIG_REFRESH_TOKEN` after calling Slack's `tooling.tokens.rotate`, which invalidates the previous refresh token.

Subjects cover `refs/heads/main` (production deploy, scheduled preview sweep) and `pull_request` (preview deploy/destroy) — the same runs that use the `SLACK_GH_TOKEN` fine-grained PAT today.

Policy only; a follow-up PR will switch the workflows to `tempoxyz/gh-actions/actions/github-sts` and retire `SLACK_GH_TOKEN`.