### PR TITLE
chore: allow production environment subject in slack-config STS policy

### DIFF
--- a/.github/sts/slack-config.sts.yaml
+++ b/.github/sts/slack-config.sts.yaml
@@ -4,14 +4,17 @@
 # (rotation invalidates the previous refresh token, so the new one must be
 # stored immediately). Replaces the SLACK_GH_TOKEN fine-grained PAT.
 #
-# refs/heads/main covers the production deploy and the scheduled preview sweep;
-# pull_request covers preview deploy/destroy runs. Jobs that reference a GitHub
-# environment present it as their OIDC subject instead of the ref/event form,
-# so environment:preview covers the jobs running in the preview environment.
+# Jobs that reference a GitHub environment present it as their OIDC subject
+# instead of the ref/event form. All jobs that rotate the token run in an
+# environment: environment:production covers the production Slack app update,
+# and environment:preview covers the preview deploy/destroy/sweep jobs. The
+# refs/heads/main and pull_request subjects cover rotation from any future job
+# that runs without an environment.
 subject:
   - repo:tempoxyz@211589300/tip.bot@1232143975:ref:refs/heads/main
   - repo:tempoxyz@211589300/tip.bot@1232143975:pull_request
   - repo:tempoxyz@211589300/tip.bot@1232143975:environment:preview
+  - repo:tempoxyz@211589300/tip.bot@1232143975:environment:production
 
 permissions:
   secrets: write


### PR DESCRIPTION
Adds `repo:tempoxyz@211589300/tip.bot@1232143975:environment:production` to the `slack-config` trust policy, the production counterpart to #80: the `update_slack_app` job runs in `environment: production`, so its OIDC subject is the environment form and the existing `refs/heads/main` subject does not match it. Without this, the production Slack app update would fail to mint once #79 lands.

Also rewrites the subject comment to reflect that all rotating jobs run in environments; the ref/event subjects remain for any future job that rotates without one.