### PR TITLE
chore: update GitHub STS action

### DIFF
--- a/.github/actions/setup-slack-config-token/action.yml
+++ b/.github/actions/setup-slack-config-token/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Mint GitHub token
       if: inputs.slack-config-access-token == '' && inputs.slack-config-refresh-token != ''
       id: github_token
-      uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+      uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
       with:
         policy: slack-config
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/preview_destroy.yml
+++ b/.github/workflows/preview_destroy.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/preview_sweep.yml
+++ b/.github/workflows/preview_sweep.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: workflow-member
 


### PR DESCRIPTION
Pins every GitHub STS action use in this repository to tempoxyz/gh-actions@8819cf80bdcb39c36c34700e3f2ecc08bde54f23, including the deterministic revocation cleanup from tempoxyz/gh-actions#73 and TTL support from tempoxyz/gh-actions#74. pnpm check and pnpm check:types pass; local integration setup is blocked minting the Tempo emulator fee payer, and actionlint reports the existing SC2001 warning at preview_sweep.yml:70.