### PR TITLE
chore: restrict slack-config STS policy to environment subjects

### DIFF
--- a/.github/sts/slack-config.sts.yaml
+++ b/.github/sts/slack-config.sts.yaml
@@ -7,12 +7,9 @@
 # Jobs that reference a GitHub environment present it as their OIDC subject
 # instead of the ref/event form. All jobs that rotate the token run in an
 # environment: environment:production covers the production Slack app update,
-# and environment:preview covers the preview deploy/destroy/sweep jobs. The
-# refs/heads/main and pull_request subjects cover rotation from any future job
-# that runs without an environment.
+# and environment:preview covers the preview deploy/destroy/sweep jobs. A job
+# without an environment cannot mint; add its subject here if one ever needs to.
 subject:
-  - repo:tempoxyz@211589300/tip.bot@1232143975:ref:refs/heads/main
-  - repo:tempoxyz@211589300/tip.bot@1232143975:pull_request
   - repo:tempoxyz@211589300/tip.bot@1232143975:environment:preview
   - repo:tempoxyz@211589300/tip.bot@1232143975:environment:production
 


### PR DESCRIPTION
Removes the `ref:refs/heads/main` and `pull_request` subjects from the `slack-config` trust policy. Every job that rotates the Slack config token runs in a GitHub environment, so those subjects match nothing today — jobs with an `environment:` key always present the environment-form OIDC subject (#80, #81).

Dropping them also tightens the grant: with `pull_request` present, any same-repo PR workflow job without an environment could mint a `secrets: write` token; now minting requires entering the `preview` or `production` environment, so any deployment protection rules on those environments gate token minting too. A future environment-less job that needs to rotate can add its subject back in a reviewed diff.