### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      uses: tempoxyz/gh-actions/vendor/pnpm/action-setup@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
     - name: Setup node
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -409,7 +409,7 @@ jobs:
           SLACK_APP_ID: ${{ steps.slack.outputs.app_id }}
 
       - name: Deploy preview
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: tempoxyz/gh-actions/vendor/cloudflare/wrangler-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
           SLACK_APP_ID: ${{ vars.SLACK_APP_ID }}
 
       - name: Deploy to Production
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: tempoxyz/gh-actions/vendor/cloudflare/wrangler-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4
+        uses: tempoxyz/gh-actions/vendor/zizmorcore/zizmor-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           # TODO: Remove this once the repo is public or GitHub Advanced Security is enabled.
           advanced-security: false

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  # Pins to tempoxyz/gh-actions (including its vendored third-party actions) cannot carry a
+  # version comment that matches a tag, because that repository publishes no tags.
+  ref-version-mismatch:
+    disable: true


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `cloudflare/wrangler-action` | [`tempoxyz/gh-actions/vendor/cloudflare/wrangler-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/cloudflare/wrangler-action) |
| `pnpm/action-setup` | [`tempoxyz/gh-actions/vendor/pnpm/action-setup`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/pnpm/action-setup) |
| `zizmorcore/zizmor-action` | [`tempoxyz/gh-actions/vendor/zizmorcore/zizmor-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/zizmorcore/zizmor-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 4 -> 4, zizmor 0 -> 0).

## zizmor

- `zizmor.yml` disables the `ref-version-mismatch` audit: pins to tempoxyz/gh-actions (including its vendored actions) cannot carry a tag-matching version comment because that repository publishes no tags, and zizmor treats a missing comment as a finding.
