### PR TITLE
Pin GitHub STS POST action

### DIFF
--- a/.github/actions/setup-slack-config-token/action.yml
+++ b/.github/actions/setup-slack-config-token/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Mint GitHub token
       if: inputs.slack-config-access-token == '' && inputs.slack-config-refresh-token != ''
       id: github_token
-      uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+      uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
       with:
         policy: slack-config
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/preview_destroy.yml
+++ b/.github/workflows/preview_destroy.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/preview_sweep.yml
+++ b/.github/workflows/preview_sweep.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           policy: workflow-member
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Mint organization membership token
         id: member_token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           policy: workflow-member
 


### PR DESCRIPTION
## Summary

- pin all GitHub STS action uses to tempoxyz/gh-actions@c0292122e255def866c64c55e5844d1e7d5fe7ad
- use the action version that sends `POST /sts/exchange`
- preserve all existing scopes, policies, TTLs, and workflow behavior

This is part of the coordinated organization-wide rollout required before retiring legacy GET exchanges.

## Validation

- mechanical pin-only update; repository CI is the behavioral validation