### PR TITLE
chore: update nanoid 3.3.17 → 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   ip-address: 10.3.1
   js-yaml: 4.3.1
   launch-editor: 2.14.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   nanoid@>=4.0.0 <5.1.16: 5.1.16
   postcss: 8.5.23
   protobufjs: 7.6.5
@@ -4657,8 +4657,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11024,7 +11024,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -11367,7 +11367,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ minimumReleaseAgeExclude:
   - hono@4.12.34
   - fast-uri@3.1.5
   - ip-address@10.3.1
-  - nanoid@3.3.17
+  - nanoid@3.3.18
   - nanoid@5.1.16
   - postcss@8.5.23
   - sharp@0.35.0
@@ -75,7 +75,7 @@ overrides:
   ip-address: 10.3.1
   js-yaml: 4.3.1
   launch-editor: 2.14.1
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   'nanoid@>=4.0.0 <5.1.16': 5.1.16
   postcss: 8.5.23
   protobufjs: 7.6.5


### PR DESCRIPTION
Fixes the failing `pnpm audit` check: bumps the transitive `nanoid` 3.x override from 3.3.17 to 3.3.18 for [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (custom generators can loop indefinitely when size is zero; patched in >=3.3.18). The direct `nanoid@5.1.16` dependency is not affected.

`pnpm audit` and `pnpm install --frozen-lockfile` pass locally.