### PR TITLE
chore: allow preview environment subject in slack-config STS policy

### DIFF
--- a/.github/sts/slack-config.sts.yaml
+++ b/.github/sts/slack-config.sts.yaml
@@ -5,10 +5,13 @@
 # stored immediately). Replaces the SLACK_GH_TOKEN fine-grained PAT.
 #
 # refs/heads/main covers the production deploy and the scheduled preview sweep;
-# pull_request covers preview deploy/destroy runs.
+# pull_request covers preview deploy/destroy runs. Jobs that reference a GitHub
+# environment present it as their OIDC subject instead of the ref/event form,
+# so environment:preview covers the jobs running in the preview environment.
 subject:
   - repo:tempoxyz@211589300/tip.bot@1232143975:ref:refs/heads/main
   - repo:tempoxyz@211589300/tip.bot@1232143975:pull_request
+  - repo:tempoxyz@211589300/tip.bot@1232143975:environment:preview
 
 permissions:
   secrets: write


### PR DESCRIPTION
Adds `repo:tempoxyz@211589300/tip.bot@1232143975:environment:preview` to the `slack-config` trust policy subjects. Jobs that reference a GitHub environment (the preview deploy/destroy/sweep jobs all use `environment: preview`) present that environment as their OIDC subject instead of the ref/event form, so the existing `pull_request` and `refs/heads/main` subjects do not match them — the STS exchange on the #79 preview deploy was denied with "trust policy: subject did not match".